### PR TITLE
fix: UUID化前のセッションCookieを無効化

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,1 @@
+Rails.application.config.session_store :cookie_store, key: "_app_uuid_session"


### PR DESCRIPTION
## 概要

Closes #140

UUID化前のログインセッションが残っている場合に、トップページでUUID変換エラーが発生する問題を修正しました。

## 原因

旧セッションCookieに連番形式のユーザーIDが残っており、UUID化後の `users.id` に対して検索されていました。

## 変更内容

- セッションCookie名を `_app_uuid_session` に変更
- UUID化前に発行されたCookieを無効化

## 影響

既存ユーザーは一度ログアウト状態になり、再ログインが必要です。

## 確認内容

- [x] 新しいCookie名が設定されている
- [x] 既存テストが成功する
- [ ] マージ後、旧Cookieが残ったブラウザでトップページを確認
- [ ] マージ後、再ログインできることを確認