### PR TITLE
 使用中止理由を後から編集できるようにする

### DIFF
--- a/app/controllers/usage_logs_controller.rb
+++ b/app/controllers/usage_logs_controller.rb
@@ -1,11 +1,15 @@
 class UsageLogsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_usage_log, only: %i[show edit update]
+  before_action :set_discontinued_usage_log, only: %i[edit_discontinued_reason update_discontinued_reason]
 
   def show
   end
 
   def edit
+  end
+
+  def edit_discontinued_reason
   end
 
   def reviews
@@ -25,13 +29,29 @@ class UsageLogsController < ApplicationController
     end
   end
 
+  def update_discontinued_reason
+    if @usage_log.update(discontinued_reason_params)
+      redirect_to usage_log_path(@usage_log), notice: "使用中止理由を保存しました"
+    else
+      render :edit_discontinued_reason, status: :unprocessable_content
+    end
+  end
+
   private
 
   def set_usage_log
     @usage_log = current_user.usage_logs.finished.includes(:item).find(params[:id])
   end
 
+  def set_discontinued_usage_log
+    @usage_log = current_user.usage_logs.finished.discontinued.includes(:item).find(params[:id])
+  end
+
   def usage_log_params
     params.require(:usage_log).permit(:rating, :review)
+  end
+
+  def discontinued_reason_params
+    params.require(:usage_log).permit(:discontinued_reason)
   end
 end

--- a/app/models/usage_log.rb
+++ b/app/models/usage_log.rb
@@ -1,4 +1,6 @@
 class UsageLog < ApplicationRecord
+  normalizes :discontinued_reason, with: ->(reason) { reason.presence }
+
   enum :finish_reason, {
     used_up: "used_up",
     discontinued: "discontinued"

--- a/app/views/usage_logs/edit_discontinued_reason.html.erb
+++ b/app/views/usage_logs/edit_discontinued_reason.html.erb
@@ -1,0 +1,44 @@
+<div class="ui-container">
+  <div class="space-y-5">
+    <h1 class="brand-font text-center text-2xl font-bold text-slate-900">使用中止理由を編集</h1>
+
+    <div class="ui-card space-y-6">
+      <div>
+        <p class="text-xs text-slate-500">アイテム</p>
+        <p class="brand-font mt-1 text-lg font-bold text-slate-900"><%= @usage_log.item.name %></p>
+      </div>
+
+      <% if @usage_log.errors.any? %>
+        <div class="alert-error">
+          <p class="font-bold">入力内容を確認してください</p>
+          <ul class="mt-2 list-disc pl-5">
+            <% @usage_log.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <%= form_with model: @usage_log,
+                    url: update_discontinued_reason_usage_log_path(@usage_log),
+                    method: :patch,
+                    local: true,
+                    class: "space-y-6" do |form| %>
+        <div>
+          <%= form.label :discontinued_reason, "使用中止理由（任意）", class: "form-label" %>
+          <%= form.text_area :discontinued_reason,
+                             rows: 6,
+                             maxlength: 500,
+                             class: "form-input",
+                             placeholder: "例: 肌に合わなかった、香りが苦手だった など" %>
+          <p class="form-help">空欄で保存すると、使用中止理由を削除できます。</p>
+        </div>
+
+        <div class="grid gap-3 sm:grid-cols-2">
+          <%= link_to "戻る", usage_log_path(@usage_log), class: "btn-secondary" %>
+          <%= form.submit "保存する", class: "btn-primary cursor-pointer" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/usage_logs/show.html.erb
+++ b/app/views/usage_logs/show.html.erb
@@ -64,7 +64,13 @@
 
     <% if @usage_log.discontinued? %>
       <div class="border-t border-slate-100 pt-5">
-        <h2 class="form-label">使用中止理由</h2>
+        <div class="mb-2 flex items-center justify-between gap-3">
+          <h2 class="form-label mb-0">使用中止理由</h2>
+          <%= link_to "理由を編集",
+                      edit_discontinued_reason_usage_log_path(@usage_log),
+                      class: "text-sm font-medium text-emerald-700 transition hover:text-emerald-800" %>
+        </div>
+
         <% if @usage_log.discontinued_reason.present? %>
           <div class="whitespace-pre-wrap rounded-lg border border-red-200 bg-red-50 p-3 text-sm leading-6 text-slate-700">
             <%= @usage_log.discontinued_reason %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,11 @@ Rails.application.routes.draw do
   end
 
   resources :usage_logs, only: %i[show edit update] do
+    member do
+      get :edit_discontinued_reason
+      patch :update_discontinued_reason
+    end
+
     collection do
       get :reviews
     end

--- a/test/controllers/usage_logs_controller_test.rb
+++ b/test/controllers/usage_logs_controller_test.rb
@@ -130,4 +130,93 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :not_found
   end
+
+  test "edit_discontinued_reason shows reason form" do
+    usage_log = create_discontinued_usage_log
+
+    get edit_discontinued_reason_usage_log_path(usage_log)
+
+    assert_response :success
+    assert_select "textarea[name='usage_log[discontinued_reason]']"
+    assert_select "a[href='#{usage_log_path(usage_log)}']", text: "戻る"
+  end
+
+  test "show has discontinued reason edit link" do
+    usage_log = create_discontinued_usage_log
+
+    get usage_log_path(usage_log)
+
+    assert_response :success
+    assert_select "a[href='#{edit_discontinued_reason_usage_log_path(usage_log)}']", text: "理由を編集"
+  end
+
+  test "update_discontinued_reason adds reason" do
+    usage_log = create_discontinued_usage_log
+
+    patch update_discontinued_reason_usage_log_path(usage_log), params: {
+      usage_log: {
+        discontinued_reason: "香りが苦手だった"
+      }
+    }
+
+    assert_redirected_to usage_log_path(usage_log)
+    assert_equal "香りが苦手だった", usage_log.reload.discontinued_reason
+  end
+
+  test "update_discontinued_reason changes reason" do
+    usage_log = create_discontinued_usage_log(discontinued_reason: "肌に合わなかった")
+
+    patch update_discontinued_reason_usage_log_path(usage_log), params: {
+      usage_log: {
+        discontinued_reason: "香りが苦手だった"
+      }
+    }
+
+    assert_redirected_to usage_log_path(usage_log)
+    assert_equal "香りが苦手だった", usage_log.reload.discontinued_reason
+  end
+
+  test "update_discontinued_reason clears reason" do
+    usage_log = create_discontinued_usage_log(discontinued_reason: "肌に合わなかった")
+
+    patch update_discontinued_reason_usage_log_path(usage_log), params: {
+      usage_log: {
+        discontinued_reason: ""
+      }
+    }
+
+    assert_redirected_to usage_log_path(usage_log)
+    assert_nil usage_log.reload.discontinued_reason
+  end
+
+  test "used up usage log cannot edit discontinued reason" do
+    get edit_discontinued_reason_usage_log_path(@usage_log)
+
+    assert_response :not_found
+  end
+
+  test "other user's usage log cannot edit discontinued reason" do
+    other_user = users(:two)
+    other_item = other_user.items.create!(name: "他のアイテム", stock_quantity: 1)
+    other_item.start_using!(other_user, Time.zone.local(2026, 5, 10))
+    other_item.discontinue_using!(Time.zone.local(2026, 5, 12))
+    other_usage_log = other_item.usage_logs.finished.first
+
+    get edit_discontinued_reason_usage_log_path(other_usage_log)
+
+    assert_response :not_found
+  end
+
+  private
+
+  def create_discontinued_usage_log(discontinued_reason: nil)
+    item = items(:two)
+    item.update!(stock_quantity: 1)
+    item.start_using!(@user, Time.zone.local(2026, 5, 10))
+    item.discontinue_using!(
+      Time.zone.local(2026, 5, 12),
+      discontinued_reason: discontinued_reason
+    )
+    item.usage_logs.finished.discontinued.first
+  end
 end


### PR DESCRIPTION
## 概要
Closes #149

使用中止時に理由を入力しなかった場合でも、使用履歴詳細からあとで理由を追加・編集できるようにしました。

## 変更内容
- 使用中止理由の編集・更新ルートを追加
- 使用中止理由編集画面を追加
- 使用履歴詳細に「理由を編集」リンクを追加
- 使用中止理由の追加・変更・削除に対応
- 空欄の理由を `nil` に統一
- 使用中止履歴だけを編集対象にするアクセス制御を追加

## できること
- 理由が未入力の履歴へ後から理由を追加
- 入力済みの理由を変更
- 理由を空欄に戻して削除
- 保存後に使用履歴詳細へ戻る

## アクセス制御
- 使い切り履歴では使用中止理由を編集できない
- 他ユーザーの使用履歴は編集できない
- 使用中止理由以外の項目は更新できない