### PR TITLE
一覧画面のナビゲーションを操作の流れに合わせて整理する

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -14,7 +14,7 @@ class ItemsController < ApplicationController
       @page_title = "ストックBOX"
       @items = @items.where("stock_quantity > 0")
     else
-      @page_title = "アイテムDB"
+      @page_title = "アイテム一覧"
     end
 
     @items = @items.page(params[:page])
@@ -35,7 +35,7 @@ class ItemsController < ApplicationController
   end
 
   def used_up
-    @page_title = "使い切り履歴"
+    @page_title = "使い切り"
     @search_query = params[:q].to_s.strip
     @selected_category_id = params[:category_id].to_s
     @categories = current_user.categories.order(:name)
@@ -57,7 +57,7 @@ class ItemsController < ApplicationController
   end
 
   def discontinued
-    @page_title = "使用中止リスト"
+    @page_title = "使用中止"
     @search_query = params[:q].to_s.strip
     @selected_category_id = params[:category_id].to_s
     @categories = current_user.categories.order(:name)

--- a/app/controllers/usage_logs_controller.rb
+++ b/app/controllers/usage_logs_controller.rb
@@ -13,7 +13,7 @@ class UsageLogsController < ApplicationController
   end
 
   def reviews
-    @page_title = "評価・レビュー履歴"
+    @page_title = "マイレビュー"
     @search_query = params[:q].to_s.strip
     @selected_category_id = params[:category_id].to_s
     @categories = current_user.categories.order(:name)

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,18 +10,92 @@
       </div>
 
       <% if user_signed_in? %>
-        <nav class="flex flex-wrap gap-2 text-sm" aria-label="メインメニュー">
-          <% active_nav_class = "rounded-full bg-emerald-50 px-3 py-1.5 font-medium text-emerald-700 transition hover:bg-emerald-100" %>
-          <% inactive_nav_class = "rounded-full bg-slate-100 px-3 py-1.5 font-medium text-slate-700 transition hover:bg-slate-200" %>
-          <% item_db_active = current_page?(items_path) && params[:stock].blank? %>
+        <% active_nav_class = "rounded-full bg-emerald-50 px-3 py-1.5 font-medium text-emerald-700 transition hover:bg-emerald-100" %>
+        <% inactive_nav_class = "rounded-full bg-slate-100 px-3 py-1.5 font-medium text-slate-700 transition hover:bg-slate-200" %>
+        <% item_index_page = controller_name == "items" && action_name == "index" %>
+        <% item_db_active = item_index_page && params[:stock].blank? %>
+        <% stock_box_active = item_index_page && params[:stock] == "available" %>
+        <% in_use_active = controller_name == "items" && action_name == "in_use" %>
+        <% history_nav_active = controller_name == "items" && action_name.in?(%w[used_up discontinued]) %>
+        <% reviews_active = controller_name == "usage_logs" && action_name == "reviews" %>
+        <% categories_active = controller_name == "categories" && action_name == "index" %>
 
-          <%= link_to "アイテムDB", items_path, class: item_db_active ? active_nav_class : inactive_nav_class %>
-          <%= link_to "ストックBOX", items_path(stock: "available"), class: current_page?(items_path(stock: "available")) ? active_nav_class : inactive_nav_class %>
-          <%= link_to "使用中アイテム", in_use_items_path, class: current_page?(in_use_items_path) ? active_nav_class : inactive_nav_class %>
-          <%= link_to "使い切り履歴", used_up_items_path, class: current_page?(used_up_items_path) ? active_nav_class : inactive_nav_class %>
-          <%= link_to "使用中止リスト", discontinued_items_path, class: current_page?(discontinued_items_path) ? active_nav_class : inactive_nav_class %>
-          <%= link_to "評価・レビュー履歴", reviews_usage_logs_path, class: current_page?(reviews_usage_logs_path) ? active_nav_class : inactive_nav_class %>
-          <%= link_to "カテゴリ管理", categories_path, class: current_page?(categories_path) ? active_nav_class : inactive_nav_class %>
+        <details class="md:hidden">
+          <summary class="flex cursor-pointer list-none items-center justify-center gap-2 rounded-lg bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-200">
+            <svg class="h-5 w-5" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+            </svg>
+            メニュー
+          </summary>
+
+          <nav class="mt-2 divide-y divide-slate-100 rounded-lg border border-slate-200 bg-white px-3 text-sm" aria-label="スマートフォンメニュー">
+            <div class="grid gap-2 py-3">
+              <%= link_to "アイテム一覧", items_path, class: item_db_active ? active_nav_class : inactive_nav_class %>
+              <%= link_to "在庫あり", items_path(stock: "available"), class: stock_box_active ? active_nav_class : inactive_nav_class %>
+              <%= link_to "使用中", in_use_items_path, class: in_use_active ? active_nav_class : inactive_nav_class %>
+            </div>
+
+            <details class="py-3" data-menu-group="history">
+              <summary class="flex cursor-pointer items-center justify-between px-3 text-sm font-semibold text-slate-700">
+                <span>履歴</span>
+                <span class="text-xs text-slate-400" aria-hidden="true" data-menu-chevron>▼</span>
+              </summary>
+              <div class="mt-2 grid gap-2">
+                <%= link_to "使い切り", used_up_items_path, class: current_page?(used_up_items_path) ? active_nav_class : inactive_nav_class %>
+                <%= link_to "使用中止", discontinued_items_path, class: current_page?(discontinued_items_path) ? active_nav_class : inactive_nav_class %>
+              </div>
+            </details>
+
+            <div class="grid gap-2 py-3">
+              <%= link_to "マイレビュー", reviews_usage_logs_path, class: reviews_active ? active_nav_class : inactive_nav_class %>
+            </div>
+
+            <div class="py-3">
+              <%= link_to categories_path,
+                          class: class_names(
+                            "flex items-center gap-2 rounded-lg px-3 py-2 font-semibold transition",
+                            "bg-emerald-50 text-emerald-700 hover:bg-emerald-100": categories_active,
+                            "text-slate-600 hover:bg-slate-100 hover:text-slate-900": !categories_active
+                          ) do %>
+                <svg class="h-5 w-5" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317a1.724 1.724 0 013.35 0 1.724 1.724 0 002.573 1.066 1.724 1.724 0 012.366 2.366 1.724 1.724 0 001.066 2.573 1.724 1.724 0 010 3.35 1.724 1.724 0 00-1.066 2.573 1.724 1.724 0 01-2.366 2.366 1.724 1.724 0 00-2.573 1.066 1.724 1.724 0 01-3.35 0 1.724 1.724 0 00-2.573-1.066 1.724 1.724 0 01-2.366-2.366 1.724 1.724 0 00-1.066-2.573 1.724 1.724 0 010-3.35 1.724 1.724 0 001.066-2.573 1.724 1.724 0 012.366-2.366 1.724 1.724 0 002.573-1.066z"></path>
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+                </svg>
+                カテゴリ管理
+              <% end %>
+            </div>
+          </nav>
+        </details>
+
+        <nav class="hidden items-start gap-2 text-sm md:flex" aria-label="メインメニュー">
+          <%= link_to "アイテム一覧", items_path, class: item_db_active ? active_nav_class : inactive_nav_class %>
+          <%= link_to "在庫あり", items_path(stock: "available"), class: stock_box_active ? active_nav_class : inactive_nav_class %>
+          <%= link_to "使用中", in_use_items_path, class: in_use_active ? active_nav_class : inactive_nav_class %>
+
+          <details class="relative" data-desktop-menu="history">
+            <summary class="<%= history_nav_active ? active_nav_class : inactive_nav_class %> inline-flex cursor-pointer list-none items-center gap-2">
+              <span>履歴</span>
+              <span class="text-xs" aria-hidden="true" data-menu-chevron>▼</span>
+            </summary>
+            <div class="absolute left-0 z-20 mt-2 grid min-w-48 gap-2 rounded-lg border border-slate-200 bg-white p-3 shadow-sm">
+              <%= link_to "使い切り", used_up_items_path, class: current_page?(used_up_items_path) ? active_nav_class : inactive_nav_class %>
+              <%= link_to "使用中止", discontinued_items_path, class: current_page?(discontinued_items_path) ? active_nav_class : inactive_nav_class %>
+            </div>
+          </details>
+
+          <%= link_to "マイレビュー", reviews_usage_logs_path, class: reviews_active ? active_nav_class : inactive_nav_class %>
+          <%= link_to categories_path,
+                      class: class_names(
+                        "ml-auto inline-flex items-center gap-2 rounded-full px-3 py-1.5 font-medium transition",
+                        "bg-emerald-50 text-emerald-700 hover:bg-emerald-100": categories_active,
+                        "border border-slate-300 bg-white text-slate-600 hover:bg-slate-50 hover:text-slate-900": !categories_active
+                      ) do %>
+            <svg class="h-4 w-4" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317a1.724 1.724 0 013.35 0 1.724 1.724 0 002.573 1.066 1.724 1.724 0 012.366 2.366 1.724 1.724 0 001.066 2.573 1.724 1.724 0 010 3.35 1.724 1.724 0 00-1.066 2.573 1.724 1.724 0 01-2.366 2.366 1.724 1.724 0 00-2.573 1.066 1.724 1.724 0 01-3.35 0 1.724 1.724 0 00-2.573-1.066 1.724 1.724 0 01-2.366-2.366 1.724 1.724 0 00-1.066-2.573 1.724 1.724 0 010-3.35 1.724 1.724 0 001.066-2.573 1.724 1.724 0 012.366-2.366 1.724 1.724 0 002.573-1.066z"></path>
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+            </svg>
+            カテゴリ管理
+          <% end %>
         </nav>
       <% end %>
     </div>

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -15,6 +15,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     get items_path, params: { q: "化粧" }
 
     assert_response :success
+    assert_select "h1", text: "アイテム一覧"
     assert_includes response.body, items(:one).name
     assert_no_match items(:two).name, response.body
     assert_no_match other_user_item.name, response.body
@@ -26,6 +27,43 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "input[name='q'][value='化粧']"
     assert_select "a[href='#{items_path}']", text: "リセット"
+  end
+
+  test "header shows mobile menu and desktop navigation" do
+    get items_path
+
+    assert_response :success
+    assert_select "details.md\\:hidden" do
+      assert_select "summary", text: /メニュー/
+      assert_select "nav[aria-label='スマートフォンメニュー']" do
+        assert_select "details:not([open])", count: 1
+        assert_select "a[href='#{items_path}']", text: "アイテム一覧"
+        assert_select "a[href='#{items_path(stock: "available")}']", text: "在庫あり"
+        assert_select "a[href='#{in_use_items_path}']", text: "使用中"
+        assert_select "details[data-menu-group='history']" do
+          assert_select "summary span", text: "履歴"
+          assert_select "[data-menu-chevron]", text: "▼"
+          assert_select "a[href='#{used_up_items_path}']", text: "使い切り"
+          assert_select "a[href='#{discontinued_items_path}']", text: "使用中止"
+        end
+        assert_select "a[href='#{reviews_usage_logs_path}']", text: "マイレビュー"
+        assert_select "details[data-menu-group='other']", count: 0
+        assert_select "a[href='#{categories_path}']", text: "カテゴリ管理"
+      end
+    end
+    assert_select "nav[aria-label='メインメニュー'].md\\:flex" do
+      assert_select "a.bg-emerald-50[href='#{items_path}']", text: "アイテム一覧"
+      assert_select "a[href='#{items_path(stock: "available")}']", text: "在庫あり"
+      assert_select "a[href='#{in_use_items_path}']", text: "使用中"
+      assert_select "details[data-desktop-menu='history']" do
+        assert_select "summary span", text: "履歴"
+        assert_select "[data-menu-chevron]", text: "▼"
+        assert_select "a[href='#{used_up_items_path}']", text: "使い切り"
+        assert_select "a[href='#{discontinued_items_path}']", text: "使用中止"
+      end
+      assert_select "a[href='#{reviews_usage_logs_path}']", text: "マイレビュー"
+      assert_select "a.ml-auto[href='#{categories_path}']", text: "カテゴリ管理"
+    end
   end
 
   test "index shows a message when search has no results" do
@@ -470,6 +508,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     get discontinued_items_path, params: { q: "化粧" }
 
     assert_response :success
+    assert_select "h1", text: "使用中止"
     assert_includes response.body, matching_item.name
     assert_no_match other_item.name, response.body
     assert_select "input[name='q'][value='化粧']"
@@ -605,6 +644,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     get used_up_items_path, params: { q: "化粧" }
 
     assert_response :success
+    assert_select "h1", text: "使い切り"
     assert_includes response.body, matching_item.name
     assert_no_match other_item.name, response.body
     assert_select "input[name='q'][value='化粧']"

--- a/test/controllers/usage_logs_controller_test.rb
+++ b/test/controllers/usage_logs_controller_test.rb
@@ -37,6 +37,7 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
     get reviews_usage_logs_path
 
     assert_response :success
+    assert_select "h1", text: "マイレビュー"
     assert_includes response.body, @item.name
     assert_select "dd", text: /★★★★\s*☆/
     assert_includes response.body, "また使いたい"
@@ -182,7 +183,7 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
     get reviews_usage_logs_path
 
     assert_response :success
-    assert_select "a[href='#{reviews_usage_logs_path}']", text: "評価・レビュー履歴"
+    assert_select "a[href='#{reviews_usage_logs_path}']", text: "マイレビュー"
   end
 
   test "update saves rating and review" do


### PR DESCRIPTION
## 概要

一覧画面への導線を、利用者の操作の流れに合わせて整理しました。

Closes #156

## 変更内容

- PCヘッダーを `アイテム一覧 / 在庫あり / 使用中 / 履歴 / マイレビュー` の構成へ変更
- 使い切り・使用中止を履歴ドロップダウンに集約
- カテゴリ管理を補助機能として右側へ分離
- スマートフォン用ハンバーガーメニューを追加
- 現在表示中のページや履歴メニューを選択状態として表示
- ページタイトルをナビゲーションの文言に合わせて整理
- 既存URL、controller、route、検索仕様は維持

## 影響

日常的に操作する画面へ直接移動でき、閲覧が中心の履歴はまとめて確認できるようになりました。

## 確認

```bash
docker compose exec web bin/rails test
```

- 142 tests
- 521 assertions
- 0 failures
- 0 errors
