### PR TITLE
使い切り時に続けて使用開始できるようにする

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -146,16 +146,39 @@ class ItemsController < ApplicationController
 
   def finish_using
     @item = current_user.items.find(params[:id])
-    usage_log = @item.current_usage_log
+    usage_log =
+      if params[:usage_log_id].present?
+        @item.usage_logs.in_use.find_by(id: params[:usage_log_id])
+      else
+        @item.current_usage_log
+      end
 
     if usage_log.blank?
       redirect_to in_use_items_path, alert: "使用中のアイテムがありません"
       return
     end
 
-    @item.finish_using!(params[:finished_at])
+    continue_using = ActiveModel::Type::Boolean.new.cast(params[:continue_using])
 
-    redirect_to edit_usage_log_path(usage_log), notice: "アイテムを使い切りました🎉"
+    if continue_using
+      begin
+        @item.finish_and_continue_using!(current_user, usage_log, params[:finished_at])
+      rescue ActiveRecord::RecordInvalid
+        redirect_to in_use_items_path, alert: "在庫または使用状態が更新されたため、続けて使用を開始できませんでした"
+        return
+      end
+    else
+      @item.finish_using!(params[:finished_at])
+    end
+
+    notice =
+      if continue_using
+        "アイテムを使い切り、次の使用を開始しました"
+      else
+        "アイテムを使い切りました🎉"
+      end
+
+    redirect_to edit_usage_log_path(usage_log), notice: notice
   end
 
   def discontinue_using_form

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -66,6 +66,28 @@ class Item < ApplicationRecord
     )
   end
 
+  def finish_and_continue_using!(user, usage_log, finished_at)
+    with_lock do
+      usage_log.reload
+      unless usage_log.item_id == id && usage_log.in_use?
+        errors.add(:base, "使用状態が更新されています")
+        raise ActiveRecord::RecordInvalid, self
+      end
+
+      unless stock_available?
+        errors.add(:stock_quantity, "がありません")
+        raise ActiveRecord::RecordInvalid, self
+      end
+
+      continued_at = finished_at.presence || Time.current
+      usage_log.update!(
+        finished_at: continued_at,
+        finish_reason: :used_up
+      )
+      start_using!(user, continued_at)
+    end
+  end
+
   def discontinue_using!(finished_at, discontinued_reason: nil)
     current_usage_log.update!(
       finished_at: finished_at.presence || Time.current,

--- a/app/views/items/finish_using_form.html.erb
+++ b/app/views/items/finish_using_form.html.erb
@@ -9,10 +9,27 @@
       </div>
 
       <%= form_with url: finish_using_item_path(@item), method: :patch, local: true, class: "space-y-6" do %>
+        <%= hidden_field_tag :usage_log_id, @item.current_usage_log.id %>
+
         <div>
           <%= label_tag :finished_at, "使い切り日", class: "form-label" %>
           <%= date_field_tag :finished_at, Date.current, class: "form-input" %>
         </div>
+
+        <% if @item.stock_available? %>
+          <label class="flex cursor-pointer items-start gap-3 rounded-lg border border-emerald-200 bg-emerald-50 p-4">
+            <%= check_box_tag :continue_using,
+                              "1",
+                              false,
+                              class: "mt-1 h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500" %>
+            <span>
+              <span class="block font-semibold text-emerald-900">続けて新しく使う</span>
+              <span class="mt-1 block text-sm leading-relaxed text-emerald-800">
+                在庫を1個減らし、使い切り日と同じ日から次の使用を開始します。
+              </span>
+            </span>
+          </label>
+        <% end %>
 
         <div class="grid gap-3 sm:grid-cols-2">
           <%= link_to "戻る", params[:return_to] == "show" ? item_path(@item) : in_use_items_path, class: "btn-secondary" %>

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -255,6 +255,69 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_nil usage_log.review
   end
 
+  test "finish_using starts next stock when continue_using is selected" do
+    item = items(:one)
+    item.start_using!(@user, Time.zone.local(2026, 5, 10))
+    usage_log = item.current_usage_log
+
+    assert_difference -> { item.usage_logs.count }, 1 do
+      patch finish_using_item_path(item), params: {
+        finished_at: "2026-05-12",
+        usage_log_id: usage_log.id,
+        continue_using: "1"
+      }
+    end
+
+    assert_redirected_to edit_usage_log_path(usage_log)
+    assert_equal "アイテムを使い切り、次の使用を開始しました", flash[:notice]
+    assert_equal 0, item.reload.stock_quantity
+    assert_equal Time.zone.local(2026, 5, 12), usage_log.reload.finished_at
+    assert_equal "used_up", usage_log.finish_reason
+    assert_equal Time.zone.local(2026, 5, 12), item.current_usage_log.started_at
+  end
+
+  test "finish_using does not change usage log when continue_using is selected without stock" do
+    item = items(:one)
+    item.update!(stock_quantity: 1)
+    item.start_using!(@user, Time.zone.local(2026, 5, 10))
+    usage_log = item.current_usage_log
+
+    assert_no_difference -> { item.usage_logs.count } do
+      patch finish_using_item_path(item), params: {
+        finished_at: "2026-05-12",
+        usage_log_id: usage_log.id,
+        continue_using: "1"
+      }
+    end
+
+    assert_redirected_to in_use_items_path
+    assert_equal 0, item.reload.stock_quantity
+    assert_nil usage_log.reload.finished_at
+    assert item.using?
+  end
+
+  test "finish_using does not consume another stock when the same form is submitted twice" do
+    item = items(:one)
+    item.update!(stock_quantity: 3)
+    item.start_using!(@user, Time.zone.local(2026, 5, 10))
+    usage_log = item.current_usage_log
+    params = {
+      finished_at: "2026-05-12",
+      usage_log_id: usage_log.id,
+      continue_using: "1"
+    }
+
+    patch finish_using_item_path(item), params: params
+
+    assert_no_difference -> { item.usage_logs.count } do
+      patch finish_using_item_path(item), params: params
+    end
+
+    assert_redirected_to in_use_items_path
+    assert_equal 1, item.reload.stock_quantity
+    assert_equal 1, item.usage_logs.in_use.count
+  end
+
   test "discontinue_using discontinues current usage log and redirects to in-use page" do
     item = items(:one)
     item.start_using!(@user, Time.zone.local(2026, 5, 10))
@@ -291,6 +354,20 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "input[name='finished_at']"
+    assert_select "input[name='usage_log_id'][value='#{item.current_usage_log.id}']"
+    assert_select "input[name='continue_using']"
+    assert_select "span", text: "続けて新しく使う"
+  end
+
+  test "finish_using_form does not show continue option when stock is empty" do
+    item = items(:one)
+    item.update!(stock_quantity: 1)
+    item.start_using!(@user, Time.zone.local(2026, 5, 10))
+
+    get finish_using_form_item_path(item)
+
+    assert_response :success
+    assert_select "input[name='continue_using']", count: 0
   end
 
   test "finish_using_form redirects when item is not in use" do

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -76,6 +76,72 @@ class ItemTest < ActiveSupport::TestCase
     assert_nil usage_log.review
   end
 
+  test "finish_and_continue_using! finishes current log and starts next stock" do
+    item = items(:one)
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 10))
+    continued_at = Time.zone.local(2026, 5, 12)
+
+    assert_difference -> { item.usage_logs.count }, 1 do
+      item.finish_and_continue_using!(users(:one), item.current_usage_log, continued_at)
+    end
+
+    finished_log = item.usage_logs.finished.first
+    current_log = item.current_usage_log
+    assert_equal 0, item.reload.stock_quantity
+    assert_equal continued_at, finished_log.finished_at
+    assert_equal "used_up", finished_log.finish_reason
+    assert_equal continued_at, current_log.started_at
+    assert_equal users(:one), current_log.user
+  end
+
+  test "finish_and_continue_using! rolls back when next usage log cannot be created" do
+    item = items(:one)
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 10))
+
+    assert_no_difference -> { item.usage_logs.count } do
+      assert_raises ActiveRecord::RecordInvalid do
+        item.finish_and_continue_using!(nil, item.current_usage_log, Time.zone.local(2026, 5, 12))
+      end
+    end
+
+    assert_equal 1, item.reload.stock_quantity
+    assert item.using?
+    assert_nil item.current_usage_log.finished_at
+  end
+
+  test "finish_and_continue_using! does not finish current log when stock is empty" do
+    item = items(:one)
+    item.update!(stock_quantity: 1)
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 10))
+
+    assert_no_difference -> { item.usage_logs.count } do
+      assert_raises ActiveRecord::RecordInvalid do
+        item.finish_and_continue_using!(users(:one), item.current_usage_log, Time.zone.local(2026, 5, 12))
+      end
+    end
+
+    assert_equal 0, item.reload.stock_quantity
+    assert item.using?
+    assert_nil item.current_usage_log.finished_at
+  end
+
+  test "finish_and_continue_using! does not finish a usage log twice" do
+    item = items(:one)
+    item.update!(stock_quantity: 3)
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 10))
+    usage_log = item.current_usage_log
+    item.finish_and_continue_using!(users(:one), usage_log, Time.zone.local(2026, 5, 12))
+
+    assert_no_difference -> { item.usage_logs.count } do
+      assert_raises ActiveRecord::RecordInvalid do
+        item.finish_and_continue_using!(users(:one), usage_log, Time.zone.local(2026, 5, 12))
+      end
+    end
+
+    assert_equal 1, item.reload.stock_quantity
+    assert_equal 1, item.usage_logs.in_use.count
+  end
+
   test "discontinue_using! discontinues current usage log" do
     item = items(:one)
     item.start_using!(users(:one), Time.zone.local(2026, 5, 10))


### PR DESCRIPTION
## 概要
使い切り時に在庫が残っている場合、そのまま次の1個を使用開始できるようにしました。

Closes #170

## 変更内容
- `Item#finish_and_continue_using!` を追加
  - 現在の使用履歴を使い切りとして完了
  - 在庫を1個減らす
  - 同じ日時で次の未完了使用履歴を作成
  - 上記を同一トランザクションで処理
- 使い切りフォームに「続けて新しく使う」チェック項目を追加
  - 在庫がある場合のみ表示
- controllerでチェック選択時に続けて使用開始処理を呼び出すよう変更
- hiddenの `usage_log_id` で、フォーム表示時点の使用履歴を固定
  - 同じフォームの二重送信で次の在庫まで消費しないよう対策
- model / controller testを追加

## 確認内容
- `docker compose exec web bin/rails test test/models/item_test.rb test/controllers/items_controller_test.rb`
  - 92 tests / 402 assertions
  - 0 failures / 0 errors
- `docker compose exec web bin/rails test`
  - 145 tests / 563 assertions
  - 0 failures / 0 errors

## 補足
関連テストと全テストを同時に実行した際、一度テストDBのfixture衝突で関連テストが失敗しました。単独で再実行し、関連テスト・全テストともに成功しています。