### PR TITLE
使用中止機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -151,8 +151,7 @@ class ItemsController < ApplicationController
 
     @item.discontinue_using!(
       params[:finished_at],
-      rating: params[:rating],
-      review: params[:review]
+      discontinued_reason: params[:discontinued_reason]
     )
 
     redirect_to in_use_items_path, notice: "使用を中止しました"

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,13 +25,24 @@ class ItemsController < ApplicationController
     @page_title = "使い切り履歴"
     finished_usage_logs = current_user.usage_logs
                                       .finished
+                                      .used_up
                                       .includes(:item)
                                       .order(finished_at: :desc)
     @usage_logs = finished_usage_logs.to_a.uniq(&:item_id)
     @used_up_counts_by_item_id = current_user.usage_logs
                                              .finished
+                                             .used_up
                                              .group(:item_id)
                                              .count
+  end
+
+  def discontinued
+    @page_title = "使用中止リスト"
+    @usage_logs = current_user.usage_logs
+                              .finished
+                              .discontinued
+                              .includes(:item)
+                              .order(finished_at: :desc)
   end
 
   def new
@@ -119,6 +130,32 @@ class ItemsController < ApplicationController
     @item.finish_using!(params[:finished_at])
 
     redirect_to edit_usage_log_path(usage_log), notice: "アイテムを使い切りました🎉"
+  end
+
+  def discontinue_using_form
+    @item = current_user.items.find(params[:id])
+
+    unless @item.using?
+      redirect_to in_use_items_path, alert: "使用中のアイテムがありません"
+    end
+  end
+
+  def discontinue_using
+    @item = current_user.items.find(params[:id])
+    usage_log = @item.current_usage_log
+
+    if usage_log.blank?
+      redirect_to in_use_items_path, alert: "使用中のアイテムがありません"
+      return
+    end
+
+    @item.discontinue_using!(
+      params[:finished_at],
+      rating: params[:rating],
+      review: params[:review]
+    )
+
+    redirect_to in_use_items_path, notice: "使用を中止しました"
   end
 
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -55,12 +55,11 @@ class Item < ApplicationRecord
     )
   end
 
-  def discontinue_using!(finished_at, rating: nil, review: nil)
+  def discontinue_using!(finished_at, discontinued_reason: nil)
     current_usage_log.update!(
       finished_at: finished_at.presence || Time.current,
       finish_reason: :discontinued,
-      rating: rating.presence,
-      review: review.presence
+      discontinued_reason: discontinued_reason.presence
     )
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -49,6 +49,16 @@ class Item < ApplicationRecord
   def finish_using!(finished_at, rating: nil, review: nil)
     current_usage_log.update!(
       finished_at: finished_at.presence || Time.current,
+      finish_reason: :used_up,
+      rating: rating.presence,
+      review: review.presence
+    )
+  end
+
+  def discontinue_using!(finished_at, rating: nil, review: nil)
+    current_usage_log.update!(
+      finished_at: finished_at.presence || Time.current,
+      finish_reason: :discontinued,
       rating: rating.presence,
       review: review.presence
     )

--- a/app/models/usage_log.rb
+++ b/app/models/usage_log.rb
@@ -1,4 +1,9 @@
 class UsageLog < ApplicationRecord
+  enum :finish_reason, {
+    used_up: "used_up",
+    discontinued: "discontinued"
+  }, validate: { allow_nil: true }
+
   belongs_to :item
   belongs_to :user
 

--- a/app/models/usage_log.rb
+++ b/app/models/usage_log.rb
@@ -13,6 +13,7 @@ class UsageLog < ApplicationRecord
 
   validates :started_at, presence: true
   validates :rating, inclusion: { in: 1..5 }, allow_nil: true
+  validates :discontinued_reason, length: { maximum: 500 }, allow_blank: true
 
   validate :finished_at_must_be_after_started_at
   validate :review_requires_rating

--- a/app/views/items/discontinue_using_form.html.erb
+++ b/app/views/items/discontinue_using_form.html.erb
@@ -18,6 +18,17 @@
           <%= date_field_tag :finished_at, Date.current, class: "form-input" %>
         </div>
 
+        <div>
+          <%= label_tag :discontinued_reason, "使用中止理由（任意）", class: "form-label" %>
+          <%= text_area_tag :discontinued_reason,
+                            nil,
+                            rows: 4,
+                            maxlength: 500,
+                            class: "form-input",
+                            placeholder: "例: 肌に合わなかった、香りが苦手だった など" %>
+          <p class="form-help">理由はあとから見返すためのメモです。空欄でも使用中止できます。</p>
+        </div>
+
         <div class="grid gap-3 sm:grid-cols-2">
           <%= link_to "戻る", in_use_items_path, class: "btn-secondary" %>
           <%= submit_tag "使用を中止する", class: "btn-danger cursor-pointer", data: { turbo_confirm: "使用中止として記録しますか?" } %>

--- a/app/views/items/discontinue_using_form.html.erb
+++ b/app/views/items/discontinue_using_form.html.erb
@@ -1,0 +1,28 @@
+<div class="ui-container">
+  <div class="space-y-5">
+    <h1 class="brand-font text-center text-2xl font-bold text-slate-900">使用中止日を入力</h1>
+
+    <div class="ui-card space-y-6">
+      <div>
+        <p class="text-xs text-slate-500">アイテム</p>
+        <p class="brand-font mt-1 text-lg font-bold text-slate-900"><%= @item.name %></p>
+      </div>
+
+      <p class="rounded-lg bg-red-50 px-3 py-2 text-sm leading-relaxed text-red-700">
+        肌に合わない、香りが苦手など、使い切らずにやめる場合はこちらで記録します。
+      </p>
+
+      <%= form_with url: discontinue_using_item_path(@item), method: :patch, local: true, class: "space-y-6" do %>
+        <div>
+          <%= label_tag :finished_at, "使用中止日", class: "form-label" %>
+          <%= date_field_tag :finished_at, Date.current, class: "form-input" %>
+        </div>
+
+        <div class="grid gap-3 sm:grid-cols-2">
+          <%= link_to "戻る", in_use_items_path, class: "btn-secondary" %>
+          <%= submit_tag "使用を中止する", class: "btn-danger cursor-pointer", data: { turbo_confirm: "使用中止として記録しますか?" } %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/items/discontinued.html.erb
+++ b/app/views/items/discontinued.html.erb
@@ -23,7 +23,7 @@
                 <h2 class="brand-font break-words text-lg font-bold text-slate-900">
                   <%= link_to item.name, item_path(item), class: "transition hover:text-emerald-700" %>
                 </h2>
-                <span class="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-800">使用中</span>
+                <span class="rounded-full bg-red-50 px-3 py-1 text-xs font-semibold text-red-700">使用中止</span>
               </div>
 
               <dl class="grid grid-cols-2 gap-3 text-sm">
@@ -35,36 +35,38 @@
                 </div>
 
                 <div>
-                  <dt class="text-xs text-slate-500">使用日数</dt>
+                  <dt class="text-xs text-slate-500">使用中止日</dt>
                   <dd class="mt-1 text-slate-700">
-                    <% if usage_log.started_at.present? %>
-                      <%= "#{(Date.current - usage_log.started_at.to_date).to_i + 1}日目" %>
-                    <% else %>
-                      -
-                    <% end %>
+                    <%= usage_log.finished_at&.strftime("%Y/%-m/%-d") || "-" %>
                   </dd>
                 </div>
               </dl>
             </div>
           </div>
 
-          <div class="mt-4 border-t border-slate-100 pt-4">
-            <div class="grid gap-2 sm:grid-cols-2">
-              <%= link_to "使い切る", finish_using_form_item_path(item), class: "btn-primary text-center" %>
-              <%= link_to "使用を中止する", discontinue_using_form_item_path(item), class: "btn-danger text-center" %>
+          <dl class="mt-4 text-sm">
+            <div class="rounded-lg bg-slate-50 p-3">
+              <dt class="text-xs text-slate-500">使用期間</dt>
+              <dd class="mt-1 font-semibold text-slate-800">
+                <% if usage_log.started_at.present? && usage_log.finished_at.present? %>
+                  <%= "#{(usage_log.finished_at.to_date - usage_log.started_at.to_date).to_i + 1}日" %>
+                <% else %>
+                  -
+                <% end %>
+              </dd>
             </div>
+          </dl>
 
-            <div class="mt-3 flex items-center justify-end gap-4">
-              <%= link_to "詳細を見る", item_path(item), class: "btn-secondary px-3 py-1.5" %>
-            </div>
+          <div class="mt-4 flex items-center justify-end gap-4 border-t border-slate-100 pt-4">
+            <%= link_to "詳細を見る", item_path(item), class: "btn-secondary px-3 py-1.5" %>
           </div>
         </article>
       <% end %>
     </div>
   <% else %>
     <div class="ui-empty-state">
-      <p class="text-lg">使用中のアイテムがありません</p>
-      <p class="mt-2 text-sm">使い始めたアイテムがここに表示されます。</p>
+      <p class="text-lg">使用中止したアイテムがありません</p>
+      <p class="mt-2 text-sm">肌に合わなかったものなどがここに表示されます。</p>
     </div>
   <% end %>
 </div>

--- a/app/views/items/discontinued.html.erb
+++ b/app/views/items/discontinued.html.erb
@@ -57,6 +57,13 @@
             </div>
           </dl>
 
+          <% if usage_log.discontinued_reason.present? %>
+            <div class="mt-4 rounded-lg bg-red-50 p-3 text-sm">
+              <p class="text-xs font-semibold text-red-700">使用中止理由</p>
+              <p class="mt-1 whitespace-pre-wrap text-slate-700"><%= usage_log.discontinued_reason %></p>
+            </div>
+          <% end %>
+
           <div class="mt-4 flex items-center justify-end gap-4 border-t border-slate-100 pt-4">
             <%= link_to "詳細を見る", item_path(item), class: "btn-secondary px-3 py-1.5" %>
           </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -19,6 +19,7 @@
           <%= link_to "ストックBOX", items_path(stock: "available"), class: current_page?(items_path(stock: "available")) ? active_nav_class : inactive_nav_class %>
           <%= link_to "使用中アイテム", in_use_items_path, class: current_page?(in_use_items_path) ? active_nav_class : inactive_nav_class %>
           <%= link_to "使い切り履歴", used_up_items_path, class: current_page?(used_up_items_path) ? active_nav_class : inactive_nav_class %>
+          <%= link_to "使用中止リスト", discontinued_items_path, class: current_page?(discontinued_items_path) ? active_nav_class : inactive_nav_class %>
           <%= link_to "評価・レビュー履歴", reviews_usage_logs_path, class: current_page?(reviews_usage_logs_path) ? active_nav_class : inactive_nav_class %>
           <%= link_to "カテゴリ管理", categories_path, class: current_page?(categories_path) ? active_nav_class : inactive_nav_class %>
         </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,11 +12,14 @@ Rails.application.routes.draw do
       patch :start_using
       get :finish_using_form, path: :finish_using
       patch :finish_using
+      get :discontinue_using_form, path: :discontinue_using
+      patch :discontinue_using
       delete :image, action: :destroy_image
     end
 
     collection do
       get :used_up
+      get :discontinued
       get :in_use
     end
   end

--- a/db/migrate/20260604000000_add_finish_reason_to_usage_logs.rb
+++ b/db/migrate/20260604000000_add_finish_reason_to_usage_logs.rb
@@ -1,0 +1,6 @@
+class AddFinishReasonToUsageLogs < ActiveRecord::Migration[7.1]
+  def change
+    add_column :usage_logs, :finish_reason, :string
+    add_index :usage_logs, :finish_reason
+  end
+end

--- a/db/migrate/20260605000000_add_discontinued_reason_to_usage_logs.rb
+++ b/db/migrate/20260605000000_add_discontinued_reason_to_usage_logs.rb
@@ -1,0 +1,5 @@
+class AddDiscontinuedReasonToUsageLogs < ActiveRecord::Migration[7.1]
+  def change
+    add_column :usage_logs, :discontinued_reason, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_03_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_04_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -77,6 +77,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_03_000000) do
     t.datetime "updated_at", null: false
     t.uuid "item_id", null: false
     t.uuid "user_id", null: false
+    t.string "finish_reason"
+    t.index ["finish_reason"], name: "index_usage_logs_on_finish_reason"
     t.index ["item_id", "finished_at"], name: "index_usage_logs_on_item_id_and_finished_at"
     t.index ["item_id"], name: "index_usage_logs_on_item_id"
     t.index ["item_id"], name: "index_usage_logs_on_item_id_where_in_use", unique: true, where: "(finished_at IS NULL)"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_04_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_05_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -78,6 +78,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_04_000000) do
     t.uuid "item_id", null: false
     t.uuid "user_id", null: false
     t.string "finish_reason"
+    t.text "discontinued_reason"
     t.index ["finish_reason"], name: "index_usage_logs_on_finish_reason"
     t.index ["item_id", "finished_at"], name: "index_usage_logs_on_item_id_and_finished_at"
     t.index ["item_id"], name: "index_usage_logs_on_item_id"

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -55,6 +55,34 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_nil usage_log.review
   end
 
+  test "discontinue_using discontinues current usage log and redirects to in-use page" do
+    item = items(:one)
+    item.start_using!(@user, Time.zone.local(2026, 5, 10))
+
+    patch discontinue_using_item_path(item), params: {
+      finished_at: "2026-05-11",
+      rating: 1,
+      review: "肌に合わなかった"
+    }
+
+    usage_log = item.usage_logs.finished.first
+    assert_redirected_to in_use_items_path
+    assert_equal Time.zone.local(2026, 5, 11), usage_log.finished_at
+    assert_equal "discontinued", usage_log.finish_reason
+    assert_equal 1, usage_log.rating
+    assert_equal "肌に合わなかった", usage_log.review
+  end
+
+  test "discontinue_using redirects when item is not in use" do
+    item = items(:one)
+
+    patch discontinue_using_item_path(item), params: {
+      finished_at: "2026-05-11"
+    }
+
+    assert_redirected_to in_use_items_path
+  end
+
   test "finish_using_form shows date field" do
     item = items(:one)
     item.start_using!(@user, Time.zone.local(2026, 5, 10))
@@ -71,15 +99,41 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to in_use_items_path
   end
 
-  test "in_use page has finish using form in item card" do
+  test "discontinue_using_form shows date field" do
+    item = items(:one)
+    item.start_using!(@user, Time.zone.local(2026, 5, 10))
+
+    get discontinue_using_form_item_path(item)
+
+    assert_response :success
+    assert_select "form[action='#{discontinue_using_item_path(item)}'] input[name='finished_at']"
+    assert_select "input[type='submit'][value='使用を中止する']"
+  end
+
+  test "discontinue_using_form redirects when item is not in use" do
+    get discontinue_using_form_item_path(items(:one))
+
+    assert_redirected_to in_use_items_path
+  end
+
+  test "in_use page has finish using link in item card" do
     item = items(:one)
     item.start_using!(@user, Time.zone.local(2026, 5, 10))
 
     get in_use_items_path
 
     assert_response :success
-    assert_select "form[action='#{finish_using_item_path(item)}'] input[name='finished_at']"
-    assert_select "button[data-disclosure-toggle]", text: "使い切る"
+    assert_select "a[href='#{finish_using_form_item_path(item)}']", text: "使い切る"
+  end
+
+  test "in_use page has discontinue using link in item card" do
+    item = items(:one)
+    item.start_using!(@user, Time.zone.local(2026, 5, 10))
+
+    get in_use_items_path
+
+    assert_response :success
+    assert_select "a[href='#{discontinue_using_form_item_path(item)}']", text: "使用を中止する"
   end
 
   test "used_up page shows used up count" do
@@ -91,6 +145,31 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_includes response.body, "1回"
+  end
+
+  test "used_up page does not show discontinued usage logs" do
+    item = items(:one)
+    item.start_using!(@user, Time.zone.local(2026, 5, 10))
+    item.discontinue_using!(Time.zone.local(2026, 5, 12))
+
+    get used_up_items_path
+
+    assert_response :success
+    assert_includes response.body, "使い切り履歴がありません"
+    assert_no_match item.name, response.body
+  end
+
+  test "discontinued page shows discontinued usage logs" do
+    item = items(:one)
+    item.start_using!(@user, Time.zone.local(2026, 5, 10))
+    item.discontinue_using!(Time.zone.local(2026, 5, 12))
+
+    get discontinued_items_path
+
+    assert_response :success
+    assert_includes response.body, item.name
+    assert_includes response.body, "使用中止"
+    assert_includes response.body, "使用期間"
   end
 
   test "used_up page shows one card per item with used up count" do

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -61,16 +61,16 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
 
     patch discontinue_using_item_path(item), params: {
       finished_at: "2026-05-11",
-      rating: 1,
-      review: "肌に合わなかった"
+      discontinued_reason: "肌に合わなかった"
     }
 
     usage_log = item.usage_logs.finished.first
     assert_redirected_to in_use_items_path
     assert_equal Time.zone.local(2026, 5, 11), usage_log.finished_at
     assert_equal "discontinued", usage_log.finish_reason
-    assert_equal 1, usage_log.rating
-    assert_equal "肌に合わなかった", usage_log.review
+    assert_equal "肌に合わなかった", usage_log.discontinued_reason
+    assert_nil usage_log.rating
+    assert_nil usage_log.review
   end
 
   test "discontinue_using redirects when item is not in use" do
@@ -107,6 +107,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "form[action='#{discontinue_using_item_path(item)}'] input[name='finished_at']"
+    assert_select "textarea[name='discontinued_reason']"
     assert_select "input[type='submit'][value='使用を中止する']"
   end
 
@@ -170,6 +171,21 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, item.name
     assert_includes response.body, "使用中止"
     assert_includes response.body, "使用期間"
+  end
+
+  test "discontinued page shows discontinued reason when present" do
+    item = items(:one)
+    item.start_using!(@user, Time.zone.local(2026, 5, 10))
+    item.discontinue_using!(
+      Time.zone.local(2026, 5, 12),
+      discontinued_reason: "香りが苦手だった"
+    )
+
+    get discontinued_items_path
+
+    assert_response :success
+    assert_includes response.body, "使用中止理由"
+    assert_includes response.body, "香りが苦手だった"
   end
 
   test "used_up page shows one card per item with used up count" do

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -55,14 +55,18 @@ class ItemTest < ActiveSupport::TestCase
     item = items(:one)
     item.start_using!(users(:one), Time.zone.local(2026, 5, 10))
 
-    item.discontinue_using!(Time.zone.local(2026, 5, 11), rating: 1, review: "肌に合わなかった")
+    item.discontinue_using!(
+      Time.zone.local(2026, 5, 11),
+      discontinued_reason: "肌に合わなかった"
+    )
 
     usage_log = item.usage_logs.finished.first
     assert_not item.using?
     assert_equal Time.zone.local(2026, 5, 11), usage_log.finished_at
     assert_equal "discontinued", usage_log.finish_reason
-    assert_equal 1, usage_log.rating
-    assert_equal "肌に合わなかった", usage_log.review
+    assert_equal "肌に合わなかった", usage_log.discontinued_reason
+    assert_nil usage_log.rating
+    assert_nil usage_log.review
   end
 
   test "item can be saved without image" do

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -24,6 +24,7 @@ class ItemTest < ActiveSupport::TestCase
     usage_log = item.usage_logs.finished.first
     assert_not item.using?
     assert_equal Time.zone.local(2026, 5, 12), usage_log.finished_at
+    assert_equal "used_up", usage_log.finish_reason
     assert_equal 5, usage_log.rating
     assert_equal "使いやすい", usage_log.review
   end
@@ -48,6 +49,20 @@ class ItemTest < ActiveSupport::TestCase
     usage_log = item.usage_logs.finished.first
     assert_not item.using?
     assert_nil usage_log.review
+  end
+
+  test "discontinue_using! discontinues current usage log" do
+    item = items(:one)
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 10))
+
+    item.discontinue_using!(Time.zone.local(2026, 5, 11), rating: 1, review: "肌に合わなかった")
+
+    usage_log = item.usage_logs.finished.first
+    assert_not item.using?
+    assert_equal Time.zone.local(2026, 5, 11), usage_log.finished_at
+    assert_equal "discontinued", usage_log.finish_reason
+    assert_equal 1, usage_log.rating
+    assert_equal "肌に合わなかった", usage_log.review
   end
 
   test "item can be saved without image" do

--- a/test/models/usage_log_test.rb
+++ b/test/models/usage_log_test.rb
@@ -67,4 +67,39 @@ class UsageLogTest < ActiveSupport::TestCase
 
     assert usage_log.valid?
   end
+
+  test "usage log accepts used up finish reason" do
+    usage_log = @item.usage_logs.build(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 10),
+      finished_at: Time.zone.local(2026, 5, 12),
+      finish_reason: :used_up
+    )
+
+    assert usage_log.valid?
+    assert usage_log.used_up?
+  end
+
+  test "usage log accepts discontinued finish reason" do
+    usage_log = @item.usage_logs.build(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 10),
+      finished_at: Time.zone.local(2026, 5, 12),
+      finish_reason: :discontinued
+    )
+
+    assert usage_log.valid?
+    assert usage_log.discontinued?
+  end
+
+  test "usage log rejects invalid finish reason" do
+    usage_log = @item.usage_logs.build(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 10),
+      finished_at: Time.zone.local(2026, 5, 12),
+      finish_reason: :unknown
+    )
+
+    assert_not usage_log.valid?
+  end
 end

--- a/test/models/usage_log_test.rb
+++ b/test/models/usage_log_test.rb
@@ -92,6 +92,30 @@ class UsageLogTest < ActiveSupport::TestCase
     assert usage_log.discontinued?
   end
 
+  test "usage log accepts discontinued reason without rating" do
+    usage_log = @item.usage_logs.build(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 10),
+      finished_at: Time.zone.local(2026, 5, 12),
+      finish_reason: :discontinued,
+      discontinued_reason: "肌に合わなかった"
+    )
+
+    assert usage_log.valid?
+  end
+
+  test "usage log rejects too long discontinued reason" do
+    usage_log = @item.usage_logs.build(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 10),
+      finished_at: Time.zone.local(2026, 5, 12),
+      finish_reason: :discontinued,
+      discontinued_reason: "あ" * 501
+    )
+
+    assert_not usage_log.valid?
+  end
+
   test "usage log rejects invalid finish reason" do
     usage_log = @item.usage_logs.build(
       user: @user,


### PR DESCRIPTION
## 概要
Closes #143

使用中アイテムを「使い切り」以外に、「使用中止」として終了できるようにしました。

## 変更内容
- `usage_logs.finish_reason` を追加
  - `used_up`: 使い切り
  - `discontinued`: 使用中止
- 使用中アイテム一覧に「使用を中止する」導線を追加
- 使用中止日と使用中止理由を入力できる画面を追加
- 使用中止した履歴を確認できる「使用中止リスト」を追加
- ヘッダーに「使用中止リスト」へのリンクを追加
- 使い切り履歴に使用中止履歴が混ざらないように修正
- controller / model テストを追加

## 確認したこと
- 使用中アイテムを使用中止として終了できる
- 使用中止日を保存できる
- 使用中止理由を任意で保存できる
- 使用中止リストに履歴が表示される
- 使い切り履歴には使用中止履歴が表示されない
- 既存の使い切り・レビュー機能が壊れていない