### PR TITLE
在庫切れ表示と在庫追加導線を整える

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -45,7 +45,7 @@
                 <% elsif item.stock_available? %>
                   <span class="rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700">在庫あり</span>
                 <% else %>
-                  <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">在庫なし</span>
+                  <span class="rounded-full border border-red-200 bg-red-50 px-3 py-1 text-xs font-semibold text-red-700">在庫なし</span>
                 <% end %>
               </div>
 
@@ -58,7 +58,9 @@
                 </div>
                 <div>
                   <dt class="text-xs text-slate-500">在庫数</dt>
-                  <dd class="mt-1 text-slate-700"><%= item.stock_quantity %></dd>
+                  <dd class="mt-1 font-sans text-xl font-bold tracking-wide <%= item.out_of_stock? ? "text-red-700" : "text-slate-900" %>">
+                    <%= item.stock_quantity %>
+                  </dd>
                 </div>
                 <div class="col-span-2">
                   <dt class="text-xs text-slate-500">カテゴリ</dt>
@@ -70,13 +72,23 @@
 
           <div class="mt-4 border-t border-slate-100 pt-4">
             <% if item.using? %>
-              <p class="rounded-lg bg-amber-50 px-3 py-2 text-sm text-amber-800">
-                このアイテムは使用中です。
-              </p>
+              <div class="space-y-3">
+                <p class="rounded-lg bg-amber-50 px-3 py-2 text-sm text-amber-800">
+                  このアイテムは使用中です。
+                </p>
+                <%= link_to "在庫を追加する",
+                            edit_item_path(item),
+                            class: "inline-flex w-full items-center justify-center rounded-lg bg-yellow-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-600" %>
+              </div>
             <% elsif item.stock_available? %>
-              <button type="button" class="btn-primary w-full" data-disclosure-toggle>
-                使い始める
-              </button>
+              <div class="grid gap-2 sm:grid-cols-2">
+                <button type="button" class="btn-primary w-full" data-disclosure-toggle>
+                  使い始める
+                </button>
+                <%= link_to "在庫を追加する",
+                            edit_item_path(item),
+                            class: "inline-flex w-full items-center justify-center rounded-lg bg-yellow-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-600" %>
+              </div>
 
               <div class="mt-3 hidden rounded-lg border border-emerald-100 bg-emerald-50 p-3" data-disclosure-panel>
                 <%= form_with url: start_using_item_path(item), method: :patch, local: true, class: "space-y-3" do %>
@@ -94,12 +106,17 @@
                 <% end %>
               </div>
             <% else %>
-              <p class="rounded-lg bg-slate-50 px-3 py-2 text-sm text-slate-600">
-                在庫がないため、使用を開始できません。
-              </p>
+              <div class="space-y-3 rounded-lg border border-red-100 bg-red-50 px-3 py-3">
+                <p class="text-sm font-medium text-red-700">
+                  在庫がないため、使用を開始できません。
+                </p>
+                <%= link_to "在庫を追加する",
+                            edit_item_path(item),
+                            class: "inline-flex w-full items-center justify-center rounded-lg bg-yellow-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-600" %>
+              </div>
             <% end %>
 
-            <div class="mt-3 flex items-center justify-between gap-4">
+            <div class="mt-3 flex flex-wrap items-center justify-between gap-3">
               <%= link_to "削除", item_path(item), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか?" }, class: "text-sm font-medium text-red-600 transition duration-150 hover:text-red-800" %>
               <%= link_to "詳細を見る", item_path(item), class: "btn-secondary px-3 py-1.5" %>
             </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,7 +23,7 @@
         <% elsif @item.stock_available? %>
           <span class="rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700">在庫あり</span>
         <% else %>
-          <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">在庫なし</span>
+          <span class="rounded-full border border-red-200 bg-red-50 px-3 py-1 text-xs font-semibold text-red-700">在庫なし</span>
         <% end %>
       </div>
 
@@ -37,7 +37,9 @@
 
         <div class="rounded-lg bg-slate-50 p-3">
           <dt class="text-xs text-slate-500">在庫数</dt>
-          <dd class="mt-1 font-semibold text-slate-800"><%= @item.stock_quantity %></dd>
+          <dd class="mt-1 font-sans text-2xl font-bold tracking-wide <%= @item.out_of_stock? ? "text-red-700" : "text-slate-900" %>">
+            <%= @item.stock_quantity %>
+          </dd>
         </div>
 
         <div class="rounded-lg bg-slate-50 p-3">
@@ -64,12 +66,22 @@
           <p class="rounded-lg bg-amber-50 px-3 py-2 text-sm text-amber-800">
             このアイテムは使用中です。
           </p>
-          <%= link_to "使い切り日を入力する", finish_using_form_item_path(@item, return_to: "show"), class: "btn-primary w-full" %>
+          <div class="grid gap-2 sm:grid-cols-2">
+            <%= link_to "使い切り日を入力する", finish_using_form_item_path(@item, return_to: "show"), class: "btn-primary w-full" %>
+            <%= link_to "在庫を追加する",
+                        edit_item_path(@item),
+                        class: "inline-flex w-full items-center justify-center rounded-lg bg-yellow-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-600" %>
+          </div>
         </div>
       <% elsif @item.stock_available? %>
-        <button type="button" class="btn-primary w-full" data-disclosure-toggle>
-          使い始める
-        </button>
+        <div class="grid gap-2 sm:grid-cols-2">
+          <button type="button" class="btn-primary w-full" data-disclosure-toggle>
+            使い始める
+          </button>
+          <%= link_to "在庫を追加する",
+                      edit_item_path(@item),
+                      class: "inline-flex w-full items-center justify-center rounded-lg bg-yellow-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-600" %>
+        </div>
 
         <div class="mt-3 hidden rounded-lg border border-emerald-100 bg-emerald-50 p-3" data-disclosure-panel>
           <%= form_with url: start_using_item_path(@item), method: :patch, local: true, class: "space-y-3" do %>
@@ -87,9 +99,14 @@
           <% end %>
         </div>
       <% else %>
-        <p class="rounded-lg bg-slate-50 px-3 py-2 text-sm text-slate-600">
-          在庫がないため、使用を開始できません。
-        </p>
+        <div class="space-y-3 rounded-lg border border-red-100 bg-red-50 px-3 py-3">
+          <p class="text-sm font-medium text-red-700">
+            在庫がないため、使用を開始できません。
+          </p>
+          <%= link_to "在庫を追加する",
+                      edit_item_path(@item),
+                      class: "inline-flex w-full items-center justify-center rounded-lg bg-yellow-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-600" %>
+        </div>
       <% end %>
     </div>
 

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -72,6 +72,27 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{items_path}']", text: "検索条件をリセット"
   end
 
+  test "index highlights out of stock item" do
+    item = items(:two)
+
+    get items_path
+
+    assert_response :success
+    assert_select "span.bg-red-50", text: "在庫なし"
+    assert_select "dd.font-bold.text-red-700", text: item.stock_quantity.to_s
+  end
+
+  test "index shows restock link for every item" do
+    item = items(:one)
+    out_of_stock_item = items(:two)
+
+    get items_path
+
+    assert_response :success
+    assert_select "a[href='#{edit_item_path(item)}']", text: "在庫を追加する"
+    assert_select "a[href='#{edit_item_path(out_of_stock_item)}']", text: "在庫を追加する"
+  end
+
   test "index filters items by category" do
     items(:one).update!(category: categories(:hair_care))
     items(:two).update!(category: categories(:skin_care))
@@ -1030,6 +1051,26 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_includes response.body, categories(:hair_care).name
+  end
+
+  test "show highlights out of stock item and shows restock link" do
+    item = items(:two)
+
+    get item_path(item)
+
+    assert_response :success
+    assert_select "span.bg-red-50", text: "在庫なし"
+    assert_select "dd.font-bold.text-red-700", text: item.stock_quantity.to_s
+    assert_select "a[href='#{edit_item_path(item)}']", text: "在庫を追加する"
+  end
+
+  test "show shows restock link for item with stock" do
+    item = items(:one)
+
+    get item_path(item)
+
+    assert_response :success
+    assert_select "a[href='#{edit_item_path(item)}']", text: "在庫を追加する"
   end
 
   test "update with invalid image rerenders edit page" do


### PR DESCRIPTION
## 概要
在庫0のアイテムを一覧・詳細で見つけやすくし、すべてのアイテムから在庫追加へ進める導線を追加しました。

Closes #171
Closes #174

## 変更内容
- 在庫0の「在庫なし」バッジを赤系に変更
- 在庫数を価格・カテゴリより目立つ表示に調整
  - 在庫0は赤色
  - 在庫ありは濃い文字色
- 一覧画面に「在庫を追加する」導線を追加
  - 在庫あり・在庫0・使用中のすべてで表示
  - 既存のアイテム編集画面へ遷移
- 詳細画面にも同じ方針で「在庫を追加する」導線を追加
- 「使い始める」と「在庫を追加する」が同じ操作グループに見えるよう配置
- 一覧・詳細の表示分岐テストを追加

## 確認内容
- `docker compose exec web bin/rails test test/controllers/items_controller_test.rb`
  - 76 tests / 352 assertions
  - 0 failures / 0 errors
- `docker compose exec web bin/rails test`
  - 149 tests / 575 assertions
  - 0 failures / 0 errors

## 補足
#174 は実装途中で「在庫0限定」から「いつでも在庫追加できる導線」へ方針変更したため、issue本文も更新済みです。