### PR TITLE
アイテムのカテゴリ登録機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,9 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user! # ユーザーがログインしていることを確認
+  before_action :set_categories, only: %i[new create edit update]
 
   def index
-    @items = current_user.items.visible.order(created_at: :desc)
+    @items = current_user.items.visible.includes(:category).order(created_at: :desc)
 
     if params[:stock] == "available"
       @page_title = "ストックBOX"
@@ -39,11 +40,13 @@ class ItemsController < ApplicationController
 
   def create
     @item = current_user.items.build(item_params) # ログイン中のユーザーに紐づくアイテムを作成
-    if @item.save
+
+    if assign_category(@item) && @item.save
       redirect_to items_path, success: 'アイテムが作成されました。'
     else
-    flash.now[:danger] = 'アイテムの作成に失敗しました。'  # ← flash.nowを使う！
-    render :new, status: :unprocessable_content
+      set_categories
+      flash.now[:danger] = 'アイテムの作成に失敗しました。'  # ← flash.nowを使う！
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -57,10 +60,12 @@ class ItemsController < ApplicationController
 
   def update
     @item = current_user.items.find(params[:id])
+    @item.assign_attributes(item_params)
 
-    if @item.update(item_params)
+    if assign_category(@item) && @item.save
       redirect_to items_path, notice: 'アイテム情報を更新しました'
     else
+      set_categories
       render :edit, status: :unprocessable_content
     end
   end
@@ -124,5 +129,36 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:name, :price, :stock_quantity, :favorite, :memo, :image)
+  end
+
+  def set_categories
+    @categories = current_user.categories.order(:name)
+  end
+
+  def assign_category(item)
+    category_name = params.dig(:item, :new_category_name).to_s.strip
+    category_id = params.dig(:item, :category_id)
+    remove_category = ActiveModel::Type::Boolean.new.cast(params.dig(:item, :remove_category))
+
+    item.new_category_name = category_name
+    item.remove_category = remove_category
+
+    if category_name.present?
+      category = current_user.categories.find_or_initialize_by(name: category_name)
+      unless category.save
+        category.errors[:name].each { |message| item.errors.add(:new_category_name, message) }
+        return false
+      end
+
+      item.category = category
+    elsif remove_category
+      item.category = nil
+    elsif category_id.present?
+      item.category = current_user.categories.find(category_id)
+    else
+      item.category = nil
+    end
+
+    true
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,6 @@
 class Category < ApplicationRecord
   belongs_to :user
+  has_many :items, dependent: :nullify
 
   validates :name, presence: true,
                    length: { maximum: 20 },

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,6 @@
 class Item < ApplicationRecord
+  attr_accessor :new_category_name, :remove_category
+
   validates :name, presence: true, length: { maximum: 100 }
   validates :price, numericality: { only_integer: true, allow_blank: true, greater_than_or_equal_to: 0 }
   validates :stock_quantity, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
@@ -6,6 +8,7 @@ class Item < ApplicationRecord
   validate :image_size
 
   belongs_to :user
+  belongs_to :category, optional: true
   has_many :usage_logs, dependent: :destroy
   has_one_attached :image do |attachable|
     attachable.variant :thumbnail, resize_to_fill: [160, 160], format: :webp, saver: { quality: 80 }

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -25,6 +25,41 @@
           <%= f.text_field :name, class: "form-input" %>
         </div>
 
+        <!-- カテゴリ -->
+        <div class="space-y-3">
+          <% if @item.category.present? %>
+            <div class="rounded-lg border border-emerald-100 bg-emerald-50 p-3">
+              <p class="text-xs text-emerald-700">現在のカテゴリ</p>
+              <div class="mt-2 flex flex-wrap items-center justify-between gap-3">
+                <span class="rounded-full bg-white px-3 py-1 text-sm font-medium text-emerald-800">
+                  <%= @item.category.name %>
+                </span>
+                <label class="flex items-center text-sm text-slate-700">
+                  <%= f.check_box :remove_category, class: "h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500" %>
+                  <span class="ml-2">このカテゴリを外す</span>
+                </label>
+              </div>
+            </div>
+          <% end %>
+
+          <div>
+            <%= f.label :category_id, "カテゴリ", class: "form-label" %>
+            <%= f.collection_select :category_id,
+                                    @categories,
+                                    :id,
+                                    :name,
+                                    { include_blank: "カテゴリを選択してください" },
+                                    { class: "form-input" } %>
+            <p class="form-help">別のカテゴリを選ぶとカテゴリを変更できます。</p>
+          </div>
+
+          <div>
+            <%= f.label :new_category_name, "カテゴリが見つからない場合", class: "form-label" %>
+            <%= f.text_field :new_category_name, class: "form-input", placeholder: "例: ヘアケア", maxlength: 20 %>
+            <p class="form-help">入力すると、新しいカテゴリを追加してこのアイテムに設定します。</p>
+          </div>
+        </div>
+
         <!-- 画像プレビュー -->
         <div>
           <label class="form-label">画像</label>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -42,6 +42,10 @@
                   <dt class="text-xs text-slate-500">在庫数</dt>
                   <dd class="mt-1 text-slate-700"><%= item.stock_quantity %></dd>
                 </div>
+                <div class="col-span-2">
+                  <dt class="text-xs text-slate-500">カテゴリ</dt>
+                  <dd class="mt-1 text-slate-700"><%= item.category&.name || "未設定" %></dd>
+                </div>
               </dl>
             </div>
           </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -25,6 +25,25 @@
           <%= f.text_field :name, class: "form-input" %>
         </div>
 
+        <!-- カテゴリ -->
+        <div class="space-y-3">
+          <div>
+            <%= f.label :category_id, "カテゴリ", class: "form-label" %>
+            <%= f.collection_select :category_id,
+                                    @categories,
+                                    :id,
+                                    :name,
+                                    { include_blank: "カテゴリを選択してください" },
+                                    { class: "form-input" } %>
+          </div>
+
+          <div>
+            <%= f.label :new_category_name, "カテゴリが見つからない場合", class: "form-label" %>
+            <%= f.text_field :new_category_name, class: "form-input", placeholder: "例: ヘアケア", maxlength: 20 %>
+            <p class="form-help">入力すると、新しいカテゴリを追加してこのアイテムに設定します。</p>
+          </div>
+        </div>
+
         <!-- 画像プレビュー -->
         <div>
           <label class="form-label">画像</label>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -39,6 +39,11 @@
           <dt class="text-xs text-slate-500">在庫数</dt>
           <dd class="mt-1 font-semibold text-slate-800"><%= @item.stock_quantity %></dd>
         </div>
+
+        <div class="rounded-lg bg-slate-50 p-3">
+          <dt class="text-xs text-slate-500">カテゴリ</dt>
+          <dd class="mt-1 font-semibold text-slate-800"><%= @item.category&.name || "未設定" %></dd>
+        </div>
       </dl>
     </div>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,6 +12,9 @@ ja:
       item:
         name: アイテム名
         category_name: カテゴリー
+        category: カテゴリ
+        category_id: カテゴリ
+        new_category_name: 新しいカテゴリ名
         price: 価格
         stock_quantity: 在庫数
         favorite: お気に入り

--- a/db/migrate/20260603000000_add_category_to_items.rb
+++ b/db/migrate/20260603000000_add_category_to_items.rb
@@ -1,0 +1,5 @@
+class AddCategoryToItems < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :items, :category, foreign_key: true, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_02_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_03_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -62,7 +62,9 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_02_000000) do
     t.datetime "updated_at", null: false
     t.boolean "archived", default: false, null: false
     t.uuid "user_id", null: false
+    t.uuid "category_id"
     t.index ["archived"], name: "index_items_on_archived"
+    t.index ["category_id"], name: "index_items_on_category_id"
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
@@ -98,6 +100,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_02_000000) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "categories", "users"
+  add_foreign_key "items", "categories"
   add_foreign_key "items", "users"
   add_foreign_key "usage_logs", "items"
   add_foreign_key "usage_logs", "users"

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -131,11 +131,165 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-submit-loading]", text: "アイテムを登録しています..."
   end
 
+  test "new page has category select and new category field" do
+    get new_item_path
+
+    assert_response :success
+    assert_select "select[name='item[category_id]']"
+    assert_select "input[name='item[new_category_name]']"
+    assert_includes response.body, categories(:hair_care).name
+  end
+
   test "edit page has submit loading message" do
     get edit_item_path(items(:one))
 
     assert_response :success
     assert_select "[data-submit-loading]", text: "アイテム情報を更新しています..."
+  end
+
+  test "create assigns selected category to item" do
+    category = categories(:hair_care)
+
+    assert_difference -> { @user.items.count }, 1 do
+      post items_path, params: {
+        item: {
+          name: "シャンプー",
+          price: 1200,
+          stock_quantity: 1,
+          category_id: category.id
+        }
+      }
+    end
+
+    item = @user.items.order(:created_at).last
+    assert_redirected_to items_path
+    assert_equal category, item.category
+  end
+
+  test "create creates new category and assigns it to item" do
+    assert_difference -> { @user.categories.count }, 1 do
+      assert_difference -> { @user.items.count }, 1 do
+        post items_path, params: {
+          item: {
+            name: "歯ブラシ",
+            price: 300,
+            stock_quantity: 2,
+            new_category_name: "日用品"
+          }
+        }
+      end
+    end
+
+    item = @user.items.order(:created_at).last
+    assert_redirected_to items_path
+    assert_equal "日用品", item.category.name
+  end
+
+  test "create rerenders new when new category is invalid" do
+    assert_no_difference -> { @user.categories.count } do
+      assert_no_difference -> { @user.items.count } do
+        post items_path, params: {
+          item: {
+            name: "長いカテゴリのアイテム",
+            price: 300,
+            stock_quantity: 2,
+            new_category_name: "あ" * 21
+          }
+        }
+      end
+    end
+
+    assert_response :unprocessable_content
+    assert_includes response.body, "新しいカテゴリ名は20文字以内で入力してください"
+  end
+
+  test "update changes category" do
+    item = items(:one)
+    category = categories(:skin_care)
+
+    patch item_path(item), params: {
+      item: {
+        name: item.name,
+        price: item.price,
+        stock_quantity: item.stock_quantity,
+        category_id: category.id
+      }
+    }
+
+    assert_redirected_to items_path
+    assert_equal category, item.reload.category
+  end
+
+  test "update creates new category and assigns it to item" do
+    item = items(:one)
+
+    assert_difference -> { @user.categories.count }, 1 do
+      patch item_path(item), params: {
+        item: {
+          name: item.name,
+          price: item.price,
+          stock_quantity: item.stock_quantity,
+          new_category_name: "メイク"
+        }
+      }
+    end
+
+    assert_redirected_to items_path
+    assert_equal "メイク", item.reload.category.name
+  end
+
+  test "update removes category from item" do
+    item = items(:one)
+    item.update!(category: categories(:hair_care))
+
+    patch item_path(item), params: {
+      item: {
+        name: item.name,
+        price: item.price,
+        stock_quantity: item.stock_quantity,
+        remove_category: "1"
+      }
+    }
+
+    assert_redirected_to items_path
+    assert_nil item.reload.category
+  end
+
+  test "create cannot assign another user's category" do
+    category = Category.create!(user: users(:two), name: "日用品")
+
+    assert_no_difference -> { @user.items.count } do
+      post items_path, params: {
+        item: {
+          name: "他ユーザーカテゴリのアイテム",
+          price: 300,
+          stock_quantity: 1,
+          category_id: category.id
+        }
+      }
+    end
+
+    assert_response :not_found
+  end
+
+  test "index shows item category" do
+    item = items(:one)
+    item.update!(category: categories(:hair_care))
+
+    get items_path
+
+    assert_response :success
+    assert_includes response.body, categories(:hair_care).name
+  end
+
+  test "show shows item category" do
+    item = items(:one)
+    item.update!(category: categories(:hair_care))
+
+    get item_path(item)
+
+    assert_response :success
+    assert_includes response.body, categories(:hair_care).name
   end
 
   test "update with invalid image rerenders edit page" do


### PR DESCRIPTION
## 概要
アイテム登録・編集時にカテゴリを設定できるようにした。

Closes #107

## 実装内容
- `items` に `category_id` を追加
- `Item` と `Category` の関連付けを追加
- アイテム登録画面にカテゴリ選択フォームを追加
- アイテム編集画面にカテゴリ変更フォームを追加
- アイテム登録・編集画面から新しいカテゴリ名を入力できるように追加
- 新しいカテゴリ名が入力された場合、カテゴリを作成してアイテムに設定
- 編集画面で現在のカテゴリを表示
- 編集画面でカテゴリを外せるチェックボックスを追加
- アイテム一覧・詳細画面にカテゴリを表示
- 他ユーザーのカテゴリを紐付けられないように制御
- 登録・更新・カテゴリ表示のテストを追加

## 補足
- カテゴリなしでもアイテム登録できる
- カテゴリ削除時、紐付いているアイテムは削除せずカテゴリ未設定になる
- UX は今後必要に応じて改善予定