### PR TITLE
ci: GitHub ActionsでRailsテストを自動実行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: user
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: app_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U user -d app_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      RAILS_ENV: test
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2.2
+          bundler-cache: true
+
+      - name: Prepare database
+        run: bin/rails db:prepare
+
+      - name: Run tests
+        run: bin/rails test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
 
     env:
       RAILS_ENV: test
+      POSTGRES_HOST: localhost
       POSTGRES_USER: user
       POSTGRES_PASSWORD: password
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,7 +18,7 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  host: db
+  host: <%= ENV.fetch("POSTGRES_HOST") { "db" } %>
   username: <%= ENV.fetch("POSTGRES_USER") { "user" } %>
   password: <%= ENV.fetch("POSTGRES_PASSWORD") { "password" } %>
 


### PR DESCRIPTION
## 概要

Closes #78

PR作成時にRailsの自動テストを実行できるよう、GitHub Actionsのworkflowを追加しました。

## 変更内容

- `.github/workflows/ci.yml` を追加
- PR作成時にCIを実行
- `main` へのpush時にもCIを実行
- GitHub Actions上でPostgreSQLを起動
- Ruby 3.2.2 と Bundlerをセットアップ
- `bin/rails db:prepare` でテストDBを準備
- `bin/rails test` を実行
- CI環境ではDB接続先を `localhost` に切り替えるよう設定

## 補足

ローカルDockerではDBホスト名として `db` を使い、GitHub Actionsでは `POSTGRES_HOST=localhost` を使うようにしました。

## 対象外

- RSpecの導入
- RuboCopの導入
- デプロイ自動化

## 確認内容

- [x] YAML構文確認
- [x] ローカルで既存テスト成功
- [x] PR上でGitHub Actionsが起動することを確認
- [x] GitHub Actions上でテスト成功を確認