### PR TITLE
各履歴一覧にアイテム名検索を追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,8 +19,10 @@ class ItemsController < ApplicationController
 
   def in_use
     @page_title = "使用中アイテム"
+    @search_query = params[:q].to_s.strip
     @usage_logs = current_user.usage_logs
                               .in_use
+                              .by_item_name(@search_query)
                               .includes(:item)
                               .order(started_at: :desc)
                               .page(params[:page])
@@ -28,9 +30,11 @@ class ItemsController < ApplicationController
 
   def used_up
     @page_title = "使い切り履歴"
+    @search_query = params[:q].to_s.strip
     finished_usage_logs = current_user.usage_logs
                                       .finished
                                       .used_up
+                                      .by_item_name(@search_query)
                                       .includes(:item)
                                       .order(finished_at: :desc)
     @usage_logs = Kaminari.paginate_array(
@@ -45,9 +49,11 @@ class ItemsController < ApplicationController
 
   def discontinued
     @page_title = "使用中止リスト"
+    @search_query = params[:q].to_s.strip
     @usage_logs = current_user.usage_logs
                               .finished
                               .discontinued
+                              .by_item_name(@search_query)
                               .includes(:item)
                               .order(finished_at: :desc)
                               .page(params[:page])

--- a/app/controllers/usage_logs_controller.rb
+++ b/app/controllers/usage_logs_controller.rb
@@ -14,9 +14,11 @@ class UsageLogsController < ApplicationController
 
   def reviews
     @page_title = "評価・レビュー履歴"
+    @search_query = params[:q].to_s.strip
     @usage_logs = current_user.usage_logs
                               .finished
                               .rated
+                              .by_item_name(@search_query)
                               .includes(:item)
                               .order(finished_at: :desc)
                               .page(params[:page])

--- a/app/models/usage_log.rb
+++ b/app/models/usage_log.rb
@@ -12,6 +12,11 @@ class UsageLog < ApplicationRecord
   scope :in_use, -> { where(finished_at: nil) }
   scope :finished, -> { where.not(finished_at: nil) }
   scope :rated, -> { where.not(rating: nil) }
+  scope :by_item_name, ->(query) {
+    return all if query.blank?
+
+    joins(:item).where("items.name ILIKE ?", "%#{sanitize_sql_like(query)}%")
+  }
 
   validates :started_at, presence: true
   validates :rating, inclusion: { in: 1..5 }, allow_nil: true

--- a/app/views/items/discontinued.html.erb
+++ b/app/views/items/discontinued.html.erb
@@ -3,6 +3,30 @@
     <h1 class="brand-font text-2xl font-bold text-slate-900"><%= @page_title %></h1>
   </div>
 
+  <%= form_with url: discontinued_items_path,
+                method: :get,
+                local: true,
+                class: "mb-6 rounded-lg bg-slate-50 p-3" do %>
+    <div class="flex gap-2">
+      <div class="flex-1">
+        <%= search_field_tag :q,
+                             @search_query,
+                             placeholder: "アイテム名で検索",
+                             class: "form-input h-10" %>
+      </div>
+
+      <%= submit_tag "検索", name: nil, class: "btn-primary h-10 shrink-0 cursor-pointer" %>
+    </div>
+
+    <% if @search_query.present? %>
+      <div class="mt-2 text-right">
+        <%= link_to "リセット",
+                    discontinued_items_path,
+                    class: "text-sm font-medium text-slate-600 transition hover:text-slate-900" %>
+      </div>
+    <% end %>
+  <% end %>
+
   <% if @usage_logs.any? %>
     <div class="grid gap-4 lg:grid-cols-2">
       <% @usage_logs.each do |usage_log| %>
@@ -79,8 +103,14 @@
     </div>
   <% else %>
     <div class="ui-empty-state">
-      <p class="text-lg">使用中止したアイテムがありません</p>
-      <p class="mt-2 text-sm">肌に合わなかったものなどがここに表示されます。</p>
+      <% if @search_query.present? %>
+        <p class="text-lg">条件に合う使用中止履歴がありません</p>
+        <p class="mt-2 text-sm">別のアイテム名で検索してください。</p>
+        <%= link_to "検索条件をリセット", discontinued_items_path, class: "btn-secondary mt-5" %>
+      <% else %>
+        <p class="text-lg">使用中止したアイテムがありません</p>
+        <p class="mt-2 text-sm">肌に合わなかったものなどがここに表示されます。</p>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/app/views/items/in_use.html.erb
+++ b/app/views/items/in_use.html.erb
@@ -3,6 +3,30 @@
     <h1 class="brand-font text-2xl font-bold text-slate-900"><%= @page_title %></h1>
   </div>
 
+  <%= form_with url: in_use_items_path,
+                method: :get,
+                local: true,
+                class: "mb-6 rounded-lg bg-slate-50 p-3" do %>
+    <div class="flex gap-2">
+      <div class="flex-1">
+        <%= search_field_tag :q,
+                             @search_query,
+                             placeholder: "アイテム名で検索",
+                             class: "form-input h-10" %>
+      </div>
+
+      <%= submit_tag "検索", name: nil, class: "btn-primary h-10 shrink-0 cursor-pointer" %>
+    </div>
+
+    <% if @search_query.present? %>
+      <div class="mt-2 text-right">
+        <%= link_to "リセット",
+                    in_use_items_path,
+                    class: "text-sm font-medium text-slate-600 transition hover:text-slate-900" %>
+      </div>
+    <% end %>
+  <% end %>
+
   <% if @usage_logs.any? %>
     <div class="grid gap-4 lg:grid-cols-2">
       <% @usage_logs.each do |usage_log| %>
@@ -67,8 +91,14 @@
     </div>
   <% else %>
     <div class="ui-empty-state">
-      <p class="text-lg">使用中のアイテムがありません</p>
-      <p class="mt-2 text-sm">使い始めたアイテムがここに表示されます。</p>
+      <% if @search_query.present? %>
+        <p class="text-lg">条件に合う使用中アイテムがありません</p>
+        <p class="mt-2 text-sm">別のアイテム名で検索してください。</p>
+        <%= link_to "検索条件をリセット", in_use_items_path, class: "btn-secondary mt-5" %>
+      <% else %>
+        <p class="text-lg">使用中のアイテムがありません</p>
+        <p class="mt-2 text-sm">使い始めたアイテムがここに表示されます。</p>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/app/views/items/used_up.html.erb
+++ b/app/views/items/used_up.html.erb
@@ -3,6 +3,30 @@
     <h1 class="brand-font text-2xl font-bold text-slate-900"><%= @page_title %></h1>
   </div>
 
+  <%= form_with url: used_up_items_path,
+                method: :get,
+                local: true,
+                class: "mb-6 rounded-lg bg-slate-50 p-3" do %>
+    <div class="flex gap-2">
+      <div class="flex-1">
+        <%= search_field_tag :q,
+                             @search_query,
+                             placeholder: "アイテム名で検索",
+                             class: "form-input h-10" %>
+      </div>
+
+      <%= submit_tag "検索", name: nil, class: "btn-primary h-10 shrink-0 cursor-pointer" %>
+    </div>
+
+    <% if @search_query.present? %>
+      <div class="mt-2 text-right">
+        <%= link_to "リセット",
+                    used_up_items_path,
+                    class: "text-sm font-medium text-slate-600 transition hover:text-slate-900" %>
+      </div>
+    <% end %>
+  <% end %>
+
   <% if @usage_logs.any? %>
     <div class="grid gap-4 lg:grid-cols-2">
       <% @usage_logs.each do |usage_log| %>
@@ -76,8 +100,14 @@
     </div>
   <% else %>
     <div class="ui-empty-state">
-      <p class="text-lg">使い切り履歴がありません</p>
-      <p class="mt-2 text-sm">使い切ったアイテムがここに表示されます。</p>
+      <% if @search_query.present? %>
+        <p class="text-lg">条件に合う使い切り履歴がありません</p>
+        <p class="mt-2 text-sm">別のアイテム名で検索してください。</p>
+        <%= link_to "検索条件をリセット", used_up_items_path, class: "btn-secondary mt-5" %>
+      <% else %>
+        <p class="text-lg">使い切り履歴がありません</p>
+        <p class="mt-2 text-sm">使い切ったアイテムがここに表示されます。</p>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/app/views/usage_logs/reviews.html.erb
+++ b/app/views/usage_logs/reviews.html.erb
@@ -3,6 +3,30 @@
     <h1 class="brand-font text-2xl font-bold text-slate-900"><%= @page_title %></h1>
   </div>
 
+  <%= form_with url: reviews_usage_logs_path,
+                method: :get,
+                local: true,
+                class: "mb-6 rounded-lg bg-slate-50 p-3" do %>
+    <div class="flex gap-2">
+      <div class="flex-1">
+        <%= search_field_tag :q,
+                             @search_query,
+                             placeholder: "アイテム名で検索",
+                             class: "form-input h-10" %>
+      </div>
+
+      <%= submit_tag "検索", name: nil, class: "btn-primary h-10 shrink-0 cursor-pointer" %>
+    </div>
+
+    <% if @search_query.present? %>
+      <div class="mt-2 text-right">
+        <%= link_to "リセット",
+                    reviews_usage_logs_path,
+                    class: "text-sm font-medium text-slate-600 transition hover:text-slate-900" %>
+      </div>
+    <% end %>
+  <% end %>
+
   <% if @usage_logs.any? %>
     <div class="grid gap-4 lg:grid-cols-2">
       <% @usage_logs.each do |usage_log| %>
@@ -67,8 +91,14 @@
     </div>
   <% else %>
     <div class="ui-empty-state">
-      <p class="text-lg">評価・レビュー履歴がありません</p>
-      <p class="mt-2 text-sm">評価を残したアイテムがここに表示されます。</p>
+      <% if @search_query.present? %>
+        <p class="text-lg">条件に合う評価・レビュー履歴がありません</p>
+        <p class="mt-2 text-sm">別のアイテム名で検索してください。</p>
+        <%= link_to "検索条件をリセット", reviews_usage_logs_path, class: "btn-secondary mt-5" %>
+      <% else %>
+        <p class="text-lg">評価・レビュー履歴がありません</p>
+        <p class="mt-2 text-sm">評価を残したアイテムがここに表示されます。</p>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -167,6 +167,30 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{discontinue_using_form_item_path(item)}']", text: "使用を中止する"
   end
 
+  test "in_use page searches current user's usage logs by item name" do
+    matching_item = items(:one)
+    matching_item.start_using!(@user, Time.zone.local(2026, 5, 10))
+    other_item = items(:two)
+    other_item.update!(stock_quantity: 1)
+    other_item.start_using!(@user, Time.zone.local(2026, 5, 11))
+
+    get in_use_items_path, params: { q: "化粧" }
+
+    assert_response :success
+    assert_includes response.body, matching_item.name
+    assert_no_match other_item.name, response.body
+    assert_select "input[name='q'][value='化粧']"
+    assert_select "a[href='#{in_use_items_path}']", text: "リセット"
+  end
+
+  test "in_use page shows a message when search has no results" do
+    get in_use_items_path, params: { q: "存在しないアイテム" }
+
+    assert_response :success
+    assert_includes response.body, "条件に合う使用中アイテムがありません"
+    assert_select "a[href='#{in_use_items_path}']", text: "検索条件をリセット"
+  end
+
   test "used_up page shows used up count" do
     item = items(:one)
     item.start_using!(@user, Time.zone.local(2026, 5, 10))
@@ -242,6 +266,48 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "article.ui-card", count: 1
   end
 
+  test "discontinued page searches discontinued logs by item name" do
+    matching_item = items(:one)
+    matching_item.start_using!(@user, Time.zone.local(2026, 5, 10))
+    matching_item.discontinue_using!(Time.zone.local(2026, 5, 12))
+    other_item = items(:two)
+    other_item.update!(stock_quantity: 1)
+    other_item.start_using!(@user, Time.zone.local(2026, 5, 11))
+    other_item.discontinue_using!(Time.zone.local(2026, 5, 13))
+
+    get discontinued_items_path, params: { q: "化粧" }
+
+    assert_response :success
+    assert_includes response.body, matching_item.name
+    assert_no_match other_item.name, response.body
+    assert_select "input[name='q'][value='化粧']"
+    assert_select "a[href='#{discontinued_items_path}']", text: "リセット"
+  end
+
+  test "discontinued page shows a message when search has no results" do
+    get discontinued_items_path, params: { q: "存在しないアイテム" }
+
+    assert_response :success
+    assert_includes response.body, "条件に合う使用中止履歴がありません"
+    assert_select "a[href='#{discontinued_items_path}']", text: "検索条件をリセット"
+  end
+
+  test "discontinued page keeps search query in pagination links" do
+    11.times do |number|
+      item = @user.items.create!(
+        name: "検索対象#{number}",
+        stock_quantity: 1
+      )
+      item.start_using!(@user, Time.zone.local(2026, 5, 10))
+      item.discontinue_using!(Time.zone.local(2026, 5, 12))
+    end
+
+    get discontinued_items_path, params: { q: "検索対象" }
+
+    assert_response :success
+    assert_select "a[href='#{discontinued_items_path(page: 2, q: "検索対象")}']"
+  end
+
   test "used_up page shows one card per item with used up count" do
     item = items(:one)
     item.start_using!(@user, Time.zone.local(2026, 5, 10))
@@ -255,6 +321,48 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "article.ui-card", count: 1
     assert_includes response.body, "2回"
+  end
+
+  test "used_up page searches used up logs by item name" do
+    matching_item = items(:one)
+    matching_item.start_using!(@user, Time.zone.local(2026, 5, 10))
+    matching_item.finish_using!(Time.zone.local(2026, 5, 12))
+    other_item = items(:two)
+    other_item.update!(stock_quantity: 1)
+    other_item.start_using!(@user, Time.zone.local(2026, 5, 11))
+    other_item.finish_using!(Time.zone.local(2026, 5, 13))
+
+    get used_up_items_path, params: { q: "化粧" }
+
+    assert_response :success
+    assert_includes response.body, matching_item.name
+    assert_no_match other_item.name, response.body
+    assert_select "input[name='q'][value='化粧']"
+    assert_select "a[href='#{used_up_items_path}']", text: "リセット"
+  end
+
+  test "used_up page shows a message when search has no results" do
+    get used_up_items_path, params: { q: "存在しないアイテム" }
+
+    assert_response :success
+    assert_includes response.body, "条件に合う使い切り履歴がありません"
+    assert_select "a[href='#{used_up_items_path}']", text: "検索条件をリセット"
+  end
+
+  test "used_up page keeps search query in pagination links" do
+    11.times do |number|
+      item = @user.items.create!(
+        name: "検索対象#{number}",
+        stock_quantity: 1
+      )
+      item.start_using!(@user, Time.zone.local(2026, 5, 10))
+      item.finish_using!(Time.zone.local(2026, 5, 12))
+    end
+
+    get used_up_items_path, params: { q: "検索対象" }
+
+    assert_response :success
+    assert_select "a[href='#{used_up_items_path(page: 2, q: "検索対象")}']"
   end
 
   test "destroy_image removes attached image and redirects to edit page" do

--- a/test/controllers/usage_logs_controller_test.rb
+++ b/test/controllers/usage_logs_controller_test.rb
@@ -74,6 +74,34 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
     assert_no_match "他ユーザー", response.body
   end
 
+  test "reviews searches rated usage logs by item name" do
+    @usage_log.update!(rating: 4, review: "また使いたい")
+    other_item = items(:two)
+    other_item.update!(stock_quantity: 1)
+    other_item.start_using!(@user, Time.zone.local(2026, 5, 11))
+    other_item.finish_using!(
+      Time.zone.local(2026, 5, 13),
+      rating: 5,
+      review: "しっとりした"
+    )
+
+    get reviews_usage_logs_path, params: { q: "化粧" }
+
+    assert_response :success
+    assert_includes response.body, @item.name
+    assert_no_match other_item.name, response.body
+    assert_select "input[name='q'][value='化粧']"
+    assert_select "a[href='#{reviews_usage_logs_path}']", text: "リセット"
+  end
+
+  test "reviews shows a message when search has no results" do
+    get reviews_usage_logs_path, params: { q: "存在しないアイテム" }
+
+    assert_response :success
+    assert_includes response.body, "条件に合う評価・レビュー履歴がありません"
+    assert_select "a[href='#{reviews_usage_logs_path}']", text: "検索条件をリセット"
+  end
+
   test "header links to reviews page" do
     get reviews_usage_logs_path
 

--- a/test/models/usage_log_test.rb
+++ b/test/models/usage_log_test.rb
@@ -6,6 +6,29 @@ class UsageLogTest < ActiveSupport::TestCase
     @item = items(:one)
   end
 
+  test "by_item_name returns usage logs whose item names partially match" do
+    matching_log = @item.usage_logs.create!(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 10)
+    )
+    other_log = items(:two).usage_logs.create!(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 11)
+    )
+
+    assert_equal [matching_log], UsageLog.by_item_name("化粧").to_a
+    assert_not_includes UsageLog.by_item_name("化粧"), other_log
+  end
+
+  test "by_item_name returns all usage logs when query is blank" do
+    @item.usage_logs.create!(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 10)
+    )
+
+    assert_equal UsageLog.order(:id).to_a, UsageLog.by_item_name(" ").order(:id).to_a
+  end
+
   test "rated returns usage logs with rating" do
     rated_log = @item.usage_logs.create!(
       user: @user,


### PR DESCRIPTION
## 概要
使用中・各履歴一覧に、関連するアイテム名による部分一致検索を追加した。

Closes #158

## 変更内容
- 使用中アイテムに検索機能を追加
- 使い切り履歴に検索機能を追加
- 使用中止リストに検索機能を追加
- 評価・レビュー履歴に検索機能を追加
- `UsageLog.by_item_name`スコープを追加
- 検索条件の保持・リセットを追加
- 検索結果が0件の場合の表示を追加
- ページネーション時の検索条件を保持
- モデル・controllerテストを追加

## 確認内容
- アイテム名の部分一致検索ができる
- ログイン中ユーザーの履歴だけが表示される
- 各一覧固有の状態条件が維持される
- 検索語が入力欄とページリンクに保持される
- 検索条件をリセットできる
- 0件時に専用メッセージが表示される
