### PR TITLE
プライバシーポリシーページを追加

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -2,4 +2,6 @@ class StaticPagesController < ApplicationController
   def top; end
 
   def terms; end
+
+  def privacy; end
 end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,7 @@
   <div class="mx-auto w-full max-w-5xl px-4">
     <nav class="mb-3 flex flex-wrap justify-center gap-x-5 gap-y-2 text-sm">
       <%= link_to "利用規約", terms_path, class: "text-slate-500 transition hover:text-emerald-700" %>
-      <%= link_to "プライバシーポリシー", "#", class: "text-slate-500 transition hover:text-emerald-700" %>
+      <%= link_to "プライバシーポリシー", privacy_path, class: "text-slate-500 transition hover:text-emerald-700" %>
       <%= link_to "お問い合わせ", "#", class: "text-slate-500 transition hover:text-emerald-700" %>
     </nav>
 

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,0 +1,83 @@
+<div class="ui-container-wide">
+  <div class="mx-auto max-w-5xl space-y-6">
+    <div class="space-y-2">
+      <h1 class="brand-font text-2xl font-bold text-slate-900">プライバシーポリシー</h1>
+      <p class="text-sm leading-relaxed text-slate-600">
+        「ものログ」（以下「本サービス」といいます。）は、ユーザーの個人情報を適切に取り扱うため、以下のとおりプライバシーポリシーを定めます。
+      </p>
+    </div>
+
+    <div class="ui-card space-y-6 text-sm leading-relaxed text-slate-700">
+      <section class="space-y-2">
+        <h2 class="font-bold text-slate-900">1. 取得する情報</h2>
+        <p>本サービスでは、サービスの提供にあたり、以下の情報を取得します。</p>
+        <ul class="list-disc space-y-2 pl-5">
+          <li>ユーザー登録時に入力されるユーザー名、メールアドレス、パスワード</li>
+          <li>ユーザーが登録するアイテム名、画像、価格、在庫数、メモ</li>
+          <li>ユーザーが登録する使用履歴、評価、レビュー</li>
+          <li>本サービスの利用に伴い自動的に送信されるアクセス情報</li>
+        </ul>
+        <p>パスワードは、安全性に配慮してハッシュ化した状態で保存します。</p>
+      </section>
+
+      <section class="space-y-2">
+        <h2 class="font-bold text-slate-900">2. 利用目的</h2>
+        <p>取得した情報は、以下の目的で利用します。</p>
+        <ul class="list-disc space-y-2 pl-5">
+          <li>本サービスの提供、維持および改善のため</li>
+          <li>ユーザー登録、本人確認および認証のため</li>
+          <li>パスワード再設定など、本サービスに関する案内を送信するため</li>
+          <li>不正利用の防止および安全性の確保のため</li>
+          <li>お問い合わせに対応するため</li>
+        </ul>
+      </section>
+
+      <section class="space-y-2">
+        <h2 class="font-bold text-slate-900">3. 第三者提供</h2>
+        <p>
+          本サービスは、法令に基づく場合を除き、ユーザー本人の同意なく個人データを第三者に提供しません。
+        </p>
+      </section>
+
+      <section class="space-y-2">
+        <h2 class="font-bold text-slate-900">4. 外部サービスの利用</h2>
+        <p>本サービスでは、サービスの提供に必要な範囲で、以下の外部サービスを利用します。</p>
+        <ul class="list-disc space-y-2 pl-5">
+          <li>Resend：パスワード再設定などのメール送信</li>
+          <li>Google Fonts：Webフォントの配信</li>
+        </ul>
+        <p>外部サービスにおける情報の取り扱いについては、各サービスのプライバシーポリシーをご確認ください。</p>
+      </section>
+
+      <section class="space-y-2">
+        <h2 class="font-bold text-slate-900">5. 安全管理</h2>
+        <p>
+          本サービスは、取得した情報の漏えい、滅失または毀損を防止するため、必要かつ適切な安全管理措置を講じます。
+        </p>
+      </section>
+
+      <section class="space-y-2">
+        <h2 class="font-bold text-slate-900">6. 開示、訂正および削除</h2>
+        <p>
+          ユーザー本人から個人情報の開示、訂正、削除その他法令に基づく請求があった場合、本人確認を行ったうえで、法令に従い適切に対応します。
+        </p>
+      </section>
+
+      <section class="space-y-2">
+        <h2 class="font-bold text-slate-900">7. プライバシーポリシーの変更</h2>
+        <p>
+          本サービスは、法令の変更やサービス内容の変更などに応じて、本ポリシーを変更することがあります。重要な変更については、本サービス上その他適切な方法でお知らせします。
+        </p>
+      </section>
+
+      <section class="space-y-2">
+        <h2 class="font-bold text-slate-900">8. お問い合わせ</h2>
+        <p>
+          本ポリシーに関するお問い合わせ方法は、お問い合わせページにてご案内します。
+        </p>
+      </section>
+
+      <p class="border-t border-slate-100 pt-4 text-right text-slate-500">制定日：2026年5月31日</p>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   devise_for :users
   root "static_pages#top"
   get "terms", to: "static_pages#terms", as: :terms
+  get "privacy", to: "static_pages#privacy", as: :privacy
 
   resources :items, only: %i[index new create show edit update destroy] do
     member do

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -14,4 +14,18 @@ class StaticPagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "footer a[href='#{terms_path}']", "利用規約"
   end
+
+  test "プライバシーポリシーページを表示できる" do
+    get privacy_path
+
+    assert_response :success
+    assert_select "h1", "プライバシーポリシー"
+  end
+
+  test "フッターからプライバシーポリシーページに移動できる" do
+    get root_path
+
+    assert_response :success
+    assert_select "footer a[href='#{privacy_path}']", "プライバシーポリシー"
+  end
 end


### PR DESCRIPTION
## 概要
issue #64 の対応として、プライバシーポリシーページを追加しました。

## 変更内容
- `/privacy` のルーティングを追加
- `StaticPagesController` に `privacy` アクションを追加
- プライバシーポリシーページを作成
- フッターの「プライバシーポリシー」リンクを `/privacy` に接続
- ページ表示とフッター導線のテストを追加

## プライバシーポリシーの内容
現在のサービス内容に合わせて、以下の項目を記載しました。

- 取得する情報
- 個人情報の利用目的
- 第三者提供
- 外部サービスの利用
- 安全管理
- 開示、訂正および削除
- ポリシーの変更
- お問い合わせ