### PR TITLE
共通UIの土台を整える

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,1 +1,47 @@
 @import "tailwindcss";
+
+@layer components {
+  .ui-container {
+    @apply mx-auto w-full max-w-md px-4 py-6;
+  }
+
+  .ui-card {
+    @apply rounded-lg border border-slate-200 bg-white p-4 shadow-sm;
+  }
+
+  .btn-primary {
+    @apply inline-flex items-center justify-center rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-700;
+  }
+
+  .btn-secondary {
+    @apply inline-flex items-center justify-center rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50;
+  }
+
+  .btn-danger {
+    @apply inline-flex items-center justify-center rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-red-700;
+  }
+
+  .form-label {
+    @apply mb-2 block text-sm font-semibold text-slate-700;
+  }
+
+  .form-input {
+    @apply w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-100;
+  }
+
+  .form-help {
+    @apply mt-2 text-xs text-slate-500;
+  }
+
+  .alert-success {
+    @apply rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800;
+  }
+
+  .alert-error {
+    @apply rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800;
+  }
+
+  .alert-info {
+    @apply rounded-lg border border-sky-200 bg-sky-50 px-4 py-3 text-sm text-sky-800;
+  }
+}

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,12 +1,34 @@
 @import "tailwindcss";
 
+@layer base {
+  body {
+    font-family: "Zen Kaku Gothic New", "Hiragino Sans", system-ui, sans-serif;
+  }
+}
+
 @layer components {
+  .brand-font {
+    font-family: "Kiwi Maru", "Zen Kaku Gothic New", system-ui, sans-serif;
+  }
+
   .ui-container {
     @apply mx-auto w-full max-w-md px-4 py-6;
   }
 
+  .ui-container-wide {
+    @apply mx-auto w-full max-w-5xl px-4 py-6;
+  }
+
   .ui-card {
     @apply rounded-lg border border-slate-200 bg-white p-4 shadow-sm;
+  }
+
+  .ui-table-card {
+    @apply overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm;
+  }
+
+  .ui-empty-state {
+    @apply rounded-lg border border-slate-200 bg-white px-4 py-10 text-center text-slate-500 shadow-sm;
   }
 
   .btn-primary {

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,54 +1,54 @@
-<div class="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-  <div class="max-w-md w-full space-y-8">
+<div class="ui-container">
+  <div class="space-y-6">
     <!-- ヘッダー部分 -->
     <div class="text-center">
-      <h2 class="text-3xl font-extrabold text-gray-900">
+      <h2 class="text-2xl font-bold text-slate-900">
         新規登録
       </h2>
-      <p class="mt-2 text-sm text-gray-600">
+      <p class="mt-2 text-sm text-slate-500">
         アカウントを作成しましょう
       </p>
     </div>
 
     <!-- フォーム部分 -->
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "mt-8" }) do |f| %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "ui-card space-y-6" }) do |f| %>
       <%= render "devise/shared/error_messages", resource: resource %>
 
       <div class="space-y-5">
         <!-- 名前フィールド -->
         <div>
-          <%= f.label :name, "ユーザー名", class: "block text-sm font-medium text-gray-700 mb-2" %>
-          <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+          <%= f.label :name, "ユーザー名", class: "form-label" %>
+          <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-input" %>
         </div>
 
         <!-- メールアドレスフィールド -->
         <div>
-          <%= f.label :email, "メールアドレス", class: "block text-sm font-medium text-gray-700 mb-2" %>
-          <%= f.email_field :email, autocomplete: "email", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+          <%= f.label :email, "メールアドレス", class: "form-label" %>
+          <%= f.email_field :email, autocomplete: "email", class: "form-input" %>
         </div>
 
         <!-- パスワードフィールド -->
         <div>
           <div class="flex items-baseline justify-between mb-2">
-            <%= f.label :password, "パスワード", class: "block text-sm font-medium text-gray-700" %>
+            <%= f.label :password, "パスワード", class: "block text-sm font-semibold text-slate-700" %>
             <% if @minimum_password_length %>
-              <span class="text-xs text-gray-500">
+              <span class="text-xs text-slate-500">
                 (<%= @minimum_password_length %>文字以上)
               </span>
             <% end %>
           </div>
-          <%= f.password_field :password, autocomplete: "new-password", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+          <%= f.password_field :password, autocomplete: "new-password", class: "form-input" %>
         </div>
 
         <!-- パスワード確認フィールド -->
         <div>
-          <%= f.label :password_confirmation, "パスワード（確認）", class: "block text-sm font-medium text-gray-700 mb-2" %>
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+          <%= f.label :password_confirmation, "パスワード（確認）", class: "form-label" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-input" %>
         </div>
       </div>
 
-      <div class="actions mt-12">
-        <%= f.submit '新規登録', class: "inline-flex w-full items-center justify-center rounded-md bg-indigo-500 p-3 text-white duration-100 ease-in-out hover:bg-indigo-600 focus:outline-none cursor-pointer" %>
+      <div class="actions">
+        <%= f.submit '新規登録', class: "btn-primary w-full cursor-pointer" %>
       </div>
     <% end %>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -2,7 +2,7 @@
   <div class="space-y-6">
     <!-- ヘッダー部分 -->
     <div class="text-center">
-      <h2 class="text-2xl font-bold text-slate-900">
+      <h2 class="brand-font text-2xl font-bold text-slate-900">
         新規登録
       </h2>
       <p class="mt-2 text-sm text-slate-500">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,47 +1,47 @@
-<div class="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-  <div class="max-w-md w-full space-y-8">
+<div class="ui-container">
+  <div class="space-y-6">
     <!-- ヘッダー部分 -->
     <div class="text-center">
-      <h2 class="text-3xl font-extrabold text-gray-900">
+      <h2 class="text-2xl font-bold text-slate-900">
         ログイン
       </h2>
-      <p class="mt-2 text-sm text-gray-600">
+      <p class="mt-2 text-sm text-slate-500">
         アカウントにログインしましょう
       </p>
     </div>
 
     <!-- フォーム部分 -->
-    <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "mt-8" }) do |f| %>
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "ui-card" }) do |f| %>
       <div class="space-y-5">
         <!-- メールアドレスフィールド -->
         <div>
-          <%= f.label :email, "メールアドレス", class: "block text-sm font-medium text-gray-700 mb-2" %>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+          <%= f.label :email, "メールアドレス", class: "form-label" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-input" %>
         </div>
 
         <!-- パスワードフィールド -->
         <div>
-          <%= f.label :password, "パスワード", class: "block text-sm font-medium text-gray-700 mb-2" %>
-          <%= f.password_field :password, autocomplete: "current-password", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+          <%= f.label :password, "パスワード", class: "form-label" %>
+          <%= f.password_field :password, autocomplete: "current-password", class: "form-input" %>
         </div>
 
         <!-- Remember meチェックボックス -->
         <% if devise_mapping.rememberable? %>
           <div class="flex items-center">
-            <%= f.check_box :remember_me, class: "h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded" %>
-            <%= f.label :remember_me, "ログイン状態を保持する", class: "ml-2 block text-sm text-gray-700" %>
+            <%= f.check_box :remember_me, class: "h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500" %>
+            <%= f.label :remember_me, "ログイン状態を保持する", class: "ml-2 block text-sm text-slate-700" %>
           </div>
         <% end %>
       </div>
 
       <!-- ログインボタン -->
-      <div class="actions mt-8">
-        <%= f.submit "ログイン", class: "inline-flex w-full items-center justify-center rounded-md bg-indigo-500 p-3 text-white duration-100 ease-in-out hover:bg-indigo-600 focus:outline-none cursor-pointer" %>
+      <div class="actions mt-6">
+        <%= f.submit "ログイン", class: "btn-primary w-full cursor-pointer" %>
       </div>
     <% end %>
 
     <!-- リンク部分 -->
-    <div class="mt-6">
+    <div>
       <%= render "devise/shared/links" %>
     </div>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,7 +2,7 @@
   <div class="space-y-6">
     <!-- ヘッダー部分 -->
     <div class="text-center">
-      <h2 class="text-2xl font-bold text-slate-900">
+      <h2 class="brand-font text-2xl font-bold text-slate-900">
         ログイン
       </h2>
       <p class="mt-2 text-sm text-slate-500">

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,12 +1,12 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
-    <h2>
+  <div id="error_explanation" class="alert-error" data-turbo-cache="false">
+    <h2 class="mb-2 font-bold">
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
     </h2>
-    <ul>
+    <ul class="list-disc list-inside">
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,27 @@
+<div class="space-y-2 text-center text-sm">
 <%- if controller_name != 'sessions' %>
-  <%= link_to "ログイン", new_session_path(resource_name) %><br />
+  <%= link_to "ログイン", new_session_path(resource_name), class: "font-medium text-emerald-700 transition hover:text-emerald-800" %>
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "新規登録", new_registration_path(resource_name) %><br />
+  <%= link_to "新規登録", new_registration_path(resource_name), class: "font-medium text-emerald-700 transition hover:text-emerald-800" %>
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "パスワードをお忘れですか？", new_password_path(resource_name) %><br />
+  <%= link_to "パスワードをお忘れですか？", new_password_path(resource_name), class: "font-medium text-slate-600 transition hover:text-emerald-700" %>
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name), class: "font-medium text-slate-600 transition hover:text-emerald-700" %>
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: "font-medium text-slate-600 transition hover:text-emerald-700" %>
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), class: "btn-secondary w-full", data: { turbo: false } %>
   <% end %>
 <% end %>
+</div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,13 +1,13 @@
-<div class="container mx-auto px-4 py-8">
-  <div class="max-w-2xl mx-auto">
-    <h1 class="text-2xl mb-6 text-center">アイテム編集</h1>
+<div class="ui-container">
+  <div class="space-y-5">
+    <h1 class="text-center text-2xl font-bold text-slate-900">アイテム編集</h1>
 
-    <%= form_with model: @item, class: "bg-white rounded-lg shadow-lg p-8" do |f| %>
+    <%= form_with model: @item, class: "ui-card space-y-6" do |f| %>
 
       <!-- エラーメッセージ表示 -->
       <% if @item.errors.any? %>
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-          <h2 class="font-bold mb-2">
+        <div class="alert-error">
+          <h2 class="mb-2 font-bold">
             <%= @item.errors.count %>件のエラーがあります
           </h2>
           <ul class="list-disc list-inside">
@@ -21,13 +21,13 @@
       <div class="space-y-6">
         <!-- アイテム名 -->
         <div>
-          <%= f.label :name, class: "block text-gray-700 text-sm font-bold mb-2" %>
-          <%= f.text_field :name, class: "shadow appearance-none border border-slate-300 rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline focus:border-blue-500" %>
+          <%= f.label :name, class: "form-label" %>
+          <%= f.text_field :name, class: "form-input" %>
         </div>
 
         <!-- 画像プレビュー -->
         <div>
-          <label class="block text-gray-700 text-sm font-bold mb-2">画像</label>
+          <label class="form-label">画像</label>
           <div data-image-preview-placeholder>
             <%= render "image",
                        item: @item,
@@ -42,36 +42,36 @@
               <%= link_to "画像を削除",
                           image_item_path(@item),
                           data: { turbo_method: :delete, turbo_confirm: "画像を削除しますか?" },
-                          class: "text-red-600 hover:text-red-800 font-medium transition duration-150" %>
+                          class: "font-medium text-red-600 transition duration-150 hover:text-red-800" %>
             </div>
           <% end %>
-          <%= f.file_field :image, accept: "image/jpeg,image/png", class: "mt-4 block w-full text-sm text-gray-700" %>
-          <p class="mt-2 text-xs text-gray-500">JPEG / PNG、10MB以下の画像を選択してください</p>
-          <div class="hidden mt-2 rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700" data-upload-progress></div>
+          <%= f.file_field :image, accept: "image/jpeg,image/png", class: "mt-4 block w-full text-sm text-slate-700" %>
+          <p class="form-help">JPEG / PNG、10MB以下の画像を選択してください</p>
+          <div class="alert-success hidden" data-upload-progress></div>
         </div>
 
         <!-- 価格 -->
         <div class="flex gap-4">
           <div class="flex-1">
-            <%= f.label :price, class: "block text-gray-700 text-sm font-bold mb-2" %>
-            <%= f.text_field :price, class: "shadow appearance-none border border-slate-300 rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline focus:border-blue-500", placeholder: "例: 1000" %>
+            <%= f.label :price, class: "form-label" %>
+            <%= f.text_field :price, class: "form-input", placeholder: "例: 1000" %>
           </div>
         </div>
 
         <!-- メモ -->
         <div>
-          <%= f.label :memo, class: "block text-gray-700 text-sm font-bold mb-2" %>
-          <%= f.text_area :memo, rows: "5", class: "shadow appearance-none border border-slate-300 rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline focus:border-blue-500" %>
+          <%= f.label :memo, class: "form-label" %>
+          <%= f.text_area :memo, rows: "5", class: "form-input" %>
         </div>
 
         <!-- ボタン群 -->
-        <div class="hidden rounded border border-blue-200 bg-blue-50 px-3 py-2 text-center text-sm text-blue-700" data-submit-loading>
+        <div class="alert-info hidden text-center" data-submit-loading>
           アイテム情報を更新しています...
         </div>
 
-        <div class="flex gap-4 justify-center">
-          <%= link_to 'キャンセル', item_path(@item), class: "inline-block bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" %>
-          <%= f.submit '更新する', class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline cursor-pointer" %>
+        <div class="grid gap-3 sm:grid-cols-2">
+          <%= link_to 'キャンセル', item_path(@item), class: "btn-secondary" %>
+          <%= f.submit '更新する', class: "btn-primary cursor-pointer" %>
         </div>
       </div>
     <% end %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="ui-container">
   <div class="space-y-5">
-    <h1 class="text-center text-2xl font-bold text-slate-900">アイテム編集</h1>
+    <h1 class="brand-font text-center text-2xl font-bold text-slate-900">アイテム編集</h1>
 
     <%= form_with model: @item, class: "ui-card space-y-6" do |f| %>
 

--- a/app/views/items/in_use.html.erb
+++ b/app/views/items/in_use.html.erb
@@ -1,11 +1,11 @@
-<div class="container mx-auto px-4 py-8">
-  <div class="flex justify-between items-center mb-6">
+<div class="ui-container-wide">
+  <div class="mb-6 flex items-center justify-between">
     <!-- ページタイトル -->
-    <h1 class="text-2xl text-gray-900"><%= @page_title %></h1>
+    <h1 class="brand-font text-2xl font-bold text-slate-900"><%= @page_title %></h1>
   </div>
 
   <% if @usage_logs.any? %>
-    <div class="bg-white rounded-lg shadow overflow-hidden">
+    <div class="ui-table-card">
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50">
           <tr>
@@ -24,7 +24,7 @@
                 <%= render "image", item: usage_log.item %>
               </td>
               <td class="px-4 py-4 text-center">
-                <%= link_to usage_log.item.name, item_path(usage_log.item), class: "text-blue-600 hover:text-blue-800 font-medium transition duration-150" %>
+                <%= link_to usage_log.item.name, item_path(usage_log.item), class: "font-medium text-emerald-700 transition duration-150 hover:text-emerald-800" %>
               </td>
               <td class="px-4 py-4 whitespace-nowrap text-xs text-gray-400 text-center">
                 <%= usage_log.started_at&.strftime('%Y/%-m/%-d') || '-' %>
@@ -37,10 +37,10 @@
                 <% end %>
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-center">
-                <%= link_to "使い切り", finish_using_form_item_path(usage_log.item), class: "inline-block px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded transition duration-200" %>
+                <%= link_to "使い切り", finish_using_form_item_path(usage_log.item), class: "btn-primary" %>
               </td>
               <td class="px-4 py-4 whitespace-nowrap text-sm text-center">
-                <%= link_to "詳細", item_path(usage_log.item), class: "text-blue-600 hover:text-blue-800 font-medium transition duration-150" %>
+                <%= link_to "詳細", item_path(usage_log.item), class: "font-medium text-emerald-700 transition duration-150 hover:text-emerald-800" %>
               </td>
             </tr>
           <% end %>
@@ -48,8 +48,8 @@
       </table>
     </div>
   <% else %>
-    <div class="text-center py-12 bg-white rounded-lg shadow">
-      <p class="mt-4 text-gray-500 text-lg">使用中のアイテムがありません</p>
+    <div class="ui-empty-state">
+      <p class="text-lg">使用中のアイテムがありません</p>
     </div>
   <% end %>
 </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,12 +1,12 @@
-<div class="container mx-auto px-4 py-8">
-  <div class="flex justify-between items-center mb-6">
+<div class="ui-container-wide">
+  <div class="mb-6 flex items-center justify-between gap-4">
     <!-- ページタイトル　-->
-    <h1 class="text-2xl text-gray-900"><%= @page_title %></h1>
-    <%= link_to "新規登録", new_item_path, class: "bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-6 rounded-lg transition duration-200" %>
+    <h1 class="brand-font text-2xl font-bold text-slate-900"><%= @page_title %></h1>
+    <%= link_to "新規登録", new_item_path, class: "btn-primary shrink-0" %>
   </div>
 
   <% if @items.any? %>
-    <div class="bg-white rounded-lg shadow overflow-hidden">
+    <div class="ui-table-card">
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50">
           <tr>
@@ -37,21 +37,21 @@
               <td class="px-6 py-4 whitespace-nowrap text-center">
                 <!-- 使用中なら状態を表示 -->
                 <% if item.using? %>
-                  <span class="px-3 py-1 bg-yellow-100 text-yellow-800 rounded-full text-sm">使用中</span>
+                  <span class="rounded-full bg-amber-100 px-3 py-1 text-sm text-amber-800">使用中</span>
                 <!-- 在庫ありなら使い始めるボタン -->
                 <% elsif item.stock_available? %>
                   <%= form_with url: start_using_item_path(item), method: :patch, local: true, class: 'inline-flex items-center gap-2' do %>
-                    <%= date_field_tag :started_at, Date.current, class: 'border rounded px-2 py-1 text-sm' %>
-                    <%= submit_tag '使い始める', class: 'px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded transition duration-200', data: { turbo_confirm: '使用を開始しますか?' } %>
+                    <%= date_field_tag :started_at, Date.current, class: 'rounded border border-slate-300 px-2 py-1 text-sm' %>
+                    <%= submit_tag '使い始める', class: 'btn-primary cursor-pointer', data: { turbo_confirm: '使用を開始しますか?' } %>
                   <% end %>
                 <!-- 使用中でなく、在庫もなければ「在庫なし」 -->
                 <% else %>
-                  <span class="px-3 py-1 bg-gray-100 text-gray-800 rounded-full text-sm">在庫なし</span>
+                  <span class="rounded-full bg-slate-100 px-3 py-1 text-sm text-slate-700">在庫なし</span>
                 <% end %>
               </td>
               <td class="px-4 py-4 whitespace-nowrap text-sm text-center">
                 <div class="flex gap-2 justify-center">
-                  <%= link_to "詳細", item_path(item), class: "text-blue-600 hover:text-blue-800 font-medium transition duration-150" %>
+                  <%= link_to "詳細", item_path(item), class: "font-medium text-emerald-700 transition duration-150 hover:text-emerald-800" %>
                   <%= link_to "削除", item_path(item), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか?' }, class: "text-red-600 hover:text-red-800 font-medium transition duration-150" %>
                 </div>
               </td>
@@ -61,11 +61,11 @@
       </table>
     </div>
   <% else %>
-    <div class="text-center py-12 bg-white rounded-lg shadow">
+    <div class="ui-empty-state">
       <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"></path>
       </svg>
-      <p class="mt-4 text-gray-500 text-lg">アイテムがありません</p>
+      <p class="mt-4 text-lg">アイテムがありません</p>
     </div>
   <% end %>
 </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,6 +1,6 @@
 <div class="ui-container">
   <div class="space-y-5">
-    <h1 class="text-center text-2xl font-bold text-slate-900">アイテム登録</h1>
+    <h1 class="brand-font text-center text-2xl font-bold text-slate-900">アイテム登録</h1>
 
     <%= form_with model: @item, class: "ui-card space-y-6" do |f| %>
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,13 +1,13 @@
-<div class="container mx-auto px-4 py-8">
-  <div class="max-w-2xl mx-auto">
-    <h1 class="text-2xl mb-6 text-center">アイテム登録</h1>
+<div class="ui-container">
+  <div class="space-y-5">
+    <h1 class="text-center text-2xl font-bold text-slate-900">アイテム登録</h1>
 
-    <%= form_with model: @item, class: "bg-white rounded-lg shadow-lg p-8" do |f| %>
+    <%= form_with model: @item, class: "ui-card space-y-6" do |f| %>
 
       <!-- エラーメッセージ表示 -->
       <% if @item.errors.any? %>
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-          <h2 class="font-bold mb-2">
+        <div class="alert-error">
+          <h2 class="mb-2 font-bold">
             <%= @item.errors.count %>件のエラーがあります
           </h2>
           <ul class="list-disc list-inside">
@@ -21,49 +21,49 @@
       <div class="space-y-6">
         <!-- アイテム名 -->
         <div>
-          <%= f.label :name, class: "block text-gray-700 text-sm font-bold mb-2" %>
-          <%= f.text_field :name, class: "shadow appearance-none border border-slate-300 rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline focus:border-blue-500" %>
+          <%= f.label :name, class: "form-label" %>
+          <%= f.text_field :name, class: "form-input" %>
         </div>
 
         <!-- 画像プレビュー -->
         <div>
-          <label class="block text-gray-700 text-sm font-bold mb-2">画像</label>
-          <div class="w-64 h-64 bg-gray-200 rounded-lg flex items-center justify-center mx-auto">
-            <span class="text-gray-500" data-image-preview-placeholder>画像プレビュー</span>
+          <label class="form-label">画像</label>
+          <div class="mx-auto flex h-64 w-64 items-center justify-center rounded-lg border border-slate-200 bg-slate-100">
+            <span class="text-sm text-slate-500" data-image-preview-placeholder>画像プレビュー</span>
             <img class="hidden w-64 h-64 rounded-lg object-cover" data-image-preview>
           </div>
-          <%= f.file_field :image, accept: "image/jpeg,image/png", class: "mt-4 block w-full text-sm text-gray-700" %>
-          <p class="mt-2 text-xs text-gray-500">JPEG / PNG、10MB以下の画像を選択してください</p>
-          <div class="hidden mt-2 rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700" data-upload-progress></div>
+          <%= f.file_field :image, accept: "image/jpeg,image/png", class: "mt-4 block w-full text-sm text-slate-700" %>
+          <p class="form-help">JPEG / PNG、10MB以下の画像を選択してください</p>
+          <div class="alert-success hidden" data-upload-progress></div>
         </div>
 
         <!-- 価格 -->
         <div class="flex gap-4">
           <div class="flex-1">
-            <%= f.label :price, class: "block text-gray-700 text-sm font-bold mb-2" %>
-            <%= f.text_field :price, class: "shadow appearance-none border border-slate-300 rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline focus:border-blue-500", placeholder: "例: 1000" %>
+            <%= f.label :price, class: "form-label" %>
+            <%= f.text_field :price, class: "form-input", placeholder: "例: 1000" %>
           </div>
         </div>
 
         <!-- 在庫数 -->
         <div>
-          <%= f.label :stock_quantity, "在庫数", class: "block text-gray-700 text-sm font-bold mb-2" %>
-          <%= f.number_field :stock_quantity, min: 0, value: @item.stock_quantity || 1, class: "shadow appearance-none border border-slate-300 rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline focus:border-blue-500" %>
+          <%= f.label :stock_quantity, "在庫数", class: "form-label" %>
+          <%= f.number_field :stock_quantity, min: 0, value: @item.stock_quantity || 1, class: "form-input" %>
         </div>
 
         <!-- メモ -->
         <div>
-          <%= f.label :memo, class: "block text-gray-700 text-sm font-bold mb-2" %>
-          <%= f.text_area :memo, rows: "5", class: "shadow appearance-none border border-slate-300 rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline focus:border-blue-500" %>
+          <%= f.label :memo, class: "form-label" %>
+          <%= f.text_area :memo, rows: "5", class: "form-input" %>
         </div>
 
         <!-- 登録ボタン -->
-        <div class="hidden rounded border border-blue-200 bg-blue-50 px-3 py-2 text-center text-sm text-blue-700" data-submit-loading>
+        <div class="alert-info hidden text-center" data-submit-loading>
           アイテムを登録しています...
         </div>
 
-        <div class="text-center">
-          <%= f.submit nil, class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline cursor-pointer" %>
+        <div>
+          <%= f.submit nil, class: "btn-primary w-full cursor-pointer" %>
         </div>
       </div>
     <% end %>

--- a/app/views/items/used_up.html.erb
+++ b/app/views/items/used_up.html.erb
@@ -1,11 +1,11 @@
-<div class="container mx-auto px-4 py-8">
-  <div class="flex justify-between items-center mb-6">
+<div class="ui-container-wide">
+  <div class="mb-6 flex items-center justify-between">
     <!-- ページタイトル -->
-    <h1 class="text-2xl text-gray-900"><%= @page_title %></h1>
+    <h1 class="brand-font text-2xl font-bold text-slate-900"><%= @page_title %></h1>
   </div>
 
   <% if @usage_logs.any? %>
-    <div class="bg-white rounded-lg shadow overflow-hidden">
+    <div class="ui-table-card">
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50">
           <tr>
@@ -22,7 +22,7 @@
           <% @usage_logs.each do |usage_log| %>
             <tr class="hover:bg-gray-50 transition duration-150">
               <td class="px-4 py-4 text-center">
-                <%= link_to usage_log.item.name, item_path(usage_log.item), class: "text-blue-600 hover:text-blue-800 font-medium transition duration-150" %>
+                <%= link_to usage_log.item.name, item_path(usage_log.item), class: "font-medium text-emerald-700 transition duration-150 hover:text-emerald-800" %>
               </td>
               <td class="px-4 py-4 whitespace-nowrap text-xs text-gray-400 text-center">
                 <%= usage_log.started_at&.strftime('%Y/%-m/%-d') || '-' %>
@@ -44,7 +44,7 @@
                 <%= usage_log.review.presence || "-" %>
               </td>
               <td class="px-4 py-4 whitespace-nowrap text-sm text-center">
-                <%= link_to "編集", edit_usage_log_path(usage_log), class: "text-blue-600 hover:text-blue-800 font-medium transition duration-150" %>
+                <%= link_to "編集", edit_usage_log_path(usage_log), class: "font-medium text-emerald-700 transition duration-150 hover:text-emerald-800" %>
               </td>
             </tr>
           <% end %>
@@ -52,8 +52,8 @@
       </table>
     </div>
   <% else %>
-    <div class="text-center py-12 bg-white rounded-lg shadow">
-      <p class="mt-4 text-gray-500 text-lg">使い切り履歴がありません</p>
+    <div class="ui-empty-state">
+      <p class="text-lg">使い切り履歴がありません</p>
     </div>
   <% end %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>App</title>
+    <title>ものログ</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <%= tag.link rel: "preconnect", href: "https://fonts.googleapis.com" %>
+    <%= tag.link rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: true %>
+    <%= stylesheet_link_tag "https://fonts.googleapis.com/css2?family=Kiwi+Maru:wght@400;500&family=Zen+Kaku+Gothic+New:wght@400;500;700&display=swap" %>
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,26 +9,34 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
+  <body class="min-h-screen bg-slate-50 text-slate-900">
     <%= render 'shared/header' %>
 
-    <% flash.each do |message_type, message| %>
-      <%
-        # DeviseのキーをTailwind CSSのクラスにマッピング
-        if message_type.to_s == 'notice' || message_type.to_s == 'success'
-          alert_class = 'bg-green-100 border-green-400 text-green-700'
-        elsif message_type.to_s == 'alert' || message_type.to_s == 'danger'
-          alert_class = 'bg-red-100 border-red-400 text-red-700'
-        else
-          alert_class = 'bg-blue-100 border-blue-400 text-blue-700'
-        end
-      %>
-      <div class="<%= alert_class %> px-4 py-3 rounded relative mb-4 border" role="alert">
-        <span class="block sm:inline"><%= message %></span>
-      </div>
-    <% end %>
+    <main class="min-h-[calc(100vh-9rem)]">
+      <% if flash.any? %>
+        <div class="ui-container pb-0">
+          <% flash.each do |message_type, message| %>
+            <%
+              # Deviseのキーを共通の通知スタイルにマッピングする
+              alert_class =
+                if message_type.to_s == 'notice' || message_type.to_s == 'success'
+                  'alert-success'
+                elsif message_type.to_s == 'alert' || message_type.to_s == 'danger'
+                  'alert-error'
+                else
+                  'alert-info'
+                end
+            %>
+            <div class="<%= alert_class %>" role="alert">
+              <%= message %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
 
-    <%= yield %>
+      <%= yield %>
+    </main>
+
     <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
 
     <main class="min-h-[calc(100vh-9rem)]">
       <% if flash.any? %>
-        <div class="ui-container pb-0">
+        <div class="mx-auto w-full max-w-5xl px-4 pt-4">
           <% flash.each do |message_type, message| %>
             <%
               # Deviseのキーを共通の通知スタイルにマッピングする

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -7,7 +7,7 @@
     </nav>
 
     <div class="text-center text-xs text-slate-400">
-      <p>Copyright © 2026. My Stocker</p>
+      <p>Copyright © 2026. ものログ</p>
     </div>
   </div>
 </footer>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,15 +1,12 @@
-<!-- 仮フッター -->
-<footer id='footer' class='bg-gray-100 py-8'>
-  <div class='max-w-7xl mx-auto px-6'>
-    <!-- リンク部分 -->
-    <nav class='flex justify-center space-x-8 mb-4'>
-      <%= link_to "利用規約", "#", class: "text-gray-600 hover:text-gray-900 transition" %>
-      <%= link_to "プライバシーポリシー", "#", class: "text-gray-600 hover:text-gray-900 transition" %>
-      <%= link_to "お問い合わせ", "#", class: "text-gray-600 hover:text-gray-900 transition" %>
+<footer id="footer" class="border-t border-slate-200 bg-white py-6">
+  <div class="mx-auto w-full max-w-5xl px-4">
+    <nav class="mb-3 flex flex-wrap justify-center gap-x-5 gap-y-2 text-sm">
+      <%= link_to "利用規約", "#", class: "text-slate-500 transition hover:text-emerald-700" %>
+      <%= link_to "プライバシーポリシー", "#", class: "text-slate-500 transition hover:text-emerald-700" %>
+      <%= link_to "お問い合わせ", "#", class: "text-slate-500 transition hover:text-emerald-700" %>
     </nav>
 
-    <!-- Copyright -->
-    <div class='text-center text-gray-500 text-sm'>
+    <div class="text-center text-xs text-slate-400">
       <p>Copyright © 2026. My Stocker</p>
     </div>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,8 +1,8 @@
 <header class="border-b border-emerald-100 bg-white/95 shadow-sm">
-  <div class="mx-auto w-full max-w-5xl px-4 py-3">
+  <div class="mx-auto w-full max-w-5xl px-4 py-5">
     <div class="flex flex-col gap-3">
       <div class="flex items-center justify-between gap-3">
-        <%= link_to "My Stocker", root_path, class: "text-xl font-bold text-emerald-700 transition hover:text-emerald-800" %>
+        <%= link_to "ものログ", root_path, class: "brand-font text-3xl font-bold text-emerald-700 transition hover:text-emerald-800" %>
 
         <% if user_signed_in? %>
           <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "btn-secondary px-3 py-1.5" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,24 +1,23 @@
-<!-- 仮ヘッダー -->
-<header class="bg-emerald-400 shadow-md">
-  <div class="container mx-auto px-4 py-4">
-    <div class="flex items-center justify-between">
-      <div class="text-2xl font-bold text-white">
-        <%= link_to "My Stocker", root_path, class: "hover:text-green-100 transition" %>
-      </div>
+<header class="border-b border-emerald-100 bg-white/95 shadow-sm">
+  <div class="mx-auto w-full max-w-5xl px-4 py-3">
+    <div class="flex flex-col gap-3">
+      <div class="flex items-center justify-between gap-3">
+        <%= link_to "My Stocker", root_path, class: "text-xl font-bold text-emerald-700 transition hover:text-emerald-800" %>
 
-      <div class="flex items-center space-x-6">
         <% if user_signed_in? %>
-          <!-- ログイン中 -->
-          <%= link_to "アイテムDB", items_path, class: "text-white hover:text-green-100 transition" %>
-          <%= link_to "ストックBOX", items_path(stock: "available"), class: "text-white hover:text-green-100 transition" %>
-          <%= link_to "使用中アイテム", in_use_items_path, class: "text-white hover:text-green-100 transition" %>
-          <%= link_to "使い切り履歴", used_up_items_path, class: "text-white hover:text-green-100 transition" %>
-          <%= link_to "評価・レビュー履歴", reviews_usage_logs_path, class: "text-white hover:text-green-100 transition" %>
-          <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "bg-white text-green-600 px-4 py-2 rounded hover:bg-green-50 transition font-semibold" %>
-        <% else %>
-          <!-- 非ログイン中 -->
+          <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "btn-secondary px-3 py-1.5" %>
         <% end %>
       </div>
+
+      <% if user_signed_in? %>
+        <nav class="flex flex-wrap gap-2 text-sm" aria-label="メインメニュー">
+          <%= link_to "アイテムDB", items_path, class: "rounded-full bg-emerald-50 px-3 py-1.5 font-medium text-emerald-700 transition hover:bg-emerald-100" %>
+          <%= link_to "ストックBOX", items_path(stock: "available"), class: "rounded-full bg-slate-100 px-3 py-1.5 font-medium text-slate-700 transition hover:bg-slate-200" %>
+          <%= link_to "使用中アイテム", in_use_items_path, class: "rounded-full bg-slate-100 px-3 py-1.5 font-medium text-slate-700 transition hover:bg-slate-200" %>
+          <%= link_to "使い切り履歴", used_up_items_path, class: "rounded-full bg-slate-100 px-3 py-1.5 font-medium text-slate-700 transition hover:bg-slate-200" %>
+          <%= link_to "評価・レビュー履歴", reviews_usage_logs_path, class: "rounded-full bg-slate-100 px-3 py-1.5 font-medium text-slate-700 transition hover:bg-slate-200" %>
+        </nav>
+      <% end %>
     </div>
   </div>
 </header>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -2,13 +2,13 @@
   <div class="text-center">
 
     <%# アプリタイトル %>
-    <h1 class="text-6xl font-light text-gray-800 mb-4 tracking-wide">
-      My Stocker
+    <h1 class="brand-font text-6xl font-light text-gray-800 mb-4 tracking-wide">
+      ものログ
     </h1>
 
     <%# サブタイトル %>
     <p class="text-2xl text-gray-600 mb-8 font-light">
-      ストック管理×レビューアプリ
+      ストック管理&レビュー記録でもう迷わない
     </p>
 
     <%# ボタンエリア %>

--- a/app/views/usage_logs/reviews.html.erb
+++ b/app/views/usage_logs/reviews.html.erb
@@ -1,11 +1,11 @@
-<div class="container mx-auto px-4 py-8">
-  <div class="flex justify-between items-center mb-6">
+<div class="ui-container-wide">
+  <div class="mb-6 flex items-center justify-between">
     <!-- ページタイトル -->
-    <h1 class="text-2xl text-gray-900"><%= @page_title %></h1>
+    <h1 class="brand-font text-2xl font-bold text-slate-900"><%= @page_title %></h1>
   </div>
 
   <% if @usage_logs.any? %>
-    <div class="bg-white rounded-lg shadow overflow-hidden">
+    <div class="ui-table-card">
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50">
           <tr>
@@ -20,7 +20,7 @@
           <% @usage_logs.each do |usage_log| %>
             <tr class="hover:bg-gray-50 transition duration-150">
               <td class="px-4 py-4 text-center">
-                <%= link_to usage_log.item.name, item_path(usage_log.item), class: "text-blue-600 hover:text-blue-800 font-medium transition duration-150" %>
+                <%= link_to usage_log.item.name, item_path(usage_log.item), class: "font-medium text-emerald-700 transition duration-150 hover:text-emerald-800" %>
               </td>
               <td class="px-4 py-4 whitespace-nowrap text-xs text-gray-400 text-center">
                 <%= usage_log.finished_at&.strftime('%Y/%-m/%-d') || '-' %>
@@ -32,7 +32,7 @@
                 <%= usage_log.review.presence || "レビューなし" %>
               </td>
               <td class="px-4 py-4 whitespace-nowrap text-sm text-center">
-                <%= link_to "編集", edit_usage_log_path(usage_log), class: "text-blue-600 hover:text-blue-800 font-medium transition duration-150" %>
+                <%= link_to "編集", edit_usage_log_path(usage_log), class: "font-medium text-emerald-700 transition duration-150 hover:text-emerald-800" %>
               </td>
             </tr>
           <% end %>
@@ -40,8 +40,8 @@
       </table>
     </div>
   <% else %>
-    <div class="text-center py-12 bg-white rounded-lg shadow">
-      <p class="mt-4 text-gray-500 text-lg">評価・レビュー履歴がありません</p>
+    <div class="ui-empty-state">
+      <p class="text-lg">評価・レビュー履歴がありません</p>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
## 概要
#121 の対応として、アプリ全体の共通UIの土台を整えました。

## 変更内容
- 共通UIクラスを追加
  - ボタン
  - フォーム入力欄
  - フラッシュメッセージ
  - カード
  - 空状態
  - 一覧用コンテナ
- ヘッダー・フッターの見た目を調整
- アイテム登録・編集フォームに共通UIを適用
- ログイン・新規登録画面に共通UIを適用
- 一覧・履歴画面の土台を共通トーンに調整
- アプリ名を「ものログ」に変更
- 基本フォントを調整
  - 本文：Zen Kaku Gothic New
  - ブランド名・主要タイトル：Kiwi Maru
- 使い始める時の日付選択UI改善は #122 に切り分け


## 関連 issue
- close #121
- refs #80
- refs #122