### PR TITLE
アイテム名検索機能を追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,6 +4,8 @@ class ItemsController < ApplicationController
 
   def index
     @items = current_user.items.visible.includes(:category).order(created_at: :desc)
+    @search_query = params[:q].to_s.strip
+    @items = @items.by_name(@search_query)
 
     if params[:stock] == "available"
       @page_title = "ストックBOX"

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -18,6 +18,11 @@ class Item < ApplicationRecord
   # スコープ
   scope :visible, -> { where(archived: false) }
   scope :archived, -> { where(archived: true) }
+  scope :by_name, ->(query) {
+    return all if query.blank?
+
+    where("name ILIKE ?", "%#{sanitize_sql_like(query)}%")
+  }
 
   def current_usage_log
     usage_logs.in_use.order(started_at: :desc).first

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -5,6 +5,32 @@
     <%= link_to "新規登録", new_item_path, class: "btn-primary shrink-0" %>
   </div>
 
+  <%= form_with url: items_path,
+                method: :get,
+                local: true,
+                class: "mb-6 rounded-lg bg-slate-50 p-3" do %>
+    <%= hidden_field_tag :stock, params[:stock] if params[:stock].present? %>
+
+    <div class="flex gap-2">
+      <div class="flex-1">
+        <%= search_field_tag :q,
+                             @search_query,
+                             placeholder: "アイテム名で検索",
+                             class: "form-input h-10" %>
+      </div>
+
+      <%= submit_tag "検索", name: nil, class: "btn-primary h-10 shrink-0 cursor-pointer" %>
+    </div>
+
+    <% if @search_query.present? %>
+      <div class="mt-2 text-right">
+        <%= link_to "リセット",
+                    items_path(stock: params[:stock].presence),
+                    class: "text-sm font-medium text-slate-600 transition hover:text-slate-900" %>
+      </div>
+    <% end %>
+  <% end %>
+
   <% if @items.any? %>
     <div class="grid gap-4 lg:grid-cols-2">
       <% @items.each do |item| %>
@@ -98,9 +124,17 @@
       <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"></path>
       </svg>
-      <p class="mt-4 text-lg">アイテムがありません</p>
-      <p class="mt-2 text-sm">まずは使い切りを記録したいアイテムを登録しましょう。</p>
-      <%= link_to "アイテムを登録する", new_item_path, class: "btn-primary mt-5" %>
+      <% if @search_query.present? %>
+        <p class="mt-4 text-lg">条件に合うアイテムがありません</p>
+        <p class="mt-2 text-sm">別のアイテム名で検索してください。</p>
+        <%= link_to "検索条件をリセット",
+                    items_path(stock: params[:stock].presence),
+                    class: "btn-secondary mt-5" %>
+      <% else %>
+        <p class="mt-4 text-lg">アイテムがありません</p>
+        <p class="mt-2 text-sm">まずは使い切りを記録したいアイテムを登録しましょう。</p>
+        <%= link_to "アイテムを登録する", new_item_path, class: "btn-primary mt-5" %>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -6,6 +6,36 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     sign_in @user
   end
 
+  test "index searches current user's items by partial name" do
+    other_user_item = users(:two).items.create!(
+      name: "化粧水 他ユーザー",
+      stock_quantity: 1
+    )
+
+    get items_path, params: { q: "化粧" }
+
+    assert_response :success
+    assert_includes response.body, items(:one).name
+    assert_no_match items(:two).name, response.body
+    assert_no_match other_user_item.name, response.body
+  end
+
+  test "index keeps search query and shows reset link" do
+    get items_path, params: { q: "化粧" }
+
+    assert_response :success
+    assert_select "input[name='q'][value='化粧']"
+    assert_select "a[href='#{items_path}']", text: "リセット"
+  end
+
+  test "index shows a message when search has no results" do
+    get items_path, params: { q: "存在しないアイテム" }
+
+    assert_response :success
+    assert_includes response.body, "条件に合うアイテムがありません"
+    assert_select "a[href='#{items_path}']", text: "検索条件をリセット"
+  end
+
   test "start_using creates usage log and redirects to in-use page" do
     item = items(:one)
 

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -3,6 +3,14 @@ require "test_helper"
 class ItemTest < ActiveSupport::TestCase
   include ActionDispatch::TestProcess::FixtureFile
 
+  test "by_name returns items whose names partially match" do
+    assert_equal [items(:one)], Item.by_name("化粧").to_a
+  end
+
+  test "by_name returns all items when query is blank" do
+    assert_equal Item.order(:id).to_a, Item.by_name(" ").order(:id).to_a
+  end
+
   test "start_using! creates an in-use usage log and decreases stock" do
     item = items(:one)
 


### PR DESCRIPTION
## 概要
アイテム一覧に、アイテム名による部分一致検索を追加しました。

Closes #60

## 変更内容
- アイテム名検索用のフォームを追加
- `Item.by_name`スコープで部分一致検索を実装
- ログイン中ユーザーのアイテムのみを検索対象に設定
- 検索条件を入力欄に保持
- 検索条件のリセット導線を追加
- 検索結果が0件の場合の表示を追加
- モデル・controllerテストを追加

## 確認内容
- アイテム名の一部で検索できる
- 他ユーザーのアイテムが表示されない
- 検索条件が入力欄に保持される
- 検索条件をリセットできる
- 0件時に専用メッセージが表示される