### PR TITLE
お問い合わせ準備中ページを追加

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -4,4 +4,6 @@ class StaticPagesController < ApplicationController
   def terms; end
 
   def privacy; end
+
+  def contact; end
 end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,7 +3,7 @@
     <nav class="mb-3 flex flex-wrap justify-center gap-x-5 gap-y-2 text-sm">
       <%= link_to "利用規約", terms_path, class: "text-slate-500 transition hover:text-emerald-700" %>
       <%= link_to "プライバシーポリシー", privacy_path, class: "text-slate-500 transition hover:text-emerald-700" %>
-      <%= link_to "お問い合わせ", "#", class: "text-slate-500 transition hover:text-emerald-700" %>
+      <%= link_to "お問い合わせ", contact_path, class: "text-slate-500 transition hover:text-emerald-700" %>
     </nav>
 
     <div class="text-center text-xs text-slate-400">

--- a/app/views/static_pages/contact.html.erb
+++ b/app/views/static_pages/contact.html.erb
@@ -1,0 +1,22 @@
+<div class="ui-container">
+  <div class="space-y-5">
+    <h1 class="brand-font text-center text-2xl font-bold text-slate-900">お問い合わせ</h1>
+
+    <div class="ui-card space-y-4 text-sm leading-relaxed text-slate-700">
+      <p>
+        「ものログ」をご利用いただき、ありがとうございます。
+      </p>
+
+      <div class="rounded-lg bg-slate-50 px-4 py-4">
+        <p class="font-bold text-slate-900">お問い合わせ窓口を準備中です</p>
+        <p class="mt-2">
+          現在、お問い合わせ先を準備しています。ご案内まで今しばらくお待ちください。
+        </p>
+      </div>
+
+      <p class="text-slate-500">
+        お問い合わせ方法が決まり次第、このページでお知らせします。
+      </p>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   root "static_pages#top"
   get "terms", to: "static_pages#terms", as: :terms
   get "privacy", to: "static_pages#privacy", as: :privacy
+  get "contact", to: "static_pages#contact", as: :contact
 
   resources :items, only: %i[index new create show edit update destroy] do
     member do

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -28,4 +28,19 @@ class StaticPagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "footer a[href='#{privacy_path}']", "プライバシーポリシー"
   end
+
+  test "お問い合わせページを表示できる" do
+    get contact_path
+
+    assert_response :success
+    assert_select "h1", "お問い合わせ"
+    assert_select "p", "お問い合わせ窓口を準備中です"
+  end
+
+  test "フッターからお問い合わせページに移動できる" do
+    get root_path
+
+    assert_response :success
+    assert_select "footer a[href='#{contact_path}']", "お問い合わせ"
+  end
 end


### PR DESCRIPTION
## 概要
issue #65 の対応として、お問い合わせページを追加しました。

公開用メールアドレスが未確定のため、今回はお問い合わせ窓口が準備中であることを案内します。

## 変更内容
- `/contact` のルーティングを追加
- `StaticPagesController` に `contact` アクションを追加
- お問い合わせ準備中ページを作成
- フッターの「お問い合わせ」リンクを `/contact` に接続
- ページ表示とフッター導線のテストを追加

Related to #65