### PR TITLE
一覧画面の検索UIとカテゴリタグを共通化する

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+  def category_filter_class(selected_category_id, category_id)
+    if selected_category_id.to_s == category_id.to_s
+      "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white"
+    else
+      "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+    end
+  end
 end

--- a/app/views/items/discontinued.html.erb
+++ b/app/views/items/discontinued.html.erb
@@ -19,31 +19,12 @@
                 class: @selected_category_id == "uncategorized" ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
   </div>
 
-  <%= form_with url: discontinued_items_path,
-                method: :get,
-                local: true,
-                class: "mb-6 rounded-lg bg-slate-50 p-3" do %>
-    <%= hidden_field_tag :category_id, @selected_category_id if @selected_category_id.present? %>
-
-    <div class="flex gap-2">
-      <div class="flex-1">
-        <%= search_field_tag :q,
-                             @search_query,
-                             placeholder: "アイテム名で検索",
-                             class: "form-input h-10" %>
-      </div>
-
-      <%= submit_tag "検索", name: nil, class: "btn-primary h-10 shrink-0 cursor-pointer" %>
-    </div>
-
-    <% if @search_query.present? || @selected_category_id.present? %>
-      <div class="mt-2 text-right">
-        <%= link_to "リセット",
-                    discontinued_items_path,
-                    class: "text-sm font-medium text-slate-600 transition hover:text-slate-900" %>
-      </div>
-    <% end %>
-  <% end %>
+  <%= render "shared/search_form",
+             url: discontinued_items_path,
+             query: @search_query,
+             hidden_params: { category_id: @selected_category_id },
+             show_reset: @search_query.present? || @selected_category_id.present?,
+             reset_url: discontinued_items_path %>
 
   <% if @usage_logs.any? %>
     <div class="grid gap-4 lg:grid-cols-2">

--- a/app/views/items/discontinued.html.erb
+++ b/app/views/items/discontinued.html.erb
@@ -3,21 +3,10 @@
     <h1 class="brand-font text-2xl font-bold text-slate-900"><%= @page_title %></h1>
   </div>
 
-  <div class="mb-4 flex flex-wrap gap-2">
-    <%= link_to "すべて",
-                discontinued_items_path(q: @search_query.presence),
-                class: @selected_category_id.blank? ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
-
-    <% @categories.each do |category| %>
-      <%= link_to category.name,
-                  discontinued_items_path(q: @search_query.presence, category_id: category.id),
-                  class: @selected_category_id == category.id.to_s ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
-    <% end %>
-
-    <%= link_to "未分類",
-                discontinued_items_path(q: @search_query.presence, category_id: "uncategorized"),
-                class: @selected_category_id == "uncategorized" ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
-  </div>
+  <%= render "shared/category_filters",
+             categories: @categories,
+             selected_category_id: @selected_category_id,
+             filter_params: { q: @search_query.presence } %>
 
   <%= render "shared/search_form",
              url: discontinued_items_path,

--- a/app/views/items/in_use.html.erb
+++ b/app/views/items/in_use.html.erb
@@ -3,21 +3,10 @@
     <h1 class="brand-font text-2xl font-bold text-slate-900"><%= @page_title %></h1>
   </div>
 
-  <div class="mb-4 flex flex-wrap gap-2">
-    <%= link_to "すべて",
-                in_use_items_path(q: @search_query.presence),
-                class: @selected_category_id.blank? ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
-
-    <% @categories.each do |category| %>
-      <%= link_to category.name,
-                  in_use_items_path(q: @search_query.presence, category_id: category.id),
-                  class: @selected_category_id == category.id.to_s ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
-    <% end %>
-
-    <%= link_to "未分類",
-                in_use_items_path(q: @search_query.presence, category_id: "uncategorized"),
-                class: @selected_category_id == "uncategorized" ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
-  </div>
+  <%= render "shared/category_filters",
+             categories: @categories,
+             selected_category_id: @selected_category_id,
+             filter_params: { q: @search_query.presence } %>
 
   <%= render "shared/search_form",
              url: in_use_items_path,

--- a/app/views/items/in_use.html.erb
+++ b/app/views/items/in_use.html.erb
@@ -19,31 +19,12 @@
                 class: @selected_category_id == "uncategorized" ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
   </div>
 
-  <%= form_with url: in_use_items_path,
-                method: :get,
-                local: true,
-                class: "mb-6 rounded-lg bg-slate-50 p-3" do %>
-    <%= hidden_field_tag :category_id, @selected_category_id if @selected_category_id.present? %>
-
-    <div class="flex gap-2">
-      <div class="flex-1">
-        <%= search_field_tag :q,
-                             @search_query,
-                             placeholder: "アイテム名で検索",
-                             class: "form-input h-10" %>
-      </div>
-
-      <%= submit_tag "検索", name: nil, class: "btn-primary h-10 shrink-0 cursor-pointer" %>
-    </div>
-
-    <% if @search_query.present? || @selected_category_id.present? %>
-      <div class="mt-2 text-right">
-        <%= link_to "リセット",
-                    in_use_items_path,
-                    class: "text-sm font-medium text-slate-600 transition hover:text-slate-900" %>
-      </div>
-    <% end %>
-  <% end %>
+  <%= render "shared/search_form",
+             url: in_use_items_path,
+             query: @search_query,
+             hidden_params: { category_id: @selected_category_id },
+             show_reset: @search_query.present? || @selected_category_id.present?,
+             reset_url: in_use_items_path %>
 
   <% if @usage_logs.any? %>
     <div class="grid gap-4 lg:grid-cols-2">

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -5,29 +5,13 @@
     <%= link_to "新規登録", new_item_path, class: "btn-primary shrink-0" %>
   </div>
 
-  <div class="mb-4 flex flex-wrap gap-2">
-    <%= link_to "すべて",
-                items_path(q: @search_query.presence, stock: params[:stock].presence),
-                class: @selected_category_id.blank? ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
-
-    <% @categories.each do |category| %>
-      <%= link_to category.name,
-                  items_path(
-                    q: @search_query.presence,
-                    stock: params[:stock].presence,
-                    category_id: category.id
-                  ),
-                  class: @selected_category_id == category.id.to_s ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
-    <% end %>
-
-    <%= link_to "未分類",
-                items_path(
-                  q: @search_query.presence,
-                  stock: params[:stock].presence,
-                  category_id: "uncategorized"
-                ),
-                class: @selected_category_id == "uncategorized" ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
-  </div>
+  <%= render "shared/category_filters",
+             categories: @categories,
+             selected_category_id: @selected_category_id,
+             filter_params: {
+               q: @search_query.presence,
+               stock: params[:stock].presence
+             } %>
 
   <%= render "shared/search_form",
              url: items_path,

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -29,32 +29,15 @@
                 class: @selected_category_id == "uncategorized" ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
   </div>
 
-  <%= form_with url: items_path,
-                method: :get,
-                local: true,
-                class: "mb-6 rounded-lg bg-slate-50 p-3" do %>
-    <%= hidden_field_tag :stock, params[:stock] if params[:stock].present? %>
-    <%= hidden_field_tag :category_id, @selected_category_id if @selected_category_id.present? %>
-
-    <div class="flex gap-2">
-      <div class="flex-1">
-        <%= search_field_tag :q,
-                             @search_query,
-                             placeholder: "アイテム名で検索",
-                             class: "form-input h-10" %>
-      </div>
-
-      <%= submit_tag "検索", name: nil, class: "btn-primary h-10 shrink-0 cursor-pointer" %>
-    </div>
-
-    <% if @search_query.present? || @selected_category_id.present? %>
-      <div class="mt-2 text-right">
-        <%= link_to "リセット",
-                    items_path(stock: params[:stock].presence),
-                    class: "text-sm font-medium text-slate-600 transition hover:text-slate-900" %>
-      </div>
-    <% end %>
-  <% end %>
+  <%= render "shared/search_form",
+             url: items_path,
+             query: @search_query,
+             hidden_params: {
+               stock: params[:stock],
+               category_id: @selected_category_id
+             },
+             show_reset: @search_query.present? || @selected_category_id.present?,
+             reset_url: items_path(stock: params[:stock].presence) %>
 
   <% if @items.any? %>
     <div class="grid gap-4 lg:grid-cols-2">

--- a/app/views/items/used_up.html.erb
+++ b/app/views/items/used_up.html.erb
@@ -3,21 +3,10 @@
     <h1 class="brand-font text-2xl font-bold text-slate-900"><%= @page_title %></h1>
   </div>
 
-  <div class="mb-4 flex flex-wrap gap-2">
-    <%= link_to "すべて",
-                used_up_items_path(q: @search_query.presence),
-                class: @selected_category_id.blank? ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
-
-    <% @categories.each do |category| %>
-      <%= link_to category.name,
-                  used_up_items_path(q: @search_query.presence, category_id: category.id),
-                  class: @selected_category_id == category.id.to_s ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
-    <% end %>
-
-    <%= link_to "未分類",
-                used_up_items_path(q: @search_query.presence, category_id: "uncategorized"),
-                class: @selected_category_id == "uncategorized" ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
-  </div>
+  <%= render "shared/category_filters",
+             categories: @categories,
+             selected_category_id: @selected_category_id,
+             filter_params: { q: @search_query.presence } %>
 
   <%= render "shared/search_form",
              url: used_up_items_path,

--- a/app/views/items/used_up.html.erb
+++ b/app/views/items/used_up.html.erb
@@ -19,31 +19,12 @@
                 class: @selected_category_id == "uncategorized" ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
   </div>
 
-  <%= form_with url: used_up_items_path,
-                method: :get,
-                local: true,
-                class: "mb-6 rounded-lg bg-slate-50 p-3" do %>
-    <%= hidden_field_tag :category_id, @selected_category_id if @selected_category_id.present? %>
-
-    <div class="flex gap-2">
-      <div class="flex-1">
-        <%= search_field_tag :q,
-                             @search_query,
-                             placeholder: "アイテム名で検索",
-                             class: "form-input h-10" %>
-      </div>
-
-      <%= submit_tag "検索", name: nil, class: "btn-primary h-10 shrink-0 cursor-pointer" %>
-    </div>
-
-    <% if @search_query.present? || @selected_category_id.present? %>
-      <div class="mt-2 text-right">
-        <%= link_to "リセット",
-                    used_up_items_path,
-                    class: "text-sm font-medium text-slate-600 transition hover:text-slate-900" %>
-      </div>
-    <% end %>
-  <% end %>
+  <%= render "shared/search_form",
+             url: used_up_items_path,
+             query: @search_query,
+             hidden_params: { category_id: @selected_category_id },
+             show_reset: @search_query.present? || @selected_category_id.present?,
+             reset_url: used_up_items_path %>
 
   <% if @usage_logs.any? %>
     <div class="grid gap-4 lg:grid-cols-2">

--- a/app/views/shared/_category_filters.html.erb
+++ b/app/views/shared/_category_filters.html.erb
@@ -1,0 +1,15 @@
+<div class="mb-4 flex flex-wrap gap-2">
+  <%= link_to "すべて",
+              url_for(filter_params),
+              class: category_filter_class(selected_category_id, nil) %>
+
+  <% categories.each do |category| %>
+    <%= link_to category.name,
+                url_for(filter_params.merge(category_id: category.id)),
+                class: category_filter_class(selected_category_id, category.id) %>
+  <% end %>
+
+  <%= link_to "未分類",
+              url_for(filter_params.merge(category_id: "uncategorized")),
+              class: category_filter_class(selected_category_id, "uncategorized") %>
+</div>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with url: url,
+              method: :get,
+              local: true,
+              class: "mb-6 rounded-lg bg-slate-50 p-3" do %>
+  <% hidden_params.each do |name, value| %>
+    <%= hidden_field_tag name, value if value.present? %>
+  <% end %>
+
+  <div class="flex gap-2">
+    <div class="flex-1">
+      <%= search_field_tag :q,
+                           query,
+                           placeholder: "アイテム名で検索",
+                           class: "form-input h-10" %>
+    </div>
+
+    <%= submit_tag "検索", name: nil, class: "btn-primary h-10 shrink-0 cursor-pointer" %>
+  </div>
+
+  <% if show_reset %>
+    <div class="mt-2 text-right">
+      <%= link_to "リセット",
+                  reset_url,
+                  class: "text-sm font-medium text-slate-600 transition hover:text-slate-900" %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/usage_logs/reviews.html.erb
+++ b/app/views/usage_logs/reviews.html.erb
@@ -3,21 +3,10 @@
     <h1 class="brand-font text-2xl font-bold text-slate-900"><%= @page_title %></h1>
   </div>
 
-  <div class="mb-4 flex flex-wrap gap-2">
-    <%= link_to "すべて",
-                reviews_usage_logs_path(q: @search_query.presence),
-                class: @selected_category_id.blank? ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
-
-    <% @categories.each do |category| %>
-      <%= link_to category.name,
-                  reviews_usage_logs_path(q: @search_query.presence, category_id: category.id),
-                  class: @selected_category_id == category.id.to_s ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
-    <% end %>
-
-    <%= link_to "未分類",
-                reviews_usage_logs_path(q: @search_query.presence, category_id: "uncategorized"),
-                class: @selected_category_id == "uncategorized" ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
-  </div>
+  <%= render "shared/category_filters",
+             categories: @categories,
+             selected_category_id: @selected_category_id,
+             filter_params: { q: @search_query.presence } %>
 
   <%= render "shared/search_form",
              url: reviews_usage_logs_path,

--- a/app/views/usage_logs/reviews.html.erb
+++ b/app/views/usage_logs/reviews.html.erb
@@ -19,31 +19,12 @@
                 class: @selected_category_id == "uncategorized" ? "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white" : "rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50" %>
   </div>
 
-  <%= form_with url: reviews_usage_logs_path,
-                method: :get,
-                local: true,
-                class: "mb-6 rounded-lg bg-slate-50 p-3" do %>
-    <%= hidden_field_tag :category_id, @selected_category_id if @selected_category_id.present? %>
-
-    <div class="flex gap-2">
-      <div class="flex-1">
-        <%= search_field_tag :q,
-                             @search_query,
-                             placeholder: "アイテム名で検索",
-                             class: "form-input h-10" %>
-      </div>
-
-      <%= submit_tag "検索", name: nil, class: "btn-primary h-10 shrink-0 cursor-pointer" %>
-    </div>
-
-    <% if @search_query.present? || @selected_category_id.present? %>
-      <div class="mt-2 text-right">
-        <%= link_to "リセット",
-                    reviews_usage_logs_path,
-                    class: "text-sm font-medium text-slate-600 transition hover:text-slate-900" %>
-      </div>
-    <% end %>
-  <% end %>
+  <%= render "shared/search_form",
+             url: reviews_usage_logs_path,
+             query: @search_query,
+             hidden_params: { category_id: @selected_category_id },
+             show_reset: @search_query.present? || @selected_category_id.present?,
+             reset_url: reviews_usage_logs_path %>
 
   <% if @usage_logs.any? %>
     <div class="grid gap-4 lg:grid-cols-2">


### PR DESCRIPTION
## 概要

一覧画面に重複していた検索フォームとカテゴリタグを、Rails標準のpartialとhelperを使って共通化しました。

Closes #160

## 変更内容

- 検索フォームを `shared/_search_form.html.erb` に共通化
- 画面固有のURL、検索語、hiddenパラメータ、リセットURLをlocalsで指定
- カテゴリタグを `shared/_category_filters.html.erb` に共通化
- 選択状態に応じたCSS class生成を `ApplicationHelper` に移動
- 各画面固有の文言、検索仕様、カテゴリ絞り込み、ページネーションは維持

## 影響

同じUIの修正箇所が1か所にまとまり、一覧Viewが読みやすくなりました。見た目と動作の変更はありません。

## 確認

```bash
docker compose exec web bin/rails test
```

- 141 tests
- 490 assertions
- 0 failures
- 0 errors
