### PR TITLE
カテゴリタグでアイテム一覧を絞り込めるようにする

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,7 +5,10 @@ class ItemsController < ApplicationController
   def index
     @items = current_user.items.visible.includes(:category).order(created_at: :desc)
     @search_query = params[:q].to_s.strip
+    @selected_category_id = params[:category_id].to_s
+    @categories = current_user.categories.order(:name)
     @items = @items.by_name(@search_query)
+                   .by_category(@selected_category_id)
 
     if params[:stock] == "available"
       @page_title = "ストックBOX"

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -23,6 +23,12 @@ class Item < ApplicationRecord
 
     where("name ILIKE ?", "%#{sanitize_sql_like(query)}%")
   }
+  scope :by_category, ->(category_id) {
+    return all if category_id.blank?
+    return where(category_id: nil) if category_id == "uncategorized"
+
+    where(category_id: category_id)
+  }
 
   def current_usage_log
     usage_logs.in_use.order(started_at: :desc).first

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -5,11 +5,36 @@
     <%= link_to "新規登録", new_item_path, class: "btn-primary shrink-0" %>
   </div>
 
+  <div class="mb-4 flex flex-wrap gap-2">
+    <%= link_to "すべて",
+                items_path(q: @search_query.presence, stock: params[:stock].presence),
+                class: @selected_category_id.blank? ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
+
+    <% @categories.each do |category| %>
+      <%= link_to category.name,
+                  items_path(
+                    q: @search_query.presence,
+                    stock: params[:stock].presence,
+                    category_id: category.id
+                  ),
+                  class: @selected_category_id == category.id.to_s ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
+    <% end %>
+
+    <%= link_to "未分類",
+                items_path(
+                  q: @search_query.presence,
+                  stock: params[:stock].presence,
+                  category_id: "uncategorized"
+                ),
+                class: @selected_category_id == "uncategorized" ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
+  </div>
+
   <%= form_with url: items_path,
                 method: :get,
                 local: true,
                 class: "mb-6 rounded-lg bg-slate-50 p-3" do %>
     <%= hidden_field_tag :stock, params[:stock] if params[:stock].present? %>
+    <%= hidden_field_tag :category_id, @selected_category_id if @selected_category_id.present? %>
 
     <div class="flex gap-2">
       <div class="flex-1">
@@ -22,7 +47,7 @@
       <%= submit_tag "検索", name: nil, class: "btn-primary h-10 shrink-0 cursor-pointer" %>
     </div>
 
-    <% if @search_query.present? %>
+    <% if @search_query.present? || @selected_category_id.present? %>
       <div class="mt-2 text-right">
         <%= link_to "リセット",
                     items_path(stock: params[:stock].presence),
@@ -124,9 +149,9 @@
       <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"></path>
       </svg>
-      <% if @search_query.present? %>
+      <% if @search_query.present? || @selected_category_id.present? %>
         <p class="mt-4 text-lg">条件に合うアイテムがありません</p>
-        <p class="mt-2 text-sm">別のアイテム名で検索してください。</p>
+        <p class="mt-2 text-sm">検索条件を変更して、もう一度お試しください。</p>
         <%= link_to "検索条件をリセット",
                     items_path(stock: params[:stock].presence),
                     class: "btn-secondary mt-5" %>

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -36,6 +36,140 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{items_path}']", text: "検索条件をリセット"
   end
 
+  test "index filters items by category" do
+    items(:one).update!(category: categories(:hair_care))
+    items(:two).update!(category: categories(:skin_care))
+
+    get items_path, params: { category_id: categories(:hair_care).id }
+
+    assert_response :success
+    assert_includes response.body, items(:one).name
+    assert_no_match items(:two).name, response.body
+  end
+
+  test "index combines name and category filters" do
+    items(:one).update!(category: categories(:hair_care))
+    items(:two).update!(category: categories(:hair_care))
+
+    get items_path, params: {
+      q: "化粧",
+      category_id: categories(:hair_care).id
+    }
+
+    assert_response :success
+    assert_includes response.body, items(:one).name
+    assert_no_match items(:two).name, response.body
+  end
+
+  test "index filters uncategorized items" do
+    items(:one).update!(category: categories(:hair_care))
+
+    get items_path, params: { category_id: "uncategorized" }
+
+    assert_response :success
+    assert_includes response.body, items(:two).name
+    assert_no_match items(:one).name, response.body
+  end
+
+  test "index does not show another user's items for another user's category" do
+    other_user = users(:two)
+    other_category = other_user.categories.create!(name: "他ユーザーカテゴリ")
+    other_item = other_user.items.create!(
+      name: "他ユーザーアイテム",
+      stock_quantity: 1,
+      category: other_category
+    )
+
+    get items_path, params: { category_id: other_category.id }
+
+    assert_response :success
+    assert_no_match other_item.name, response.body
+  end
+
+  test "index shows current user's category tags and uncategorized tag" do
+    other_category = users(:two).categories.create!(name: "他ユーザーカテゴリ")
+
+    get items_path
+
+    assert_response :success
+    assert_select "a[href='#{items_path}']", text: "すべて"
+    assert_select "a[href='#{items_path(category_id: categories(:hair_care).id)}']",
+                  text: categories(:hair_care).name
+    assert_select "a[href='#{items_path(category_id: "uncategorized")}']", text: "未分類"
+    assert_select "a", text: other_category.name, count: 0
+  end
+
+  test "index highlights selected category tag" do
+    category = categories(:hair_care)
+
+    get items_path, params: { category_id: category.id }
+
+    assert_response :success
+    assert_select "a.bg-emerald-600[href='#{items_path(category_id: category.id)}']",
+                  text: category.name
+  end
+
+  test "index category tags keep name and stock filters" do
+    category = categories(:hair_care)
+
+    get items_path, params: { q: "化粧", stock: "available" }
+
+    assert_response :success
+    assert_select "a[href='#{items_path(q: "化粧", stock: "available", category_id: category.id)}']",
+                  text: category.name
+  end
+
+  test "index search form keeps selected category" do
+    category = categories(:hair_care)
+
+    get items_path, params: { category_id: category.id }
+
+    assert_response :success
+    assert_select "input[type='hidden'][name='category_id'][value='#{category.id}']"
+  end
+
+  test "index shows reset link when category is selected" do
+    get items_path, params: { category_id: categories(:hair_care).id }
+
+    assert_response :success
+    assert_select "a[href='#{items_path}']", text: "リセット"
+  end
+
+  test "index shows a message when category filter has no results" do
+    empty_category = @user.categories.create!(name: "アイテムなし")
+
+    get items_path, params: { category_id: empty_category.id }
+
+    assert_response :success
+    assert_includes response.body, "条件に合うアイテムがありません"
+    assert_select "a[href='#{items_path}']", text: "検索条件をリセット"
+  end
+
+  test "index keeps search category and stock filters in pagination links" do
+    category = categories(:hair_care)
+    11.times do |number|
+      @user.items.create!(
+        name: "検索対象#{number}",
+        stock_quantity: 1,
+        category: category
+      )
+    end
+
+    get items_path, params: {
+      q: "検索対象",
+      category_id: category.id,
+      stock: "available"
+    }
+
+    assert_response :success
+    assert_select "a[href='#{items_path(
+      page: 2,
+      q: "検索対象",
+      category_id: category.id,
+      stock: "available"
+    )}']"
+  end
+
   test "start_using creates usage log and redirects to in-use page" do
     item = items(:one)
 

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -11,6 +11,23 @@ class ItemTest < ActiveSupport::TestCase
     assert_equal Item.order(:id).to_a, Item.by_name(" ").order(:id).to_a
   end
 
+  test "by_category returns items in the selected category" do
+    item = items(:one)
+    item.update!(category: categories(:hair_care))
+
+    assert_equal [item], Item.by_category(categories(:hair_care).id.to_s).to_a
+  end
+
+  test "by_category returns uncategorized items" do
+    items(:one).update!(category: categories(:hair_care))
+
+    assert_equal [items(:two)], Item.by_category("uncategorized").to_a
+  end
+
+  test "by_category returns all items when category is blank" do
+    assert_equal Item.order(:id).to_a, Item.by_category("").order(:id).to_a
+  end
+
   test "start_using! creates an in-use usage log and decreases stock" do
     item = items(:one)
 


### PR DESCRIPTION
## 概要
アイテムDBとストックBOXに、タグ形式のカテゴリ絞り込みを追加しました。

Closes #106

## 変更内容
- 「すべて」「各カテゴリ」「未分類」のタグを追加
- 選択中のカテゴリタグを強調表示
- カテゴリ・未分類による絞り込みを実装
- アイテム名検索との併用に対応
- ストックBOXの在庫条件を維持
- 検索フォーム送信時にカテゴリ条件を維持
- ページネーション時に検索・カテゴリ・在庫条件を維持
- 条件に一致しない場合の表示とリセット導線を追加
- モデル・controllerテストを追加

## 確認内容
- ログイン中ユーザーのカテゴリだけが表示される
- 他ユーザーのアイテムやカテゴリが表示されない
- 通常カテゴリ・未分類・すべてを切り替えられる
- 名前検索とカテゴリを同時に利用できる
- ストックBOXでもカテゴリを切り替えられる
- ページ移動後も条件が維持される