### PR TITLE
各履歴一覧にカテゴリタグ絞り込みを追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,9 +23,12 @@ class ItemsController < ApplicationController
   def in_use
     @page_title = "使用中アイテム"
     @search_query = params[:q].to_s.strip
+    @selected_category_id = params[:category_id].to_s
+    @categories = current_user.categories.order(:name)
     @usage_logs = current_user.usage_logs
                               .in_use
                               .by_item_name(@search_query)
+                              .by_item_category(@selected_category_id)
                               .includes(:item)
                               .order(started_at: :desc)
                               .page(params[:page])
@@ -34,10 +37,13 @@ class ItemsController < ApplicationController
   def used_up
     @page_title = "使い切り履歴"
     @search_query = params[:q].to_s.strip
+    @selected_category_id = params[:category_id].to_s
+    @categories = current_user.categories.order(:name)
     finished_usage_logs = current_user.usage_logs
                                       .finished
                                       .used_up
                                       .by_item_name(@search_query)
+                                      .by_item_category(@selected_category_id)
                                       .includes(:item)
                                       .order(finished_at: :desc)
     @usage_logs = Kaminari.paginate_array(
@@ -53,10 +59,13 @@ class ItemsController < ApplicationController
   def discontinued
     @page_title = "使用中止リスト"
     @search_query = params[:q].to_s.strip
+    @selected_category_id = params[:category_id].to_s
+    @categories = current_user.categories.order(:name)
     @usage_logs = current_user.usage_logs
                               .finished
                               .discontinued
                               .by_item_name(@search_query)
+                              .by_item_category(@selected_category_id)
                               .includes(:item)
                               .order(finished_at: :desc)
                               .page(params[:page])

--- a/app/controllers/usage_logs_controller.rb
+++ b/app/controllers/usage_logs_controller.rb
@@ -15,10 +15,13 @@ class UsageLogsController < ApplicationController
   def reviews
     @page_title = "評価・レビュー履歴"
     @search_query = params[:q].to_s.strip
+    @selected_category_id = params[:category_id].to_s
+    @categories = current_user.categories.order(:name)
     @usage_logs = current_user.usage_logs
                               .finished
                               .rated
                               .by_item_name(@search_query)
+                              .by_item_category(@selected_category_id)
                               .includes(:item)
                               .order(finished_at: :desc)
                               .page(params[:page])

--- a/app/models/usage_log.rb
+++ b/app/models/usage_log.rb
@@ -17,6 +17,12 @@ class UsageLog < ApplicationRecord
 
     joins(:item).where("items.name ILIKE ?", "%#{sanitize_sql_like(query)}%")
   }
+  scope :by_item_category, ->(category_id) {
+    return all if category_id.blank?
+    return joins(:item).where(items: { category_id: nil }) if category_id == "uncategorized"
+
+    joins(:item).where(items: { category_id: category_id })
+  }
 
   validates :started_at, presence: true
   validates :rating, inclusion: { in: 1..5 }, allow_nil: true

--- a/app/views/items/discontinued.html.erb
+++ b/app/views/items/discontinued.html.erb
@@ -3,10 +3,28 @@
     <h1 class="brand-font text-2xl font-bold text-slate-900"><%= @page_title %></h1>
   </div>
 
+  <div class="mb-4 flex flex-wrap gap-2">
+    <%= link_to "すべて",
+                discontinued_items_path(q: @search_query.presence),
+                class: @selected_category_id.blank? ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
+
+    <% @categories.each do |category| %>
+      <%= link_to category.name,
+                  discontinued_items_path(q: @search_query.presence, category_id: category.id),
+                  class: @selected_category_id == category.id.to_s ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
+    <% end %>
+
+    <%= link_to "未分類",
+                discontinued_items_path(q: @search_query.presence, category_id: "uncategorized"),
+                class: @selected_category_id == "uncategorized" ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
+  </div>
+
   <%= form_with url: discontinued_items_path,
                 method: :get,
                 local: true,
                 class: "mb-6 rounded-lg bg-slate-50 p-3" do %>
+    <%= hidden_field_tag :category_id, @selected_category_id if @selected_category_id.present? %>
+
     <div class="flex gap-2">
       <div class="flex-1">
         <%= search_field_tag :q,
@@ -18,7 +36,7 @@
       <%= submit_tag "検索", name: nil, class: "btn-primary h-10 shrink-0 cursor-pointer" %>
     </div>
 
-    <% if @search_query.present? %>
+    <% if @search_query.present? || @selected_category_id.present? %>
       <div class="mt-2 text-right">
         <%= link_to "リセット",
                     discontinued_items_path,
@@ -103,9 +121,9 @@
     </div>
   <% else %>
     <div class="ui-empty-state">
-      <% if @search_query.present? %>
+      <% if @search_query.present? || @selected_category_id.present? %>
         <p class="text-lg">条件に合う使用中止履歴がありません</p>
-        <p class="mt-2 text-sm">別のアイテム名で検索してください。</p>
+        <p class="mt-2 text-sm">検索条件を変更して、もう一度お試しください。</p>
         <%= link_to "検索条件をリセット", discontinued_items_path, class: "btn-secondary mt-5" %>
       <% else %>
         <p class="text-lg">使用中止したアイテムがありません</p>

--- a/app/views/items/in_use.html.erb
+++ b/app/views/items/in_use.html.erb
@@ -3,10 +3,28 @@
     <h1 class="brand-font text-2xl font-bold text-slate-900"><%= @page_title %></h1>
   </div>
 
+  <div class="mb-4 flex flex-wrap gap-2">
+    <%= link_to "すべて",
+                in_use_items_path(q: @search_query.presence),
+                class: @selected_category_id.blank? ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
+
+    <% @categories.each do |category| %>
+      <%= link_to category.name,
+                  in_use_items_path(q: @search_query.presence, category_id: category.id),
+                  class: @selected_category_id == category.id.to_s ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
+    <% end %>
+
+    <%= link_to "未分類",
+                in_use_items_path(q: @search_query.presence, category_id: "uncategorized"),
+                class: @selected_category_id == "uncategorized" ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
+  </div>
+
   <%= form_with url: in_use_items_path,
                 method: :get,
                 local: true,
                 class: "mb-6 rounded-lg bg-slate-50 p-3" do %>
+    <%= hidden_field_tag :category_id, @selected_category_id if @selected_category_id.present? %>
+
     <div class="flex gap-2">
       <div class="flex-1">
         <%= search_field_tag :q,
@@ -18,7 +36,7 @@
       <%= submit_tag "検索", name: nil, class: "btn-primary h-10 shrink-0 cursor-pointer" %>
     </div>
 
-    <% if @search_query.present? %>
+    <% if @search_query.present? || @selected_category_id.present? %>
       <div class="mt-2 text-right">
         <%= link_to "リセット",
                     in_use_items_path,
@@ -91,9 +109,9 @@
     </div>
   <% else %>
     <div class="ui-empty-state">
-      <% if @search_query.present? %>
+      <% if @search_query.present? || @selected_category_id.present? %>
         <p class="text-lg">条件に合う使用中アイテムがありません</p>
-        <p class="mt-2 text-sm">別のアイテム名で検索してください。</p>
+        <p class="mt-2 text-sm">検索条件を変更して、もう一度お試しください。</p>
         <%= link_to "検索条件をリセット", in_use_items_path, class: "btn-secondary mt-5" %>
       <% else %>
         <p class="text-lg">使用中のアイテムがありません</p>

--- a/app/views/items/used_up.html.erb
+++ b/app/views/items/used_up.html.erb
@@ -3,10 +3,28 @@
     <h1 class="brand-font text-2xl font-bold text-slate-900"><%= @page_title %></h1>
   </div>
 
+  <div class="mb-4 flex flex-wrap gap-2">
+    <%= link_to "すべて",
+                used_up_items_path(q: @search_query.presence),
+                class: @selected_category_id.blank? ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
+
+    <% @categories.each do |category| %>
+      <%= link_to category.name,
+                  used_up_items_path(q: @search_query.presence, category_id: category.id),
+                  class: @selected_category_id == category.id.to_s ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
+    <% end %>
+
+    <%= link_to "未分類",
+                used_up_items_path(q: @search_query.presence, category_id: "uncategorized"),
+                class: @selected_category_id == "uncategorized" ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
+  </div>
+
   <%= form_with url: used_up_items_path,
                 method: :get,
                 local: true,
                 class: "mb-6 rounded-lg bg-slate-50 p-3" do %>
+    <%= hidden_field_tag :category_id, @selected_category_id if @selected_category_id.present? %>
+
     <div class="flex gap-2">
       <div class="flex-1">
         <%= search_field_tag :q,
@@ -18,7 +36,7 @@
       <%= submit_tag "検索", name: nil, class: "btn-primary h-10 shrink-0 cursor-pointer" %>
     </div>
 
-    <% if @search_query.present? %>
+    <% if @search_query.present? || @selected_category_id.present? %>
       <div class="mt-2 text-right">
         <%= link_to "リセット",
                     used_up_items_path,
@@ -100,9 +118,9 @@
     </div>
   <% else %>
     <div class="ui-empty-state">
-      <% if @search_query.present? %>
+      <% if @search_query.present? || @selected_category_id.present? %>
         <p class="text-lg">条件に合う使い切り履歴がありません</p>
-        <p class="mt-2 text-sm">別のアイテム名で検索してください。</p>
+        <p class="mt-2 text-sm">検索条件を変更して、もう一度お試しください。</p>
         <%= link_to "検索条件をリセット", used_up_items_path, class: "btn-secondary mt-5" %>
       <% else %>
         <p class="text-lg">使い切り履歴がありません</p>

--- a/app/views/usage_logs/reviews.html.erb
+++ b/app/views/usage_logs/reviews.html.erb
@@ -3,10 +3,28 @@
     <h1 class="brand-font text-2xl font-bold text-slate-900"><%= @page_title %></h1>
   </div>
 
+  <div class="mb-4 flex flex-wrap gap-2">
+    <%= link_to "すべて",
+                reviews_usage_logs_path(q: @search_query.presence),
+                class: @selected_category_id.blank? ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
+
+    <% @categories.each do |category| %>
+      <%= link_to category.name,
+                  reviews_usage_logs_path(q: @search_query.presence, category_id: category.id),
+                  class: @selected_category_id == category.id.to_s ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
+    <% end %>
+
+    <%= link_to "未分類",
+                reviews_usage_logs_path(q: @search_query.presence, category_id: "uncategorized"),
+                class: @selected_category_id == "uncategorized" ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
+  </div>
+
   <%= form_with url: reviews_usage_logs_path,
                 method: :get,
                 local: true,
                 class: "mb-6 rounded-lg bg-slate-50 p-3" do %>
+    <%= hidden_field_tag :category_id, @selected_category_id if @selected_category_id.present? %>
+
     <div class="flex gap-2">
       <div class="flex-1">
         <%= search_field_tag :q,
@@ -18,7 +36,7 @@
       <%= submit_tag "検索", name: nil, class: "btn-primary h-10 shrink-0 cursor-pointer" %>
     </div>
 
-    <% if @search_query.present? %>
+    <% if @search_query.present? || @selected_category_id.present? %>
       <div class="mt-2 text-right">
         <%= link_to "リセット",
                     reviews_usage_logs_path,
@@ -91,9 +109,9 @@
     </div>
   <% else %>
     <div class="ui-empty-state">
-      <% if @search_query.present? %>
+      <% if @search_query.present? || @selected_category_id.present? %>
         <p class="text-lg">条件に合う評価・レビュー履歴がありません</p>
-        <p class="mt-2 text-sm">別のアイテム名で検索してください。</p>
+        <p class="mt-2 text-sm">検索条件を変更して、もう一度お試しください。</p>
         <%= link_to "検索条件をリセット", reviews_usage_logs_path, class: "btn-secondary mt-5" %>
       <% else %>
         <p class="text-lg">評価・レビュー履歴がありません</p>

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -325,6 +325,64 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{in_use_items_path}']", text: "検索条件をリセット"
   end
 
+  test "in_use page filters usage logs by item category" do
+    matching_item = items(:one)
+    matching_item.update!(category: categories(:hair_care))
+    matching_item.start_using!(@user, Time.zone.local(2026, 5, 10))
+    other_item = items(:two)
+    other_item.update!(stock_quantity: 1, category: categories(:skin_care))
+    other_item.start_using!(@user, Time.zone.local(2026, 5, 11))
+
+    get in_use_items_path, params: { category_id: categories(:hair_care).id }
+
+    assert_response :success
+    assert_includes response.body, matching_item.name
+    assert_no_match other_item.name, response.body
+    assert_select "a.bg-emerald-600", text: categories(:hair_care).name
+  end
+
+  test "in_use page combines item name and category filters" do
+    items(:one).update!(category: categories(:hair_care))
+    items(:one).start_using!(@user, Time.zone.local(2026, 5, 10))
+    items(:two).update!(stock_quantity: 1, category: categories(:hair_care))
+    items(:two).start_using!(@user, Time.zone.local(2026, 5, 11))
+
+    get in_use_items_path, params: {
+      q: "化粧",
+      category_id: categories(:hair_care).id
+    }
+
+    assert_response :success
+    assert_includes response.body, items(:one).name
+    assert_no_match items(:two).name, response.body
+    assert_select "input[type='hidden'][name='category_id'][value='#{categories(:hair_care).id}']"
+  end
+
+  test "in_use page filters usage logs for uncategorized items" do
+    items(:one).update!(category: categories(:hair_care))
+    items(:one).start_using!(@user, Time.zone.local(2026, 5, 10))
+    items(:two).update!(stock_quantity: 1)
+    items(:two).start_using!(@user, Time.zone.local(2026, 5, 11))
+
+    get in_use_items_path, params: { category_id: "uncategorized" }
+
+    assert_response :success
+    assert_includes response.body, items(:two).name
+    assert_no_match items(:one).name, response.body
+    assert_select "a.bg-emerald-600", text: "未分類"
+  end
+
+  test "in_use page shows category tags for current user only" do
+    other_category = users(:two).categories.create!(name: "他ユーザーカテゴリ")
+
+    get in_use_items_path
+
+    assert_response :success
+    assert_select "a", text: categories(:hair_care).name
+    assert_select "a", text: "未分類"
+    assert_select "a", text: other_category.name, count: 0
+  end
+
   test "used_up page shows used up count" do
     item = items(:one)
     item.start_using!(@user, Time.zone.local(2026, 5, 10))
@@ -442,6 +500,84 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{discontinued_items_path(page: 2, q: "検索対象")}']"
   end
 
+  test "discontinued page filters usage logs by item category" do
+    matching_item = items(:one)
+    matching_item.update!(category: categories(:hair_care))
+    matching_item.start_using!(@user, Time.zone.local(2026, 5, 10))
+    matching_item.discontinue_using!(Time.zone.local(2026, 5, 12))
+    other_item = items(:two)
+    other_item.update!(stock_quantity: 1, category: categories(:skin_care))
+    other_item.start_using!(@user, Time.zone.local(2026, 5, 11))
+    other_item.discontinue_using!(Time.zone.local(2026, 5, 13))
+
+    get discontinued_items_path, params: { category_id: categories(:hair_care).id }
+
+    assert_response :success
+    assert_includes response.body, matching_item.name
+    assert_no_match other_item.name, response.body
+    assert_select "a.bg-emerald-600", text: categories(:hair_care).name
+  end
+
+  test "discontinued page combines item name and category filters" do
+    items(:one).update!(category: categories(:hair_care))
+    items(:one).start_using!(@user, Time.zone.local(2026, 5, 10))
+    items(:one).discontinue_using!(Time.zone.local(2026, 5, 12))
+    items(:two).update!(stock_quantity: 1, category: categories(:hair_care))
+    items(:two).start_using!(@user, Time.zone.local(2026, 5, 11))
+    items(:two).discontinue_using!(Time.zone.local(2026, 5, 13))
+
+    get discontinued_items_path, params: {
+      q: "化粧",
+      category_id: categories(:hair_care).id
+    }
+
+    assert_response :success
+    assert_includes response.body, items(:one).name
+    assert_no_match items(:two).name, response.body
+    assert_select "input[type='hidden'][name='category_id'][value='#{categories(:hair_care).id}']"
+  end
+
+  test "discontinued page filters usage logs for uncategorized items" do
+    items(:one).update!(category: categories(:hair_care))
+    items(:one).start_using!(@user, Time.zone.local(2026, 5, 10))
+    items(:one).discontinue_using!(Time.zone.local(2026, 5, 12))
+    items(:two).update!(stock_quantity: 1)
+    items(:two).start_using!(@user, Time.zone.local(2026, 5, 11))
+    items(:two).discontinue_using!(Time.zone.local(2026, 5, 13))
+
+    get discontinued_items_path, params: { category_id: "uncategorized" }
+
+    assert_response :success
+    assert_includes response.body, items(:two).name
+    assert_no_match items(:one).name, response.body
+    assert_select "a.bg-emerald-600", text: "未分類"
+  end
+
+  test "discontinued page keeps search and category filters in pagination links" do
+    category = categories(:hair_care)
+    11.times do |number|
+      item = @user.items.create!(
+        name: "検索対象#{number}",
+        stock_quantity: 1,
+        category: category
+      )
+      item.start_using!(@user, Time.zone.local(2026, 5, 10))
+      item.discontinue_using!(Time.zone.local(2026, 5, 12))
+    end
+
+    get discontinued_items_path, params: {
+      q: "検索対象",
+      category_id: category.id
+    }
+
+    assert_response :success
+    assert_select "a[href='#{discontinued_items_path(
+      page: 2,
+      q: "検索対象",
+      category_id: category.id
+    )}']"
+  end
+
   test "used_up page shows one card per item with used up count" do
     item = items(:one)
     item.start_using!(@user, Time.zone.local(2026, 5, 10))
@@ -497,6 +633,84 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "a[href='#{used_up_items_path(page: 2, q: "検索対象")}']"
+  end
+
+  test "used_up page filters usage logs by item category" do
+    matching_item = items(:one)
+    matching_item.update!(category: categories(:hair_care))
+    matching_item.start_using!(@user, Time.zone.local(2026, 5, 10))
+    matching_item.finish_using!(Time.zone.local(2026, 5, 12))
+    other_item = items(:two)
+    other_item.update!(stock_quantity: 1, category: categories(:skin_care))
+    other_item.start_using!(@user, Time.zone.local(2026, 5, 11))
+    other_item.finish_using!(Time.zone.local(2026, 5, 13))
+
+    get used_up_items_path, params: { category_id: categories(:hair_care).id }
+
+    assert_response :success
+    assert_includes response.body, matching_item.name
+    assert_no_match other_item.name, response.body
+    assert_select "a.bg-emerald-600", text: categories(:hair_care).name
+  end
+
+  test "used_up page combines item name and category filters" do
+    items(:one).update!(category: categories(:hair_care))
+    items(:one).start_using!(@user, Time.zone.local(2026, 5, 10))
+    items(:one).finish_using!(Time.zone.local(2026, 5, 12))
+    items(:two).update!(stock_quantity: 1, category: categories(:hair_care))
+    items(:two).start_using!(@user, Time.zone.local(2026, 5, 11))
+    items(:two).finish_using!(Time.zone.local(2026, 5, 13))
+
+    get used_up_items_path, params: {
+      q: "化粧",
+      category_id: categories(:hair_care).id
+    }
+
+    assert_response :success
+    assert_includes response.body, items(:one).name
+    assert_no_match items(:two).name, response.body
+    assert_select "input[type='hidden'][name='category_id'][value='#{categories(:hair_care).id}']"
+  end
+
+  test "used_up page filters usage logs for uncategorized items" do
+    items(:one).update!(category: categories(:hair_care))
+    items(:one).start_using!(@user, Time.zone.local(2026, 5, 10))
+    items(:one).finish_using!(Time.zone.local(2026, 5, 12))
+    items(:two).update!(stock_quantity: 1)
+    items(:two).start_using!(@user, Time.zone.local(2026, 5, 11))
+    items(:two).finish_using!(Time.zone.local(2026, 5, 13))
+
+    get used_up_items_path, params: { category_id: "uncategorized" }
+
+    assert_response :success
+    assert_includes response.body, items(:two).name
+    assert_no_match items(:one).name, response.body
+    assert_select "a.bg-emerald-600", text: "未分類"
+  end
+
+  test "used_up page keeps search and category filters in pagination links" do
+    category = categories(:hair_care)
+    11.times do |number|
+      item = @user.items.create!(
+        name: "検索対象#{number}",
+        stock_quantity: 1,
+        category: category
+      )
+      item.start_using!(@user, Time.zone.local(2026, 5, 10))
+      item.finish_using!(Time.zone.local(2026, 5, 12))
+    end
+
+    get used_up_items_path, params: {
+      q: "検索対象",
+      category_id: category.id
+    }
+
+    assert_response :success
+    assert_select "a[href='#{used_up_items_path(
+      page: 2,
+      q: "検索対象",
+      category_id: category.id
+    )}']"
   end
 
   test "destroy_image removes attached image and redirects to edit page" do

--- a/test/controllers/usage_logs_controller_test.rb
+++ b/test/controllers/usage_logs_controller_test.rb
@@ -102,6 +102,82 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{reviews_usage_logs_path}']", text: "検索条件をリセット"
   end
 
+  test "reviews filters usage logs by item category" do
+    @item.update!(category: categories(:hair_care))
+    @usage_log.update!(rating: 4)
+    other_item = items(:two)
+    other_item.update!(stock_quantity: 1, category: categories(:skin_care))
+    other_item.start_using!(@user, Time.zone.local(2026, 5, 11))
+    other_item.finish_using!(Time.zone.local(2026, 5, 13), rating: 5)
+
+    get reviews_usage_logs_path, params: { category_id: categories(:hair_care).id }
+
+    assert_response :success
+    assert_includes response.body, @item.name
+    assert_no_match other_item.name, response.body
+    assert_select "a.bg-emerald-600", text: categories(:hair_care).name
+  end
+
+  test "reviews combines item name and category filters" do
+    @item.update!(category: categories(:hair_care))
+    @usage_log.update!(rating: 4)
+    other_item = items(:two)
+    other_item.update!(stock_quantity: 1, category: categories(:hair_care))
+    other_item.start_using!(@user, Time.zone.local(2026, 5, 11))
+    other_item.finish_using!(Time.zone.local(2026, 5, 13), rating: 5)
+
+    get reviews_usage_logs_path, params: {
+      q: "化粧",
+      category_id: categories(:hair_care).id
+    }
+
+    assert_response :success
+    assert_includes response.body, @item.name
+    assert_no_match other_item.name, response.body
+    assert_select "input[type='hidden'][name='category_id'][value='#{categories(:hair_care).id}']"
+  end
+
+  test "reviews filters usage logs for uncategorized items" do
+    @item.update!(category: categories(:hair_care))
+    @usage_log.update!(rating: 4)
+    other_item = items(:two)
+    other_item.update!(stock_quantity: 1)
+    other_item.start_using!(@user, Time.zone.local(2026, 5, 11))
+    other_item.finish_using!(Time.zone.local(2026, 5, 13), rating: 5)
+
+    get reviews_usage_logs_path, params: { category_id: "uncategorized" }
+
+    assert_response :success
+    assert_includes response.body, other_item.name
+    assert_no_match @item.name, response.body
+    assert_select "a.bg-emerald-600", text: "未分類"
+  end
+
+  test "reviews keeps search and category filters in pagination links" do
+    category = categories(:hair_care)
+    11.times do |number|
+      item = @user.items.create!(
+        name: "検索対象#{number}",
+        stock_quantity: 1,
+        category: category
+      )
+      item.start_using!(@user, Time.zone.local(2026, 5, 10))
+      item.finish_using!(Time.zone.local(2026, 5, 12), rating: 4)
+    end
+
+    get reviews_usage_logs_path, params: {
+      q: "検索対象",
+      category_id: category.id
+    }
+
+    assert_response :success
+    assert_select "a[href='#{reviews_usage_logs_path(
+      page: 2,
+      q: "検索対象",
+      category_id: category.id
+    )}']"
+  end
+
   test "header links to reviews page" do
     get reviews_usage_logs_path
 

--- a/test/models/usage_log_test.rb
+++ b/test/models/usage_log_test.rb
@@ -29,6 +29,47 @@ class UsageLogTest < ActiveSupport::TestCase
     assert_equal UsageLog.order(:id).to_a, UsageLog.by_item_name(" ").order(:id).to_a
   end
 
+  test "by_item_category returns usage logs in the selected item category" do
+    @item.update!(category: categories(:hair_care))
+    matching_log = @item.usage_logs.create!(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 10)
+    )
+    items(:two).update!(category: categories(:skin_care))
+    items(:two).usage_logs.create!(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 11)
+    )
+
+    assert_equal [matching_log],
+                 UsageLog.by_item_category(categories(:hair_care).id.to_s).to_a
+  end
+
+  test "by_item_category returns usage logs for uncategorized items" do
+    @item.update!(category: categories(:hair_care))
+    @item.usage_logs.create!(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 10)
+    )
+    uncategorized_log = items(:two).usage_logs.create!(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 11)
+    )
+
+    assert_equal [uncategorized_log],
+                 UsageLog.by_item_category("uncategorized").to_a
+  end
+
+  test "by_item_category returns all usage logs when category is blank" do
+    @item.usage_logs.create!(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 10)
+    )
+
+    assert_equal UsageLog.order(:id).to_a,
+                 UsageLog.by_item_category("").order(:id).to_a
+  end
+
   test "rated returns usage logs with rating" do
     rated_log = @item.usage_logs.create!(
       user: @user,


### PR DESCRIPTION
## 概要
使用中・各履歴一覧に、関連アイテムのカテゴリによるタグ絞り込みを追加しました。

Closes #161

## 変更内容
- 使用中アイテムにカテゴリタグを追加
- 使い切り履歴にカテゴリタグを追加
- 使用中止リストにカテゴリタグを追加
- 評価・レビュー履歴にカテゴリタグを追加
- `UsageLog.by_item_category`スコープを追加
- 「すべて」「各カテゴリ」「未分類」に対応
- 選択中カテゴリを強調表示
- アイテム名検索との併用に対応
- 検索フォームとページネーションで条件を維持
- モデル・controllerテストを追加

## 確認内容
- ログイン中ユーザーのカテゴリだけが表示される
- カテゴリ・未分類・すべてを切り替えられる
- 名前検索とカテゴリ絞り込みを同時に利用できる
- 各一覧固有の状態条件が維持される
- ページ移動後も検索語とカテゴリ条件が維持される
- 他ユーザーの履歴が表示されない