### PR TITLE
カテゴリ登録・管理機能の追加

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,0 +1,35 @@
+class CategoriesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_categories, only: %i[index create]
+
+  def index
+    @category = current_user.categories.new
+  end
+
+  def create
+    @category = current_user.categories.build(category_params)
+
+    if @category.save
+      redirect_to categories_path, success: "カテゴリを登録しました"
+    else
+      flash.now[:danger] = "カテゴリの登録に失敗しました"
+      render :index, status: :unprocessable_content
+    end
+  end
+
+  def destroy
+    category = current_user.categories.find(params[:id])
+    category.destroy!
+    redirect_to categories_path, success: "カテゴリを削除しました"
+  end
+
+  private
+
+  def set_categories
+    @categories = current_user.categories.order(:name)
+  end
+
+  def category_params
+    params.require(:category).permit(:name)
+  end
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,7 @@
+class Category < ApplicationRecord
+  belongs_to :user
+
+  validates :name, presence: true,
+                   length: { maximum: 20 },
+                   uniqueness: { scope: :user_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   has_many :items, dependent: :destroy
   has_many :usage_logs, dependent: :destroy
+  has_many :categories, dependent: :destroy
 
   # nameは必須（重複は許可）
   validates :name, presence: true, length: { maximum: 255 }

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,0 +1,55 @@
+<div class="ui-container">
+  <div class="space-y-6">
+    <div>
+      <h1 class="brand-font text-center text-2xl font-bold text-slate-900">カテゴリ管理</h1>
+      <p class="mt-2 text-center text-sm text-slate-600">
+        アイテムを分類するカテゴリを登録できます。
+      </p>
+    </div>
+
+    <%= form_with model: @category, class: "ui-card space-y-4" do |f| %>
+      <% if @category.errors.any? %>
+        <div class="alert-error">
+          <h2 class="mb-2 font-bold">
+            <%= @category.errors.count %>件のエラーがあります
+          </h2>
+          <ul class="list-inside list-disc">
+            <% @category.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <div>
+        <%= f.label :name, class: "form-label" %>
+        <%= f.text_field :name, class: "form-input", placeholder: "例: ヘアケア", maxlength: 20 %>
+        <p class="form-help">20文字以内で入力してください。</p>
+      </div>
+
+      <%= f.submit "カテゴリを登録する", class: "btn-primary w-full cursor-pointer" %>
+    <% end %>
+
+    <section class="ui-card">
+      <h2 class="brand-font text-lg font-bold text-slate-900">登録済みカテゴリ</h2>
+
+      <% if @categories.any? %>
+        <ul class="mt-4 divide-y divide-slate-100">
+          <% @categories.each do |category| %>
+            <li class="flex items-center justify-between gap-4 py-3">
+              <span class="break-words text-sm text-slate-700"><%= category.name %></span>
+              <%= link_to "削除",
+                          category_path(category),
+                          data: { turbo_method: :delete, turbo_confirm: "このカテゴリを削除しますか?" },
+                          class: "text-sm font-medium text-red-600 transition duration-150 hover:text-red-800" %>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <p class="mt-4 text-sm text-slate-600">
+          カテゴリはまだ登録されていません。
+        </p>
+      <% end %>
+    </section>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -20,6 +20,7 @@
           <%= link_to "使用中アイテム", in_use_items_path, class: current_page?(in_use_items_path) ? active_nav_class : inactive_nav_class %>
           <%= link_to "使い切り履歴", used_up_items_path, class: current_page?(used_up_items_path) ? active_nav_class : inactive_nav_class %>
           <%= link_to "評価・レビュー履歴", reviews_usage_logs_path, class: current_page?(reviews_usage_logs_path) ? active_nav_class : inactive_nav_class %>
+          <%= link_to "カテゴリ管理", categories_path, class: current_page?(categories_path) ? active_nav_class : inactive_nav_class %>
         </nav>
       <% end %>
     </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,7 @@ ja:
     models:
       item: アイテム
       usage_log: 使用履歴
+      category: カテゴリ
     attributes:
       item:
         name: アイテム名
@@ -20,6 +21,8 @@ ja:
         finished_at: 使い切り日
         rating: 評価
         review: レビュー
+      category:
+        name: カテゴリ名
       user:
         email: メールアドレス
     errors:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,4 +26,6 @@ Rails.application.routes.draw do
       get :reviews
     end
   end
+
+  resources :categories, only: %i[index create destroy]
 end

--- a/db/migrate/20260602000000_create_categories.rb
+++ b/db/migrate/20260602000000_create_categories.rb
@@ -1,0 +1,12 @@
+class CreateCategories < ActiveRecord::Migration[7.1]
+  def change
+    create_table :categories, id: :uuid do |t|
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.string :name, null: false
+
+      t.timestamps
+    end
+
+    add_index :categories, [:user_id, :name], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_01_021000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_02_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -41,6 +41,15 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_01_021000) do
     t.string "variation_digest", null: false
     t.uuid "blob_id", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "name"], name: "index_categories_on_user_id_and_name", unique: true
+    t.index ["user_id"], name: "index_categories_on_user_id"
   end
 
   create_table "items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -88,6 +97,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_01_021000) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "categories", "users"
   add_foreign_key "items", "users"
   add_foreign_key "usage_logs", "items"
   add_foreign_key "usage_logs", "users"

--- a/test/controllers/categories_controller_test.rb
+++ b/test/controllers/categories_controller_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+
+class CategoriesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    sign_in @user
+  end
+
+  test "index shows categories for signed-in user" do
+    other_user_category = Category.create!(user: users(:two), name: "日用品")
+
+    get categories_path
+
+    assert_response :success
+    assert_includes response.body, categories(:hair_care).name
+    assert_not_includes response.body, other_user_category.name
+    assert_select "form[action='#{categories_path}'] input[name='category[name]']"
+    assert_select "input[type='submit'][value='カテゴリを登録する']"
+  end
+
+  test "create saves category for signed-in user" do
+    assert_difference -> { @user.categories.count }, 1 do
+      post categories_path, params: { category: { name: "日用品" } }
+    end
+
+    assert_redirected_to categories_path
+  end
+
+  test "create rerenders index when category is invalid" do
+    assert_no_difference -> { @user.categories.count } do
+      post categories_path, params: { category: { name: "" } }
+    end
+
+    assert_response :unprocessable_content
+    assert_includes response.body, "カテゴリ名を入力してください"
+  end
+
+  test "destroy removes category for signed-in user" do
+    category = categories(:hair_care)
+
+    assert_difference -> { @user.categories.count }, -1 do
+      delete category_path(category)
+    end
+
+    assert_redirected_to categories_path
+  end
+
+  test "destroy does not remove another user's category" do
+    category = Category.create!(user: users(:two), name: "日用品")
+
+    assert_no_difference -> { Category.count } do
+      delete category_path(category)
+    end
+
+    assert_response :not_found
+  end
+
+  test "index redirects guest to sign-in page" do
+    sign_out @user
+
+    get categories_path
+
+    assert_redirected_to new_user_session_path
+  end
+end

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,0 +1,7 @@
+hair_care:
+  user: one
+  name: ヘアケア
+
+skin_care:
+  user: one
+  name: スキンケア

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class CategoryTest < ActiveSupport::TestCase
+  test "valid with name and user" do
+    category = Category.new(user: users(:one), name: "日用品")
+
+    assert category.valid?
+  end
+
+  test "invalid without name" do
+    category = Category.new(user: users(:one), name: "")
+
+    assert_not category.valid?
+    assert_includes category.errors[:name], "を入力してください"
+  end
+
+  test "invalid with name over 20 characters" do
+    category = Category.new(user: users(:one), name: "あ" * 21)
+
+    assert_not category.valid?
+  end
+
+  test "invalid with duplicate name for same user" do
+    category = Category.new(user: users(:one), name: categories(:hair_care).name)
+
+    assert_not category.valid?
+  end
+
+  test "valid with same name for different user" do
+    category = Category.new(user: users(:two), name: categories(:hair_care).name)
+
+    assert category.valid?
+  end
+end


### PR DESCRIPTION
## 概要
ユーザーごとにカテゴリを登録・管理できる機能を追加しました。

Closes #108

## 実装内容
- Category モデルと categories テーブルを追加
- カテゴリ名の必須・文字数・重複バリデーションを追加
- 同一ユーザー内でのカテゴリ名重複を DB 制約でも防止
- カテゴリ管理画面を追加
- カテゴリの登録・一覧表示・削除を追加
- ヘッダーに「カテゴリ管理」への導線を追加
- 他ユーザーのカテゴリを表示・削除できないように制御
- モデルテストとコントローラテストを追加

## 補足
- カテゴリはユーザーごとに管理します
- 親子構造は現時点では追加していません
- アイテム登録・編集画面でのカテゴリ選択と、その場でのカテゴリ追加は #107 で対応します
