### PR TITLE
トップページと主要フォーム画面のUI共通デザイン化

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,43 +1,43 @@
-<div class="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-  <div class="max-w-md w-full space-y-8">
+<div class="ui-container">
+  <div class="space-y-6">
     <div class="text-center">
-      <h2 class="text-3xl font-extrabold text-gray-900">
+      <h2 class="brand-font text-2xl font-bold text-slate-900">
         新しいパスワードを設定
       </h2>
-      <p class="mt-2 text-sm text-gray-600">
+      <p class="mt-2 text-sm text-slate-500">
         新しいパスワードを入力してください
       </p>
     </div>
 
-    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "mt-8" }) do |f| %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "ui-card space-y-6" }) do |f| %>
       <%= render "devise/shared/error_messages", resource: resource %>
       <%= f.hidden_field :reset_password_token %>
 
-      <div class="space-y-5">
+      <div class="space-y-4">
         <div>
           <div class="flex items-baseline justify-between mb-2">
-            <%= f.label :password, "新しいパスワード", class: "block text-sm font-medium text-gray-700" %>
+            <%= f.label :password, "新しいパスワード", class: "form-label mb-0" %>
             <% if @minimum_password_length %>
-              <span class="text-xs text-gray-500">
+              <span class="text-xs text-slate-500">
                 (<%= @minimum_password_length %>文字以上)
               </span>
             <% end %>
           </div>
-          <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+          <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "form-input" %>
         </div>
 
         <div>
-          <%= f.label :password_confirmation, "新しいパスワード（確認）", class: "block text-sm font-medium text-gray-700 mb-2" %>
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+          <%= f.label :password_confirmation, "新しいパスワード（確認）", class: "form-label" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-input" %>
         </div>
       </div>
 
-      <div class="actions mt-8">
-        <%= f.submit "パスワードを変更", class: "inline-flex w-full items-center justify-center rounded-md bg-indigo-500 p-3 text-white duration-100 ease-in-out hover:bg-indigo-600 focus:outline-none cursor-pointer" %>
+      <div class="actions">
+        <%= f.submit "パスワードを変更", class: "btn-primary w-full cursor-pointer" %>
       </div>
     <% end %>
 
-    <div class="mt-6 text-center text-sm">
+    <div class="text-center text-sm">
       <%= render "devise/shared/links" %>
     </div>
   </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,30 +1,28 @@
-<div class="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-  <div class="max-w-md w-full space-y-8">
+<div class="ui-container">
+  <div class="space-y-6">
     <div class="text-center">
-      <h2 class="text-3xl font-extrabold text-gray-900">
+      <h2 class="brand-font text-2xl font-bold text-slate-900">
         パスワード再設定
       </h2>
-      <p class="mt-2 text-sm text-gray-600">
+      <p class="mt-2 text-sm text-slate-500">
         登録したメールアドレスに再設定用のリンクを送信します
       </p>
     </div>
 
-    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "mt-8" }) do |f| %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "ui-card space-y-6" }) do |f| %>
       <%= render "devise/shared/error_messages", resource: resource %>
 
-      <div class="space-y-5">
-        <div>
-          <%= f.label :email, "メールアドレス", class: "block text-sm font-medium text-gray-700 mb-2" %>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
-        </div>
+      <div>
+        <%= f.label :email, "メールアドレス", class: "form-label" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-input" %>
       </div>
 
-      <div class="actions mt-8">
-        <%= f.submit "送信", class: "inline-flex w-full items-center justify-center rounded-md bg-indigo-500 p-3 text-white duration-100 ease-in-out hover:bg-indigo-600 focus:outline-none cursor-pointer" %>
+      <div class="actions">
+        <%= f.submit "送信", class: "btn-primary w-full cursor-pointer" %>
       </div>
     <% end %>
 
-    <div class="mt-6 text-center text-sm">
+    <div class="text-center text-sm">
       <%= render "devise/shared/links" %>
     </div>
   </div>

--- a/app/views/items/finish_using_form.html.erb
+++ b/app/views/items/finish_using_form.html.erb
@@ -1,22 +1,22 @@
-<div class="container mx-auto px-4 py-8">
-  <div class="max-w-2xl mx-auto">
-    <h1 class="text-2xl mb-6 text-center">使い切り日を入力</h1>
+<div class="ui-container">
+  <div class="space-y-5">
+    <h1 class="brand-font text-center text-2xl font-bold text-slate-900">使い切り日を入力</h1>
 
-    <div class="bg-white rounded-lg shadow-lg p-8">
-      <div class="mb-6">
-        <p class="text-sm text-gray-500 mb-1">アイテム</p>
-        <p class="text-lg text-gray-900"><%= @item.name %></p>
+    <div class="ui-card space-y-6">
+      <div>
+        <p class="text-xs text-slate-500">アイテム</p>
+        <p class="brand-font mt-1 text-lg font-bold text-slate-900"><%= @item.name %></p>
       </div>
 
       <%= form_with url: finish_using_item_path(@item), method: :patch, local: true, class: "space-y-6" do %>
         <div>
-          <%= label_tag :finished_at, "使い切り日", class: "block text-gray-700 text-sm font-bold mb-2" %>
-          <%= date_field_tag :finished_at, Date.current, class: "border rounded w-full py-2 px-3 text-gray-700 leading-tight" %>
+          <%= label_tag :finished_at, "使い切り日", class: "form-label" %>
+          <%= date_field_tag :finished_at, Date.current, class: "form-input" %>
         </div>
 
-        <div class="flex gap-4 justify-center">
-          <%= link_to "戻る", params[:return_to] == "show" ? item_path(@item) : in_use_items_path, class: "inline-block bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" %>
-          <%= submit_tag "使い切る", class: "inline-block bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline", data: { turbo_confirm: "使い切りますか?" } %>
+        <div class="grid gap-3 sm:grid-cols-2">
+          <%= link_to "戻る", params[:return_to] == "show" ? item_path(@item) : in_use_items_path, class: "btn-secondary" %>
+          <%= submit_tag "使い切る", class: "btn-primary cursor-pointer", data: { turbo_confirm: "使い切りますか?" } %>
         </div>
       <% end %>
     </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,24 +1,39 @@
-<div class="min-h-screen bg-white flex items-center justify-center">
-  <div class="text-center">
+<div class="ui-container">
+  <div class="space-y-8 py-10 text-center">
+    <div class="space-y-4">
+      <%# アプリタイトル %>
+      <h1 class="brand-font text-6xl font-medium tracking-wide text-emerald-700">
+        ものログ
+      </h1>
 
-    <%# アプリタイトル %>
-    <h1 class="brand-font text-6xl font-light text-gray-800 mb-4 tracking-wide">
-      ものログ
-    </h1>
+      <%# サブタイトル %>
+      <p class="text-lg leading-relaxed text-slate-600">
+        在庫とレビューを記録して、<br>
+        次の買い物でもう迷わない。
+      </p>
+    </div>
 
-    <%# サブタイトル %>
-    <p class="text-2xl text-gray-600 mb-8 font-light">
-      ストック管理&レビュー記録でもう迷わない
-    </p>
-
-    <%# ボタンエリア %>
-    <% if user_signed_in? %>
-      <p class="text-xl text-gray-600">ようこそ、<%= current_user.name %> さん</p>
-    <% else %>
-      <div class="space-x-4">
-        <%= link_to "ログイン", new_user_session_path, class: "bg-white text-gray-700 px-8 py-3 rounded-lg font-medium hover:bg-gray-50 transition inline-block border-2 border-gray-300" %>
-        <%= link_to "新規登録", new_user_registration_path, class: "bg-emerald-400 text-white px-8 py-3 rounded-lg font-medium hover:bg-emerald-500 transition inline-block shadow-sm" %>
+    <div class="ui-card space-y-5 text-left">
+      <div>
+        <p class="brand-font text-xl font-bold text-slate-900">これ、どうだっけ…をなくす</p>
+        <p class="mt-2 text-sm leading-relaxed text-slate-600">
+          在庫管理をしながらレビュー記録を残すことで、
+          過去の記録が自分の未来の買い物を楽にしてくれるアプリです。
+        </p>
       </div>
-    <% end %>
+
+      <% if user_signed_in? %>
+        <div class="rounded-lg bg-emerald-50 px-4 py-3 text-sm text-emerald-800">
+          ようこそ、<%= current_user.name %> さん
+        </div>
+
+        <%= link_to "アイテム一覧へ", items_path, class: "btn-primary w-full" %>
+      <% else %>
+        <div class="grid gap-3">
+          <%= link_to "新規登録", new_user_registration_path, class: "btn-primary w-full" %>
+          <%= link_to "ログイン", new_user_session_path, class: "btn-secondary w-full" %>
+        </div>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/usage_logs/edit.html.erb
+++ b/app/views/usage_logs/edit.html.erb
@@ -1,17 +1,17 @@
-<div class="container mx-auto px-4 py-8">
-  <div class="max-w-2xl mx-auto">
-    <h1 class="text-2xl mb-6 text-center">評価・レビューを入力</h1>
+<div class="ui-container">
+  <div class="space-y-5">
+    <h1 class="brand-font text-center text-2xl font-bold text-slate-900">評価・レビューを入力</h1>
 
-    <div class="bg-white rounded-lg shadow-lg p-8">
-      <div class="mb-6">
-        <p class="text-sm text-gray-500 mb-1">アイテム</p>
-        <p class="text-lg text-gray-900"><%= @usage_log.item.name %></p>
+    <div class="ui-card space-y-6">
+      <div>
+        <p class="text-xs text-slate-500">アイテム</p>
+        <p class="brand-font mt-1 text-lg font-bold text-slate-900"><%= @usage_log.item.name %></p>
       </div>
 
       <% if @usage_log.errors.any? %>
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-6">
+        <div class="alert-error">
           <p class="font-bold">入力内容を確認してください</p>
-          <ul class="list-disc pl-5 mt-2">
+          <ul class="mt-2 list-disc pl-5">
             <% @usage_log.errors.full_messages.each do |message| %>
               <li><%= message %></li>
             <% end %>
@@ -21,24 +21,24 @@
 
       <%= form_with model: @usage_log, local: true, class: "space-y-6" do |form| %>
         <div>
-          <%= form.label :rating, "星評価（レビューする場合は必須）", class: "block text-gray-700 text-sm font-bold mb-2" %>
+          <%= form.label :rating, "星評価（レビューする場合は必須）", class: "form-label" %>
           <%= form.select :rating,
                           [["評価なし", ""]] + (1..5).map { |rating| ["#{rating} ★", rating] },
                           {},
-                          class: "border rounded w-full py-2 px-3 text-gray-700 leading-tight" %>
+                          class: "form-input" %>
         </div>
 
         <div>
-          <%= form.label :review, "レビュー", class: "block text-gray-700 text-sm font-bold mb-2" %>
+          <%= form.label :review, "レビュー", class: "form-label" %>
           <%= form.text_area :review,
                              rows: 6,
-                             class: "shadow appearance-none border border-slate-300 rounded w-full py-2 px-3 text-gray-700 leading-tight",
+                             class: "form-input",
                              placeholder: "レビュー本文は任意です" %>
         </div>
 
-        <div class="flex gap-4 justify-center">
-          <%= link_to "レビューしない", used_up_items_path, class: "inline-block bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" %>
-          <%= form.submit "保存する", class: "inline-block bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" %>
+        <div class="grid gap-3 sm:grid-cols-2">
+          <%= link_to "レビューしない", used_up_items_path, class: "btn-secondary" %>
+          <%= form.submit "保存する", class: "btn-primary cursor-pointer" %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
## 概要
#124 対応として、トップページと主要フォーム画面のUIを共通デザインに合わせました。

## 変更内容
- トップページのコピーと導線を「ものログ」の雰囲気に合わせて調整
- 評価・レビュー入力/編集フォームを共通UIに変更
- 使い切り日入力画面を共通UIに変更
- パスワード再設定画面を共通UIに変更
- ボタン、入力欄、カード、見出しの見た目を既存の共通クラスに統一

## 関連issue
Closes #124