### PR TITLE
利用規約ページを追加

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,3 +1,5 @@
 class StaticPagesController < ApplicationController
   def top; end
+
+  def terms; end
 end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,7 +1,7 @@
 <footer id="footer" class="border-t border-slate-200 bg-white py-6">
   <div class="mx-auto w-full max-w-5xl px-4">
     <nav class="mb-3 flex flex-wrap justify-center gap-x-5 gap-y-2 text-sm">
-      <%= link_to "利用規約", "#", class: "text-slate-500 transition hover:text-emerald-700" %>
+      <%= link_to "利用規約", terms_path, class: "text-slate-500 transition hover:text-emerald-700" %>
       <%= link_to "プライバシーポリシー", "#", class: "text-slate-500 transition hover:text-emerald-700" %>
       <%= link_to "お問い合わせ", "#", class: "text-slate-500 transition hover:text-emerald-700" %>
     </nav>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,0 +1,88 @@
+<div class="ui-container-wide">
+  <div class="mx-auto max-w-5xl space-y-6">
+    <div class="space-y-2">
+      <h1 class="brand-font text-2xl font-bold text-slate-900">利用規約</h1>
+      <p class="text-sm leading-relaxed text-slate-600">
+        この利用規約（以下「本規約」といいます。）は、「ものログ」（以下「本サービス」といいます。）の利用条件を定めるものです。
+        本サービスを利用する方（以下「ユーザー」といいます。）は、本規約に同意のうえ、本サービスをご利用ください。
+      </p>
+    </div>
+
+    <div class="ui-card space-y-6 text-sm leading-relaxed text-slate-700">
+      <section class="space-y-2">
+        <h2 class="font-bold text-slate-900">第1条（適用）</h2>
+        <p>本規約は、ユーザーと本サービスの運営者（以下「運営者」といいます。）との間の本サービスの利用に関わる一切の関係に適用されます。</p>
+      </section>
+
+      <section class="space-y-2">
+        <h2 class="font-bold text-slate-900">第2条（本サービスの内容）</h2>
+        <p>本サービスは、ユーザーが所有するアイテムの在庫、使用履歴、評価、レビュー、画像その他の情報を記録し、管理するための機能を提供します。</p>
+      </section>
+
+      <section class="space-y-2">
+        <h2 class="font-bold text-slate-900">第3条（ユーザー登録）</h2>
+        <ol class="list-decimal space-y-2 pl-5">
+          <li>登録希望者は、本規約に同意のうえ、運営者が定める方法によりユーザー登録を行うものとします。</li>
+          <li>ユーザーは、登録情報に変更が生じた場合、速やかに最新の情報へ更新するものとします。</li>
+          <li>運営者は、虚偽の情報が登録された場合その他運営者が不適切と判断した場合、登録を認めないことがあります。</li>
+        </ol>
+      </section>
+
+      <section class="space-y-2">
+        <h2 class="font-bold text-slate-900">第4条（アカウントの管理）</h2>
+        <ol class="list-decimal space-y-2 pl-5">
+          <li>ユーザーは、自己の責任において、メールアドレスおよびパスワードを適切に管理するものとします。</li>
+          <li>ユーザーは、アカウントを第三者に利用させ、または譲渡、貸与、共有してはなりません。</li>
+        </ol>
+      </section>
+
+      <section class="space-y-2">
+        <h2 class="font-bold text-slate-900">第5条（禁止事項）</h2>
+        <p>ユーザーは、本サービスの利用にあたり、次の行為をしてはなりません。</p>
+        <ol class="list-decimal space-y-2 pl-5">
+          <li>法令または公序良俗に違反する行為</li>
+          <li>第三者の権利または利益を侵害する行為</li>
+          <li>第三者になりすます行為</li>
+          <li>不正アクセス、過度な負荷をかける行為その他本サービスの運営を妨害する行為</li>
+          <li>不正な目的で本サービスを利用する行為</li>
+          <li>その他、運営者が不適切と判断する行為</li>
+        </ol>
+      </section>
+
+      <section class="space-y-2">
+        <h2 class="font-bold text-slate-900">第6条（投稿データ）</h2>
+        <ol class="list-decimal space-y-2 pl-5">
+          <li>ユーザーは、本サービスに登録する画像、レビューその他のデータについて、必要な権利を有していることを確認したうえで登録するものとします。</li>
+          <li>ユーザーは、第三者の著作権、プライバシーその他の権利を侵害するデータを登録してはなりません。</li>
+          <li>運営者は、本規約に違反するデータまたは本サービスの運営上不適切なデータを削除できるものとします。</li>
+        </ol>
+      </section>
+
+      <section class="space-y-2">
+        <h2 class="font-bold text-slate-900">第7条（サービス内容の変更、停止または終了）</h2>
+        <p>運営者は、保守、障害への対応その他必要がある場合、本サービスの内容を変更し、または提供を一時的に停止もしくは終了することがあります。重要な変更または終了については、可能な範囲で事前に本サービス上その他適切な方法でお知らせします。</p>
+      </section>
+
+      <section class="space-y-2">
+        <h2 class="font-bold text-slate-900">第8条（保証の否認および免責）</h2>
+        <ol class="list-decimal space-y-2 pl-5">
+          <li>運営者は、本サービスが常に正確、完全かつ継続的に提供されることを保証するものではありません。</li>
+          <li>ユーザーは、登録したデータを自己の責任で管理するものとします。</li>
+          <li>運営者は、本サービスに関連してユーザーに生じた損害について、運営者の故意または重大な過失による場合その他法令により免責が認められない場合を除き、責任を負わないものとします。</li>
+        </ol>
+      </section>
+
+      <section class="space-y-2">
+        <h2 class="font-bold text-slate-900">第9条（利用規約の変更）</h2>
+        <p>運営者は、法令に従い、必要に応じて本規約を変更することがあります。変更する場合は、変更内容および効力発生日を、本サービス上その他適切な方法でお知らせします。</p>
+      </section>
+
+      <section class="space-y-2">
+        <h2 class="font-bold text-slate-900">第10条（準拠法および管轄裁判所）</h2>
+        <p>本規約の解釈には日本法を準拠法とします。本サービスに関して紛争が生じた場合は、法令に定める管轄裁判所を第一審の管轄裁判所とします。</p>
+      </section>
+
+      <p class="border-t border-slate-100 pt-4 text-right text-slate-500">制定日：2026年5月30日</p>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   devise_for :users
   root "static_pages#top"
+  get "terms", to: "static_pages#terms", as: :terms
 
   resources :items, only: %i[index new create show edit update destroy] do
     member do

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -1,7 +1,17 @@
 require "test_helper"
 
 class StaticPagesControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  test "利用規約ページを表示できる" do
+    get terms_path
+
+    assert_response :success
+    assert_select "h1", "利用規約"
+  end
+
+  test "フッターから利用規約ページに移動できる" do
+    get root_path
+
+    assert_response :success
+    assert_select "footer a[href='#{terms_path}']", "利用規約"
+  end
 end


### PR DESCRIPTION
## 概要
issue #63 の対応として、利用規約ページを追加しました。

## 変更内容
- `/terms` のルーティングを追加
- `StaticPagesController` に `terms` アクションを追加
- 利用規約ページを作成
- フッターの「利用規約」リンクを `/terms` に接続
- 利用規約ページとフッター導線のテストを追加

## 利用規約の内容
在庫管理・使用履歴・評価・レビュー・画像登録を扱うサービスとして、以下の項目を記載しました。

- ユーザー登録とアカウント管理
- 禁止事項
- 投稿データの取り扱い
- サービス内容の変更・停止・終了
- 保証の否認と免責
- 利用規約の変更
- 準拠法と管轄裁判所