### PR TITLE
gem "sassc-rails"のインストール

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,3 +67,4 @@ group :test do
 end
 
 gem "tailwindcss-rails"
+gem "sassc-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,8 @@ GEM
     drb (2.2.3)
     erb (6.0.1)
     erubi (1.13.1)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     globalid (1.3.0)
       activesupport (>= 6.1)
     i18n (1.14.8)
@@ -218,6 +220,14 @@ GEM
       io-console (~> 0.5)
     rexml (3.4.4)
     rubyzip (3.2.2)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     securerandom (0.4.1)
     selenium-webdriver (4.39.0)
       base64 (~> 0.2)
@@ -242,6 +252,7 @@ GEM
     tailwindcss-ruby (4.1.18-aarch64-linux-gnu)
     tailwindcss-ruby (4.1.18-x86_64-linux-gnu)
     thor (1.4.0)
+    tilt (2.7.0)
     timeout (0.6.0)
     tsort (0.2.0)
     turbo-rails (2.0.20)
@@ -276,6 +287,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.6)
+  sassc-rails
   selenium-webdriver
   sprockets-rails
   stimulus-rails


### PR DESCRIPTION
#概要
sassc-railsのインストールに伴い、dockerコンテナに正常にインストールされていなかったため
その解消