### PR TITLE
使用履歴詳細ページを追加する

### DIFF
--- a/app/controllers/usage_logs_controller.rb
+++ b/app/controllers/usage_logs_controller.rb
@@ -1,6 +1,9 @@
 class UsageLogsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_usage_log, only: %i[edit update]
+  before_action :set_usage_log, only: %i[show edit update]
+
+  def show
+  end
 
   def edit
   end

--- a/app/views/items/discontinued.html.erb
+++ b/app/views/items/discontinued.html.erb
@@ -44,28 +44,31 @@
             </div>
           </div>
 
-          <dl class="mt-4 text-sm">
-            <div class="rounded-lg bg-slate-50 p-3">
-              <dt class="text-xs text-slate-500">使用期間</dt>
-              <dd class="mt-1 font-semibold text-slate-800">
-                <% if usage_log.started_at.present? && usage_log.finished_at.present? %>
-                  <%= "#{(usage_log.finished_at.to_date - usage_log.started_at.to_date).to_i + 1}日" %>
-                <% else %>
-                  -
-                <% end %>
-              </dd>
-            </div>
-          </dl>
+          <div class="mt-4 space-y-3">
+            <% if usage_log.discontinued_reason.present? %>
+              <div class="rounded-lg bg-red-50 p-3 text-sm">
+                <p class="text-xs font-semibold text-red-700">使用中止理由</p>
+                <p class="mt-1 whitespace-pre-wrap text-slate-700"><%= usage_log.discontinued_reason %></p>
+              </div>
+            <% else %>
+              <div class="rounded-lg bg-slate-50 p-3 text-sm">
+                <p class="text-xs font-semibold text-slate-500">使用中止理由</p>
+                <p class="mt-1 text-slate-500">理由は未入力です</p>
+              </div>
+            <% end %>
 
-          <% if usage_log.discontinued_reason.present? %>
-            <div class="mt-4 rounded-lg bg-red-50 p-3 text-sm">
-              <p class="text-xs font-semibold text-red-700">使用中止理由</p>
-              <p class="mt-1 whitespace-pre-wrap text-slate-700"><%= usage_log.discontinued_reason %></p>
+            <div class="text-xs text-slate-500">
+              <span>使用期間: </span>
+              <% if usage_log.started_at.present? && usage_log.finished_at.present? %>
+                <span><%= "#{(usage_log.finished_at.to_date - usage_log.started_at.to_date).to_i + 1}日" %></span>
+              <% else %>
+                <span>-</span>
+              <% end %>
             </div>
-          <% end %>
+          </div>
 
           <div class="mt-4 flex items-center justify-end gap-4 border-t border-slate-100 pt-4">
-            <%= link_to "詳細を見る", item_path(item), class: "btn-secondary px-3 py-1.5" %>
+            <%= link_to "詳細を見る", usage_log_path(usage_log), class: "btn-secondary px-3 py-1.5" %>
           </div>
         </article>
       <% end %>

--- a/app/views/usage_logs/show.html.erb
+++ b/app/views/usage_logs/show.html.erb
@@ -1,0 +1,90 @@
+<% item = @usage_log.item %>
+
+<div class="mx-auto w-full max-w-lg px-4 py-6">
+  <div class="mb-6 flex items-center justify-between gap-4">
+    <%= link_to "使用中止リストへ", discontinued_items_path, class: "btn-secondary" %>
+    <%= link_to "アイテム本体を見る", item_path(item), class: "btn-primary" %>
+  </div>
+
+  <section class="ui-card space-y-6">
+    <div class="mx-auto w-full md:max-w-64">
+      <%= render "items/image",
+                 item: item,
+                 size_class: "aspect-square w-full",
+                 image_class: "aspect-square w-full rounded-lg object-cover",
+                 placeholder_icon_class: "h-16 w-16",
+                 variant_name: :preview %>
+    </div>
+
+    <div class="space-y-3">
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <h1 class="brand-font break-words text-2xl font-bold text-slate-900"><%= item.name %></h1>
+
+        <% if @usage_log.discontinued? %>
+          <span class="rounded-full bg-red-50 px-3 py-1 text-xs font-semibold text-red-700">使用中止</span>
+        <% elsif @usage_log.used_up? %>
+          <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">使い切り済み</span>
+        <% else %>
+          <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">終了済み</span>
+        <% end %>
+      </div>
+
+      <dl class="grid grid-cols-2 gap-3 text-sm">
+        <div class="rounded-lg bg-slate-50 p-3">
+          <dt class="text-xs text-slate-500">使い始め日</dt>
+          <dd class="mt-1 font-semibold text-slate-800">
+            <%= @usage_log.started_at&.strftime("%Y/%-m/%-d") || "-" %>
+          </dd>
+        </div>
+
+        <div class="rounded-lg bg-slate-50 p-3">
+          <dt class="text-xs text-slate-500"><%= @usage_log.discontinued? ? "使用中止日" : "終了日" %></dt>
+          <dd class="mt-1 font-semibold text-slate-800">
+            <%= @usage_log.finished_at&.strftime("%Y/%-m/%-d") || "-" %>
+          </dd>
+        </div>
+
+        <div class="rounded-lg bg-slate-50 p-3">
+          <dt class="text-xs text-slate-500">使用期間</dt>
+          <dd class="mt-1 font-semibold text-slate-800">
+            <% if @usage_log.started_at.present? && @usage_log.finished_at.present? %>
+              <%= "#{(@usage_log.finished_at.to_date - @usage_log.started_at.to_date).to_i + 1}日" %>
+            <% else %>
+              -
+            <% end %>
+          </dd>
+        </div>
+
+        <div class="rounded-lg bg-slate-50 p-3">
+          <dt class="text-xs text-slate-500">カテゴリ</dt>
+          <dd class="mt-1 font-semibold text-slate-800"><%= item.category&.name || "未設定" %></dd>
+        </div>
+      </dl>
+    </div>
+
+    <% if @usage_log.discontinued? %>
+      <div class="border-t border-slate-100 pt-5">
+        <h2 class="form-label">使用中止理由</h2>
+        <% if @usage_log.discontinued_reason.present? %>
+          <div class="whitespace-pre-wrap rounded-lg border border-red-200 bg-red-50 p-3 text-sm leading-6 text-slate-700">
+            <%= @usage_log.discontinued_reason %>
+          </div>
+        <% else %>
+          <p class="rounded-lg bg-slate-50 px-3 py-4 text-sm text-slate-500">使用中止理由はありません。</p>
+        <% end %>
+      </div>
+    <% end %>
+
+    <% if @usage_log.rating.present? %>
+      <div class="border-t border-slate-100 pt-5">
+        <h2 class="form-label">評価・レビュー</h2>
+        <div class="rounded-lg bg-slate-50 p-3 text-sm">
+          <p class="font-semibold text-yellow-500">
+            <%= "★" * @usage_log.rating %><span class="text-slate-300"><%= "☆" * (5 - @usage_log.rating) %></span>
+          </p>
+          <p class="mt-2 whitespace-pre-wrap text-slate-700"><%= @usage_log.review.presence || "レビューなし" %></p>
+        </div>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :usage_logs, only: %i[edit update] do
+  resources :usage_logs, only: %i[show edit update] do
     collection do
       get :reviews
     end

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -171,6 +171,8 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, item.name
     assert_includes response.body, "使用中止"
     assert_includes response.body, "使用期間"
+    assert_includes response.body, "理由は未入力です"
+    assert_select "a[href='#{usage_log_path(item.usage_logs.finished.first)}']", text: "詳細を見る"
   end
 
   test "discontinued page shows discontinued reason when present" do

--- a/test/controllers/usage_logs_controller_test.rb
+++ b/test/controllers/usage_logs_controller_test.rb
@@ -20,6 +20,17 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{used_up_items_path}']", text: "レビューしない"
   end
 
+  test "show displays usage log detail" do
+    get usage_log_path(@usage_log)
+
+    assert_response :success
+    assert_includes response.body, @item.name
+    assert_includes response.body, "使い始め日"
+    assert_includes response.body, "終了日"
+    assert_includes response.body, "使用期間"
+    assert_select "a[href='#{item_path(@item)}']", text: "アイテム本体を見る"
+  end
+
   test "reviews shows finished usage logs with rating and review" do
     @usage_log.update!(rating: 4, review: "また使いたい")
 
@@ -104,6 +115,18 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
     other_usage_log = other_item.usage_logs.finished.first
 
     get edit_usage_log_path(other_usage_log)
+
+    assert_response :not_found
+  end
+
+  test "other user's usage log cannot be shown" do
+    other_user = users(:two)
+    other_item = other_user.items.create!(name: "他のアイテム", stock_quantity: 1)
+    other_item.start_using!(other_user, Time.zone.local(2026, 5, 10))
+    other_item.finish_using!(Time.zone.local(2026, 5, 12))
+    other_usage_log = other_item.usage_logs.finished.first
+
+    get usage_log_path(other_usage_log)
 
     assert_response :not_found
   end


### PR DESCRIPTION
## 概要
Closes #147

使用中止リストなどから、アイテム本体ではなく「その1回の使用履歴」に対応した詳細画面を確認できるようにしました。

## 変更内容
- `usage_logs#show` を追加
- 使用履歴詳細ページを追加
- 使用中止リストの「詳細を見る」のリンク先を `item_path` から `usage_log_path` に変更
- 使用中止リストで使用中止理由を確認できるように調整
- 使用期間の表示を小さめの補助情報に変更
- 他ユーザーの使用履歴詳細を閲覧できないようにテストを追加

## 表示内容
使用履歴詳細では、以下を表示します。

- アイテム画像
- アイテム名
- 使用状態バッジ
  - 使用中止
  - 使い切り済み
  - 終了済み
- 使い始め日
- 終了日 / 使用中止日
- 使用期間
- カテゴリ
- 使用中止理由
- 評価・レビュー
- アイテム本体詳細へのリンク

## 確認したこと
- 使用中止リストから使用履歴詳細へ遷移できる
- 使用履歴詳細でアイテム本体の在庫状態ではなく、使用履歴の状態が表示される
- 使用中止理由が表示される
- 評価・レビューが表示される
- アイテム本体詳細へのリンクが表示される
- 他ユーザーの使用履歴詳細は閲覧できない