### PR TITLE
履歴・レビューUIを整える

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,10 +22,15 @@ class ItemsController < ApplicationController
 
   def used_up
     @page_title = "使い切り履歴"
-    @usage_logs = current_user.usage_logs
-                              .finished
-                              .includes(:item)
-                              .order(finished_at: :desc)
+    finished_usage_logs = current_user.usage_logs
+                                      .finished
+                                      .includes(:item)
+                                      .order(finished_at: :desc)
+    @usage_logs = finished_usage_logs.to_a.uniq(&:item_id)
+    @used_up_counts_by_item_id = current_user.usage_logs
+                                             .finished
+                                             .group(:item_id)
+                                             .count
   end
 
   def new

--- a/app/views/items/in_use.html.erb
+++ b/app/views/items/in_use.html.erb
@@ -1,55 +1,85 @@
 <div class="ui-container-wide">
   <div class="mb-6 flex items-center justify-between">
-    <!-- ページタイトル -->
     <h1 class="brand-font text-2xl font-bold text-slate-900"><%= @page_title %></h1>
   </div>
 
   <% if @usage_logs.any? %>
-    <div class="ui-table-card">
-      <table class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
-          <tr>
-            <th class="px-4 py-3 text-center text-xs font-medium text-gray-400 uppercase tracking-wider w-20">画像</th>
-            <th class="px-4 py-3 text-center text-xs font-medium text-gray-400 uppercase tracking-wider">名前</th>
-            <th class="px-4 py-3 text-center text-xs font-medium text-gray-400 uppercase tracking-wider">使い始め日</th>
-            <th class="px-4 py-3 text-center text-xs font-medium text-gray-400 uppercase tracking-wider">使用日数</th>
-            <th class="px-4 py-3 text-center text-xs font-medium text-gray-400 uppercase tracking-wider">操作</th>
-            <th class="px-4 py-3 text-center text-xs font-medium text-gray-400 uppercase tracking-wider"></th>
-          </tr>
-        </thead>
-        <tbody class="bg-white divide-y divide-gray-200">
-          <% @usage_logs.each do |usage_log| %>
-            <tr class="hover:bg-gray-50 transition duration-150">
-              <td class="px-4 py-4 text-center">
-                <%= render "image", item: usage_log.item %>
-              </td>
-              <td class="px-4 py-4 text-center">
-                <%= link_to usage_log.item.name, item_path(usage_log.item), class: "font-medium text-emerald-700 transition duration-150 hover:text-emerald-800" %>
-              </td>
-              <td class="px-4 py-4 whitespace-nowrap text-xs text-gray-400 text-center">
-                <%= usage_log.started_at&.strftime('%Y/%-m/%-d') || '-' %>
-              </td>
-              <td class="px-4 py-4 whitespace-nowrap text-xs text-gray-400 text-center">
-                <% if usage_log.started_at.present? %>
-                  <%= "#{(Date.current - usage_log.started_at.to_date).to_i + 1}日目" %>
-                <% else %>
-                  -
-                <% end %>
-              </td>
-              <td class="px-6 py-4 whitespace-nowrap text-center">
-                <%= link_to "使い切り", finish_using_form_item_path(usage_log.item), class: "btn-primary" %>
-              </td>
-              <td class="px-4 py-4 whitespace-nowrap text-sm text-center">
-                <%= link_to "詳細", item_path(usage_log.item), class: "font-medium text-emerald-700 transition duration-150 hover:text-emerald-800" %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+    <div class="grid gap-4 lg:grid-cols-2">
+      <% @usage_logs.each do |usage_log| %>
+        <% item = usage_log.item %>
+
+        <article class="ui-card" data-disclosure>
+          <div class="flex gap-4">
+            <div class="shrink-0">
+              <%= render "image",
+                         item: item,
+                         size_class: "h-20 w-20",
+                         image_class: "h-20 w-20 rounded-lg object-cover",
+                         placeholder_icon_class: "h-8 w-8" %>
+            </div>
+
+            <div class="min-w-0 flex-1">
+              <div class="mb-2 flex flex-wrap items-start justify-between gap-2">
+                <h2 class="brand-font break-words text-lg font-bold text-slate-900">
+                  <%= link_to item.name, item_path(item), class: "transition hover:text-emerald-700" %>
+                </h2>
+                <span class="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-800">使用中</span>
+              </div>
+
+              <dl class="grid grid-cols-2 gap-3 text-sm">
+                <div>
+                  <dt class="text-xs text-slate-500">使い始め日</dt>
+                  <dd class="mt-1 text-slate-700">
+                    <%= usage_log.started_at&.strftime("%Y/%-m/%-d") || "-" %>
+                  </dd>
+                </div>
+
+                <div>
+                  <dt class="text-xs text-slate-500">使用日数</dt>
+                  <dd class="mt-1 text-slate-700">
+                    <% if usage_log.started_at.present? %>
+                      <%= "#{(Date.current - usage_log.started_at.to_date).to_i + 1}日目" %>
+                    <% else %>
+                      -
+                    <% end %>
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          </div>
+
+          <div class="mt-4 border-t border-slate-100 pt-4">
+            <button type="button" class="btn-primary w-full" data-disclosure-toggle>
+              使い切る
+            </button>
+
+            <div class="mt-3 hidden rounded-lg border border-emerald-100 bg-emerald-50 p-3" data-disclosure-panel>
+              <%= form_with url: finish_using_item_path(item), method: :patch, local: true, class: "space-y-3" do %>
+                <div>
+                  <%= label_tag :finished_at, "使い切り日", class: "form-label" %>
+                  <%= date_field_tag :finished_at, Date.current, class: "form-input bg-white" %>
+                </div>
+
+                <div class="grid gap-2 sm:grid-cols-2">
+                  <%= submit_tag "この日に使い切った", class: "btn-primary cursor-pointer", data: { turbo_confirm: "使い切りとして記録しますか?" } %>
+                  <button type="button" class="btn-secondary" data-disclosure-cancel>
+                    キャンセル
+                  </button>
+                </div>
+              <% end %>
+            </div>
+
+            <div class="mt-3 flex items-center justify-end gap-4">
+              <%= link_to "詳細を見る", item_path(item), class: "btn-secondary px-3 py-1.5" %>
+            </div>
+          </div>
+        </article>
+      <% end %>
     </div>
   <% else %>
     <div class="ui-empty-state">
       <p class="text-lg">使用中のアイテムがありません</p>
+      <p class="mt-2 text-sm">使い始めたアイテムがここに表示されます。</p>
     </div>
   <% end %>
 </div>

--- a/app/views/items/used_up.html.erb
+++ b/app/views/items/used_up.html.erb
@@ -1,59 +1,79 @@
 <div class="ui-container-wide">
   <div class="mb-6 flex items-center justify-between">
-    <!-- ページタイトル -->
     <h1 class="brand-font text-2xl font-bold text-slate-900"><%= @page_title %></h1>
   </div>
 
   <% if @usage_logs.any? %>
-    <div class="ui-table-card">
-      <table class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
-          <tr>
-            <th class="px-4 py-3 text-center text-xs font-medium text-gray-400 uppercase tracking-wider">名前</th>
-            <th class="px-4 py-3 text-center text-xs font-medium text-gray-400 uppercase tracking-wider">使い始め日</th>
-            <th class="px-4 py-3 text-center text-xs font-medium text-gray-400 uppercase tracking-wider">使い切り日</th>
-            <th class="px-4 py-3 text-center text-xs font-medium text-gray-400 uppercase tracking-wider">使用期間</th>
-            <th class="px-4 py-3 text-center text-xs font-medium text-gray-400 uppercase tracking-wider">評価</th>
-            <th class="px-4 py-3 text-center text-xs font-medium text-gray-400 uppercase tracking-wider">レビュー</th>
-            <th class="px-4 py-3 text-center text-xs font-medium text-gray-400 uppercase tracking-wider">操作</th>
-          </tr>
-        </thead>
-        <tbody class="bg-white divide-y divide-gray-200">
-          <% @usage_logs.each do |usage_log| %>
-            <tr class="hover:bg-gray-50 transition duration-150">
-              <td class="px-4 py-4 text-center">
-                <%= link_to usage_log.item.name, item_path(usage_log.item), class: "font-medium text-emerald-700 transition duration-150 hover:text-emerald-800" %>
-              </td>
-              <td class="px-4 py-4 whitespace-nowrap text-xs text-gray-400 text-center">
-                <%= usage_log.started_at&.strftime('%Y/%-m/%-d') || '-' %>
-              </td>
-              <td class="px-4 py-4 whitespace-nowrap text-xs text-gray-400 text-center">
-                <%= usage_log.finished_at&.strftime('%Y/%-m/%-d') || '-' %>
-              </td>
-              <td class="px-4 py-4 whitespace-nowrap text-xs text-gray-400 text-center">
+    <div class="grid gap-4 lg:grid-cols-2">
+      <% @usage_logs.each do |usage_log| %>
+        <% item = usage_log.item %>
+
+        <article class="ui-card">
+          <div class="flex gap-4">
+            <div class="shrink-0">
+              <%= render "image",
+                         item: item,
+                         size_class: "h-20 w-20",
+                         image_class: "h-20 w-20 rounded-lg object-cover",
+                         placeholder_icon_class: "h-8 w-8" %>
+            </div>
+
+            <div class="min-w-0 flex-1">
+              <div class="mb-2 flex flex-wrap items-start justify-between gap-2">
+                <h2 class="brand-font break-words text-lg font-bold text-slate-900">
+                  <%= link_to item.name, item_path(item), class: "transition hover:text-emerald-700" %>
+                </h2>
+                <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">使い切り済み</span>
+              </div>
+
+              <dl class="grid grid-cols-2 gap-3 text-sm">
+                <div>
+                  <dt class="text-xs text-slate-500">使い始め日</dt>
+                  <dd class="mt-1 text-slate-700">
+                    <%= usage_log.started_at&.strftime("%Y/%-m/%-d") || "-" %>
+                  </dd>
+                </div>
+
+                <div>
+                  <dt class="text-xs text-slate-500">使い切り日</dt>
+                  <dd class="mt-1 text-slate-700">
+                    <%= usage_log.finished_at&.strftime("%Y/%-m/%-d") || "-" %>
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          </div>
+
+          <dl class="mt-4 grid grid-cols-2 gap-3 text-sm">
+            <div class="rounded-lg bg-slate-50 p-3">
+              <dt class="text-xs text-slate-500">使用期間</dt>
+              <dd class="mt-1 font-semibold text-slate-800">
                 <% if usage_log.started_at.present? && usage_log.finished_at.present? %>
                   <%= "#{(usage_log.finished_at.to_date - usage_log.started_at.to_date).to_i + 1}日" %>
                 <% else %>
                   -
                 <% end %>
-              </td>
-              <td class="px-4 py-4 whitespace-nowrap text-sm text-yellow-500 text-center">
-                <%= usage_log.rating.present? ? "★" * usage_log.rating : "-" %>
-              </td>
-              <td class="px-4 py-4 text-sm text-gray-500 text-center">
-                <%= usage_log.review.presence || "-" %>
-              </td>
-              <td class="px-4 py-4 whitespace-nowrap text-sm text-center">
-                <%= link_to "編集", edit_usage_log_path(usage_log), class: "font-medium text-emerald-700 transition duration-150 hover:text-emerald-800" %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+              </dd>
+            </div>
+
+            <div class="rounded-lg bg-slate-50 p-3">
+              <dt class="text-xs text-slate-500">使い切り回数</dt>
+              <dd class="mt-1 font-semibold text-slate-800">
+                <%= "#{@used_up_counts_by_item_id[item.id]}回" %>
+              </dd>
+            </div>
+          </dl>
+
+          <div class="mt-4 flex items-center justify-end gap-4 border-t border-slate-100 pt-4">
+            <%= link_to "詳細を見る", item_path(item), class: "btn-secondary px-3 py-1.5" %>
+          </div>
+        </article>
+      <% end %>
     </div>
   <% else %>
     <div class="ui-empty-state">
       <p class="text-lg">使い切り履歴がありません</p>
+      <p class="mt-2 text-sm">使い切ったアイテムがここに表示されます。</p>
     </div>
   <% end %>
 </div>

--- a/app/views/usage_logs/reviews.html.erb
+++ b/app/views/usage_logs/reviews.html.erb
@@ -1,47 +1,70 @@
 <div class="ui-container-wide">
   <div class="mb-6 flex items-center justify-between">
-    <!-- ページタイトル -->
     <h1 class="brand-font text-2xl font-bold text-slate-900"><%= @page_title %></h1>
   </div>
 
   <% if @usage_logs.any? %>
-    <div class="ui-table-card">
-      <table class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
-          <tr>
-            <th class="px-4 py-3 text-center text-xs font-medium text-gray-400 uppercase tracking-wider">名前</th>
-            <th class="px-4 py-3 text-center text-xs font-medium text-gray-400 uppercase tracking-wider">使い切り日</th>
-            <th class="px-4 py-3 text-center text-xs font-medium text-gray-400 uppercase tracking-wider">評価</th>
-            <th class="px-4 py-3 text-center text-xs font-medium text-gray-400 uppercase tracking-wider">レビュー</th>
-            <th class="px-4 py-3 text-center text-xs font-medium text-gray-400 uppercase tracking-wider">操作</th>
-          </tr>
-        </thead>
-        <tbody class="bg-white divide-y divide-gray-200">
-          <% @usage_logs.each do |usage_log| %>
-            <tr class="hover:bg-gray-50 transition duration-150">
-              <td class="px-4 py-4 text-center">
-                <%= link_to usage_log.item.name, item_path(usage_log.item), class: "font-medium text-emerald-700 transition duration-150 hover:text-emerald-800" %>
-              </td>
-              <td class="px-4 py-4 whitespace-nowrap text-xs text-gray-400 text-center">
-                <%= usage_log.finished_at&.strftime('%Y/%-m/%-d') || '-' %>
-              </td>
-              <td class="px-4 py-4 whitespace-nowrap text-sm text-yellow-500 text-center">
-                <%= usage_log.rating.present? ? "★" * usage_log.rating : "-" %>
-              </td>
-              <td class="px-4 py-4 text-sm text-gray-500 text-center">
-                <%= usage_log.review.presence || "レビューなし" %>
-              </td>
-              <td class="px-4 py-4 whitespace-nowrap text-sm text-center">
-                <%= link_to "編集", edit_usage_log_path(usage_log), class: "font-medium text-emerald-700 transition duration-150 hover:text-emerald-800" %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+    <div class="grid gap-4 lg:grid-cols-2">
+      <% @usage_logs.each do |usage_log| %>
+        <% item = usage_log.item %>
+
+        <article class="ui-card">
+          <div class="flex gap-4">
+            <div class="shrink-0">
+              <%= render "items/image",
+                         item: item,
+                         size_class: "h-20 w-20",
+                         image_class: "h-20 w-20 rounded-lg object-cover",
+                         placeholder_icon_class: "h-8 w-8" %>
+            </div>
+
+            <div class="min-w-0 flex-1">
+              <div class="mb-2">
+                <h2 class="brand-font break-words text-lg font-bold text-slate-900">
+                  <%= link_to item.name, item_path(item), class: "transition hover:text-emerald-700" %>
+                </h2>
+              </div>
+
+              <dl class="grid grid-cols-2 gap-3 text-sm">
+                <div>
+                  <dt class="text-xs text-slate-500">使い切り日</dt>
+                  <dd class="mt-1 text-slate-700">
+                    <%= usage_log.finished_at&.strftime("%Y/%-m/%-d") || "-" %>
+                  </dd>
+                </div>
+
+                <div>
+                  <dt class="text-xs text-slate-500">評価</dt>
+                  <dd class="mt-1 font-semibold text-yellow-500">
+                    <%= "★" * usage_log.rating %><span class="text-slate-300"><%= "☆" * (5 - usage_log.rating) %></span>
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          </div>
+
+          <div class="mt-4 border-t border-slate-100 pt-4">
+            <h3 class="form-label">レビュー</h3>
+            <% if usage_log.review.present? %>
+              <p class="min-h-16 whitespace-pre-wrap rounded-lg bg-slate-50 p-3 text-sm leading-6 text-slate-700">
+                <%= usage_log.review %>
+              </p>
+            <% else %>
+              <p class="min-h-16 rounded-lg bg-slate-50 p-3 text-sm leading-6 text-slate-500">レビューなし</p>
+            <% end %>
+          </div>
+
+          <div class="mt-4 flex items-center justify-between gap-4 border-t border-slate-100 pt-4">
+            <%= link_to "編集", edit_usage_log_path(usage_log), class: "text-sm font-medium text-emerald-700 transition hover:text-emerald-800" %>
+            <%= link_to "詳細を見る", item_path(item), class: "btn-secondary px-3 py-1.5" %>
+          </div>
+        </article>
+      <% end %>
     </div>
   <% else %>
     <div class="ui-empty-state">
       <p class="text-lg">評価・レビュー履歴がありません</p>
+      <p class="mt-2 text-sm">評価を残したアイテムがここに表示されます。</p>
     </div>
   <% end %>
 </div>

--- a/app/views/usage_logs/reviews.html.erb
+++ b/app/views/usage_logs/reviews.html.erb
@@ -8,7 +8,7 @@
       <% @usage_logs.each do |usage_log| %>
         <% item = usage_log.item %>
 
-        <article class="ui-card">
+        <article class="ui-card flex h-full flex-col">
           <div class="flex gap-4">
             <div class="shrink-0">
               <%= render "items/image",
@@ -54,7 +54,7 @@
             <% end %>
           </div>
 
-          <div class="mt-4 flex items-center justify-between gap-4 border-t border-slate-100 pt-4">
+          <div class="mt-auto flex items-center justify-between gap-4 border-t border-slate-100 pt-4">
             <%= link_to "編集", edit_usage_log_path(usage_log), class: "text-sm font-medium text-emerald-700 transition hover:text-emerald-800" %>
             <%= link_to "詳細を見る", item_path(item), class: "btn-secondary px-3 py-1.5" %>
           </div>

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -71,14 +71,15 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to in_use_items_path
   end
 
-  test "in_use page links to finish using form" do
+  test "in_use page has finish using form in item card" do
     item = items(:one)
     item.start_using!(@user, Time.zone.local(2026, 5, 10))
 
     get in_use_items_path
 
     assert_response :success
-    assert_select "a[href='#{finish_using_form_item_path(item)}']", text: "使い切り"
+    assert_select "form[action='#{finish_using_item_path(item)}'] input[name='finished_at']"
+    assert_select "button[data-disclosure-toggle]", text: "使い切る"
   end
 
   test "used_up page links to edit usage log" do

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -82,16 +82,30 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "button[data-disclosure-toggle]", text: "使い切る"
   end
 
-  test "used_up page links to edit usage log" do
+  test "used_up page shows used up count" do
     item = items(:one)
     item.start_using!(@user, Time.zone.local(2026, 5, 10))
     item.finish_using!(Time.zone.local(2026, 5, 12), rating: 4, review: "また使いたい")
-    usage_log = item.usage_logs.finished.first
 
     get used_up_items_path
 
     assert_response :success
-    assert_select "a[href='#{edit_usage_log_path(usage_log)}']", text: "編集"
+    assert_includes response.body, "1回"
+  end
+
+  test "used_up page shows one card per item with used up count" do
+    item = items(:one)
+    item.start_using!(@user, Time.zone.local(2026, 5, 10))
+    item.finish_using!(Time.zone.local(2026, 5, 12), rating: 4)
+    item.update!(stock_quantity: 1)
+    item.start_using!(@user, Time.zone.local(2026, 5, 20))
+    item.finish_using!(Time.zone.local(2026, 5, 25), rating: 5)
+
+    get used_up_items_path
+
+    assert_response :success
+    assert_select "article.ui-card", count: 1
+    assert_includes response.body, "2回"
   end
 
   test "destroy_image removes attached image and redirects to edit page" do

--- a/test/controllers/usage_logs_controller_test.rb
+++ b/test/controllers/usage_logs_controller_test.rb
@@ -27,7 +27,7 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_includes response.body, @item.name
-    assert_includes response.body, "★★★★"
+    assert_select "dd", text: /★★★★\s*☆/
     assert_includes response.body, "また使いたい"
     assert_select "a[href='#{edit_usage_log_path(@usage_log)}']", text: "編集"
   end
@@ -39,7 +39,7 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_includes response.body, @item.name
-    assert_includes response.body, "★★★★"
+    assert_select "dd", text: /★★★★\s*☆/
     assert_includes response.body, "レビューなし"
   end
 


### PR DESCRIPTION
## 概要
#126 対応として、使用中アイテム一覧・使い切り履歴・評価レビュー履歴のUIをカード中心に整理しました。

## 変更内容
- 使用中アイテム一覧をカード表示に変更
- 「使い切る」ボタン押下後、同じカード内で使い切り日を選べるように変更
- 使い切り履歴をアイテムごとのカード表示に変更
- 同じアイテムは1カードにまとめ、使い切り回数を表示
- 使い切り履歴から評価・レビュー本文を外し、使い切り実績を見る画面として整理
- 評価・レビュー履歴をカード表示に変更
- 星評価を `★★★★☆` のように5段階で分かる表示に変更
- レビュー本文とレビューなし表示の高さを調整
- レビュー履歴カードの操作ボタン位置を揃える

## 関連issue
Closes #126