### PR TITLE
使用操作モーダルと履歴フィルターを調整

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -46,7 +46,7 @@ class ItemsController < ApplicationController
     @categories = current_user.categories.order(:name)
     finished_usage_logs = current_user.usage_logs
                                       .finished
-                                      .used_up
+                                      .used_up_history
                                       .by_item_name(@search_query)
                                       .by_item_category(@selected_category_id)
                                       .includes(:item)
@@ -56,7 +56,7 @@ class ItemsController < ApplicationController
     ).page(params[:page])
     @used_up_counts_by_item_id = current_user.usage_logs
                                              .finished
-                                             .used_up
+                                             .used_up_history
                                              .group(:item_id)
                                              .count
   end

--- a/app/controllers/usage_logs_controller.rb
+++ b/app/controllers/usage_logs_controller.rb
@@ -16,10 +16,12 @@ class UsageLogsController < ApplicationController
     @page_title = "レビュー"
     @search_query = params[:q].to_s.strip
     @selected_category_id = params[:category_id].to_s
+    @selected_rating = params[:rating].to_s
     @categories = current_user.categories.order(:name)
     @usage_logs = current_user.usage_logs
                               .finished
                               .rated
+                              .by_rating(@selected_rating)
                               .by_item_name(@search_query)
                               .by_item_category(@selected_category_id)
                               .includes(:item)

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -45,9 +45,31 @@ document.addEventListener("click", (event) => {
   if (!button) return
 
   const disclosure = button.closest("[data-disclosure]")
-  const panel = disclosure?.querySelector("[data-disclosure-panel]")
+  const target = button.dataset.disclosureTarget
+  const panel =
+    cancelButton?.closest("[data-disclosure-panel]") ||
+    disclosure?.querySelector(target ? `[data-disclosure-panel="${target}"]` : "[data-disclosure-panel]")
 
   if (!panel) return
 
+  if (panel.matches("[data-modal-panel]")) {
+    panel.classList.toggle("hidden", Boolean(cancelButton))
+    panel.classList.toggle("flex", Boolean(toggleButton))
+    button.setAttribute("aria-expanded", String(Boolean(toggleButton)))
+    document.body.classList.toggle("overflow-hidden", Boolean(toggleButton))
+    return
+  }
+
   panel.classList.toggle("hidden", Boolean(cancelButton))
+  button.setAttribute("aria-expanded", String(Boolean(toggleButton)))
+})
+
+document.addEventListener("keydown", (event) => {
+  if (event.key !== "Escape") return
+
+  document.querySelectorAll("[data-modal-panel]:not(.hidden)").forEach((panel) => {
+    panel.classList.add("hidden")
+    panel.classList.remove("flex")
+  })
+  document.body.classList.remove("overflow-hidden")
 })

--- a/app/models/usage_log.rb
+++ b/app/models/usage_log.rb
@@ -11,7 +11,13 @@ class UsageLog < ApplicationRecord
 
   scope :in_use, -> { where(finished_at: nil) }
   scope :finished, -> { where.not(finished_at: nil) }
+  scope :used_up_history, -> { where(finish_reason: [finish_reasons[:used_up], nil]) }
   scope :rated, -> { where.not(rating: nil) }
+  scope :by_rating, ->(rating) {
+    return all if rating.blank?
+
+    where(rating: rating)
+  }
   scope :by_item_name, ->(query) {
     return all if query.blank?
 

--- a/app/views/items/_finish_using_modal.html.erb
+++ b/app/views/items/_finish_using_modal.html.erb
@@ -1,0 +1,41 @@
+<div class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-900/40 px-4 py-6" data-disclosure-panel="finish-using" data-modal-panel role="dialog" aria-modal="true" aria-labelledby="finish-using-title-<%= item.id %>">
+  <button type="button" class="absolute inset-0 cursor-default" data-disclosure-cancel aria-label="閉じる"></button>
+
+  <div class="relative w-full max-w-sm rounded-lg bg-white p-5 shadow-xl">
+    <div class="mb-4">
+      <p id="finish-using-title-<%= item.id %>" class="brand-font text-lg font-bold text-slate-900">使い切り日を入力</p>
+      <p class="mt-1 text-sm text-slate-500"><%= item.name %></p>
+    </div>
+
+    <%= form_with url: finish_using_item_path(item), method: :patch, local: true, class: "space-y-4" do %>
+      <%= hidden_field_tag :usage_log_id, item.current_usage_log.id %>
+
+      <div>
+        <%= label_tag :finished_at, "使い切り日", class: "form-label" %>
+        <%= date_field_tag :finished_at, Date.current, class: "form-input bg-white" %>
+      </div>
+
+      <% if item.stock_available? %>
+        <label class="flex cursor-pointer items-start gap-3 rounded-lg border border-emerald-200 bg-emerald-50 p-3">
+          <%= check_box_tag :continue_using,
+                            "1",
+                            false,
+                            class: "mt-1 h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500" %>
+          <span>
+            <span class="block font-semibold text-emerald-900">続けて新しく使う</span>
+            <span class="mt-1 block text-sm leading-relaxed text-emerald-800">
+              在庫を1個減らし、使い切り日と同じ日から次の使用を開始します。
+            </span>
+          </span>
+        </label>
+      <% end %>
+
+      <div class="grid gap-2">
+        <%= submit_tag "使い切る", class: "btn-danger w-full cursor-pointer" %>
+        <button type="button" class="btn-secondary w-full" data-disclosure-cancel>
+          キャンセル
+        </button>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/items/_start_using_modal.html.erb
+++ b/app/views/items/_start_using_modal.html.erb
@@ -1,0 +1,24 @@
+<div class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-900/40 px-4 py-6" data-disclosure-panel="start-using" data-modal-panel role="dialog" aria-modal="true" aria-labelledby="start-using-title-<%= item.id %>">
+  <button type="button" class="absolute inset-0 cursor-default" data-disclosure-cancel aria-label="閉じる"></button>
+
+  <div class="relative w-full max-w-sm rounded-lg bg-white p-5 shadow-xl">
+    <div class="mb-4">
+      <p id="start-using-title-<%= item.id %>" class="brand-font text-lg font-bold text-slate-900">使い始め日を入力</p>
+      <p class="mt-1 text-sm text-slate-500"><%= item.name %></p>
+    </div>
+
+    <%= form_with url: start_using_item_path(item), method: :patch, local: true, class: "space-y-4" do %>
+      <div>
+        <%= label_tag :started_at, "使い始め日", class: "form-label" %>
+        <%= date_field_tag :started_at, Date.current, class: "form-input bg-white" %>
+      </div>
+
+      <div class="grid gap-2">
+        <%= submit_tag "この日から使う", class: "btn-primary w-full cursor-pointer" %>
+        <button type="button" class="btn-secondary w-full" data-disclosure-cancel>
+          キャンセル
+        </button>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/items/discontinued.html.erb
+++ b/app/views/items/discontinued.html.erb
@@ -2,11 +2,33 @@
   <%= render "shared/search_form",
              url: discontinued_items_path,
              query: @search_query,
-             hidden_params: {},
+             hidden_params: {
+               category_id: @selected_category_id.presence
+             },
              show_reset: @search_query.present?,
-             reset_url: discontinued_items_path %>
+             reset_url: discontinued_items_path(category_id: @selected_category_id.presence) %>
 
   <%= render "shared/history_tabs" %>
+
+  <div class="mb-4">
+    <% category_filter_params = {
+      q: @search_query.presence
+    } %>
+    <div class="mb-2 text-xs font-semibold text-slate-500">カテゴリ</div>
+    <div class="flex flex-wrap gap-2">
+      <%= link_to "すべて",
+                  discontinued_items_path(category_filter_params),
+                  class: category_filter_class(@selected_category_id, nil) %>
+      <% @categories.each do |category| %>
+        <%= link_to category.name,
+                    discontinued_items_path(category_filter_params.merge(category_id: category.id)),
+                    class: category_filter_class(@selected_category_id, category.id) %>
+      <% end %>
+      <%= link_to "未設定",
+                  discontinued_items_path(category_filter_params.merge(category_id: "uncategorized")),
+                  class: category_filter_class(@selected_category_id, "uncategorized") %>
+    </div>
+  </div>
 
   <% if @usage_logs.any? %>
     <div class="grid gap-3">

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -102,14 +102,14 @@
 
               <div class="flex flex-wrap items-center justify-end gap-2">
                 <% if item.using? %>
-                  <%= link_to "使い切る",
-                              finish_using_form_item_path(item),
-                              class: "btn-danger px-3 py-1.5" %>
+                  <button type="button" class="btn-danger px-3 py-1.5" data-disclosure-toggle data-disclosure-target="finish-using">
+                    使い切る
+                  </button>
                   <%= link_to "在庫を追加",
                               edit_item_path(item),
                               class: "inline-flex items-center justify-center rounded-lg bg-yellow-500 px-3 py-2 text-sm font-semibold text-white transition hover:bg-amber-600" %>
                 <% elsif item.stock_available? %>
-                  <button type="button" class="btn-primary px-3 py-1.5" data-disclosure-toggle>
+                  <button type="button" class="btn-primary px-3 py-1.5" data-disclosure-toggle data-disclosure-target="start-using">
                     使い始める
                   </button>
                   <%= link_to "在庫を追加",
@@ -126,21 +126,74 @@
             </div>
           </div>
 
-          <% if item.stock_available? %>
-            <div class="mt-3 hidden rounded-lg border border-emerald-100 bg-emerald-50 p-3" data-disclosure-panel>
-              <%= form_with url: start_using_item_path(item), method: :patch, local: true, class: "space-y-3" do %>
-                <div>
-                  <%= label_tag :started_at, "使い始め日", class: "form-label" %>
-                  <%= date_field_tag :started_at, Date.current, class: "form-input bg-white" %>
+          <% if item.using? %>
+            <div class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-900/40 px-4 py-6" data-disclosure-panel="finish-using" data-modal-panel role="dialog" aria-modal="true" aria-labelledby="finish-using-title-<%= item.id %>">
+              <button type="button" class="absolute inset-0 cursor-default" data-disclosure-cancel aria-label="閉じる"></button>
+
+              <div class="relative w-full max-w-sm rounded-lg bg-white p-5 shadow-xl">
+                <div class="mb-4">
+                  <p id="finish-using-title-<%= item.id %>" class="brand-font text-lg font-bold text-slate-900">使い切り日を入力</p>
+                  <p class="mt-1 text-sm text-slate-500"><%= item.name %></p>
                 </div>
 
-                <div class="grid gap-2 sm:grid-cols-2">
-                  <%= submit_tag "この日から使う", class: "btn-primary cursor-pointer", data: { turbo_confirm: "使用を開始しますか?" } %>
-                  <button type="button" class="btn-secondary" data-disclosure-cancel>
-                    キャンセル
-                  </button>
+                <%= form_with url: finish_using_item_path(item), method: :patch, local: true, class: "space-y-4" do %>
+                  <%= hidden_field_tag :usage_log_id, item.current_usage_log.id %>
+
+                  <div>
+                    <%= label_tag :finished_at, "使い切り日", class: "form-label" %>
+                    <%= date_field_tag :finished_at, Date.current, class: "form-input bg-white" %>
+                  </div>
+
+                  <% if item.stock_available? %>
+                    <label class="flex cursor-pointer items-start gap-3 rounded-lg border border-emerald-200 bg-emerald-50 p-3">
+                      <%= check_box_tag :continue_using,
+                                        "1",
+                                        false,
+                                        class: "mt-1 h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500" %>
+                      <span>
+                        <span class="block font-semibold text-emerald-900">続けて新しく使う</span>
+                        <span class="mt-1 block text-sm leading-relaxed text-emerald-800">
+                          在庫を1個減らし、使い切り日と同じ日から次の使用を開始します。
+                        </span>
+                      </span>
+                    </label>
+                  <% end %>
+
+                  <div class="grid gap-2">
+                    <%= submit_tag "使い切る", class: "btn-danger w-full cursor-pointer" %>
+                    <button type="button" class="btn-secondary w-full" data-disclosure-cancel>
+                      キャンセル
+                    </button>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+
+          <% if item.stock_available? %>
+            <div class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-900/40 px-4 py-6" data-disclosure-panel="start-using" data-modal-panel role="dialog" aria-modal="true" aria-labelledby="start-using-title-<%= item.id %>">
+              <button type="button" class="absolute inset-0 cursor-default" data-disclosure-cancel aria-label="閉じる"></button>
+
+              <div class="relative w-full max-w-sm rounded-lg bg-white p-5 shadow-xl">
+                <div class="mb-4">
+                  <p id="start-using-title-<%= item.id %>" class="brand-font text-lg font-bold text-slate-900">使い始め日を入力</p>
+                  <p class="mt-1 text-sm text-slate-500"><%= item.name %></p>
                 </div>
-              <% end %>
+
+                <%= form_with url: start_using_item_path(item), method: :patch, local: true, class: "space-y-4" do %>
+                  <div>
+                    <%= label_tag :started_at, "使い始め日", class: "form-label" %>
+                    <%= date_field_tag :started_at, Date.current, class: "form-input bg-white" %>
+                  </div>
+
+                  <div class="grid gap-2">
+                    <%= submit_tag "この日から使う", class: "btn-primary w-full cursor-pointer" %>
+                    <button type="button" class="btn-secondary w-full" data-disclosure-cancel>
+                      キャンセル
+                    </button>
+                  </div>
+                <% end %>
+              </div>
             </div>
           <% end %>
         </article>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,74 +127,11 @@
           </div>
 
           <% if item.using? %>
-            <div class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-900/40 px-4 py-6" data-disclosure-panel="finish-using" data-modal-panel role="dialog" aria-modal="true" aria-labelledby="finish-using-title-<%= item.id %>">
-              <button type="button" class="absolute inset-0 cursor-default" data-disclosure-cancel aria-label="閉じる"></button>
-
-              <div class="relative w-full max-w-sm rounded-lg bg-white p-5 shadow-xl">
-                <div class="mb-4">
-                  <p id="finish-using-title-<%= item.id %>" class="brand-font text-lg font-bold text-slate-900">使い切り日を入力</p>
-                  <p class="mt-1 text-sm text-slate-500"><%= item.name %></p>
-                </div>
-
-                <%= form_with url: finish_using_item_path(item), method: :patch, local: true, class: "space-y-4" do %>
-                  <%= hidden_field_tag :usage_log_id, item.current_usage_log.id %>
-
-                  <div>
-                    <%= label_tag :finished_at, "使い切り日", class: "form-label" %>
-                    <%= date_field_tag :finished_at, Date.current, class: "form-input bg-white" %>
-                  </div>
-
-                  <% if item.stock_available? %>
-                    <label class="flex cursor-pointer items-start gap-3 rounded-lg border border-emerald-200 bg-emerald-50 p-3">
-                      <%= check_box_tag :continue_using,
-                                        "1",
-                                        false,
-                                        class: "mt-1 h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500" %>
-                      <span>
-                        <span class="block font-semibold text-emerald-900">続けて新しく使う</span>
-                        <span class="mt-1 block text-sm leading-relaxed text-emerald-800">
-                          在庫を1個減らし、使い切り日と同じ日から次の使用を開始します。
-                        </span>
-                      </span>
-                    </label>
-                  <% end %>
-
-                  <div class="grid gap-2">
-                    <%= submit_tag "使い切る", class: "btn-danger w-full cursor-pointer" %>
-                    <button type="button" class="btn-secondary w-full" data-disclosure-cancel>
-                      キャンセル
-                    </button>
-                  </div>
-                <% end %>
-              </div>
-            </div>
+            <%= render "finish_using_modal", item: item %>
           <% end %>
 
           <% if item.stock_available? %>
-            <div class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-900/40 px-4 py-6" data-disclosure-panel="start-using" data-modal-panel role="dialog" aria-modal="true" aria-labelledby="start-using-title-<%= item.id %>">
-              <button type="button" class="absolute inset-0 cursor-default" data-disclosure-cancel aria-label="閉じる"></button>
-
-              <div class="relative w-full max-w-sm rounded-lg bg-white p-5 shadow-xl">
-                <div class="mb-4">
-                  <p id="start-using-title-<%= item.id %>" class="brand-font text-lg font-bold text-slate-900">使い始め日を入力</p>
-                  <p class="mt-1 text-sm text-slate-500"><%= item.name %></p>
-                </div>
-
-                <%= form_with url: start_using_item_path(item), method: :patch, local: true, class: "space-y-4" do %>
-                  <div>
-                    <%= label_tag :started_at, "使い始め日", class: "form-label" %>
-                    <%= date_field_tag :started_at, Date.current, class: "form-input bg-white" %>
-                  </div>
-
-                  <div class="grid gap-2">
-                    <%= submit_tag "この日から使う", class: "btn-primary w-full cursor-pointer" %>
-                    <button type="button" class="btn-secondary w-full" data-disclosure-cancel>
-                      キャンセル
-                    </button>
-                  </div>
-                <% end %>
-              </div>
-            </div>
+            <%= render "start_using_modal", item: item %>
           <% end %>
         </article>
       <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -67,15 +67,59 @@
             このアイテムは使用中です。
           </p>
           <div class="grid gap-2 sm:grid-cols-2">
-            <%= link_to "使い切り日を入力する", finish_using_form_item_path(@item, return_to: "show"), class: "btn-primary w-full" %>
+            <button type="button" class="btn-danger w-full" data-disclosure-toggle data-disclosure-target="finish-using">
+              使い切り日を入力する
+            </button>
             <%= link_to "在庫を追加",
                         edit_item_path(@item),
                         class: "inline-flex w-full items-center justify-center rounded-lg bg-yellow-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-600" %>
           </div>
+
+          <div class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-900/40 px-4 py-6" data-disclosure-panel="finish-using" data-modal-panel role="dialog" aria-modal="true" aria-labelledby="finish-using-title-<%= @item.id %>">
+            <button type="button" class="absolute inset-0 cursor-default" data-disclosure-cancel aria-label="閉じる"></button>
+
+            <div class="relative w-full max-w-sm rounded-lg bg-white p-5 shadow-xl">
+              <div class="mb-4">
+                <p id="finish-using-title-<%= @item.id %>" class="brand-font text-lg font-bold text-slate-900">使い切り日を入力</p>
+                <p class="mt-1 text-sm text-slate-500"><%= @item.name %></p>
+              </div>
+
+              <%= form_with url: finish_using_item_path(@item), method: :patch, local: true, class: "space-y-4" do %>
+                <%= hidden_field_tag :usage_log_id, @item.current_usage_log.id %>
+
+                <div>
+                  <%= label_tag :finished_at, "使い切り日", class: "form-label" %>
+                  <%= date_field_tag :finished_at, Date.current, class: "form-input bg-white" %>
+                </div>
+
+                <% if @item.stock_available? %>
+                  <label class="flex cursor-pointer items-start gap-3 rounded-lg border border-emerald-200 bg-emerald-50 p-3">
+                    <%= check_box_tag :continue_using,
+                                      "1",
+                                      false,
+                                      class: "mt-1 h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500" %>
+                    <span>
+                      <span class="block font-semibold text-emerald-900">続けて新しく使う</span>
+                      <span class="mt-1 block text-sm leading-relaxed text-emerald-800">
+                        在庫を1個減らし、使い切り日と同じ日から次の使用を開始します。
+                      </span>
+                    </span>
+                  </label>
+                <% end %>
+
+                <div class="grid gap-2">
+                  <%= submit_tag "使い切る", class: "btn-danger w-full cursor-pointer" %>
+                  <button type="button" class="btn-secondary w-full" data-disclosure-cancel>
+                    キャンセル
+                  </button>
+                </div>
+              <% end %>
+            </div>
+          </div>
         </div>
       <% elsif @item.stock_available? %>
         <div class="grid gap-2 sm:grid-cols-2">
-          <button type="button" class="btn-primary w-full" data-disclosure-toggle>
+          <button type="button" class="btn-primary w-full" data-disclosure-toggle data-disclosure-target="start-using">
             使い始める
           </button>
           <%= link_to "在庫を追加",
@@ -83,20 +127,29 @@
                       class: "inline-flex w-full items-center justify-center rounded-lg bg-yellow-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-600" %>
         </div>
 
-        <div class="mt-3 hidden rounded-lg border border-emerald-100 bg-emerald-50 p-3" data-disclosure-panel>
-          <%= form_with url: start_using_item_path(@item), method: :patch, local: true, class: "space-y-3" do %>
-            <div>
-              <%= label_tag :started_at, "使い始め日", class: "form-label" %>
-              <%= date_field_tag :started_at, Date.current, class: "form-input bg-white" %>
+        <div class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-900/40 px-4 py-6" data-disclosure-panel="start-using" data-modal-panel role="dialog" aria-modal="true" aria-labelledby="start-using-title-<%= @item.id %>">
+          <button type="button" class="absolute inset-0 cursor-default" data-disclosure-cancel aria-label="閉じる"></button>
+
+          <div class="relative w-full max-w-sm rounded-lg bg-white p-5 shadow-xl">
+            <div class="mb-4">
+              <p id="start-using-title-<%= @item.id %>" class="brand-font text-lg font-bold text-slate-900">使い始め日を入力</p>
+              <p class="mt-1 text-sm text-slate-500"><%= @item.name %></p>
             </div>
 
-            <div class="grid gap-2 sm:grid-cols-2">
-              <%= submit_tag "この日から使う", class: "btn-primary cursor-pointer", data: { turbo_confirm: "使用を開始しますか?" } %>
-              <button type="button" class="btn-secondary" data-disclosure-cancel>
-                キャンセル
-              </button>
-            </div>
-          <% end %>
+            <%= form_with url: start_using_item_path(@item), method: :patch, local: true, class: "space-y-4" do %>
+              <div>
+                <%= label_tag :started_at, "使い始め日", class: "form-label" %>
+                <%= date_field_tag :started_at, Date.current, class: "form-input bg-white" %>
+              </div>
+
+              <div class="grid gap-2">
+                <%= submit_tag "この日から使う", class: "btn-primary w-full cursor-pointer" %>
+                <button type="button" class="btn-secondary w-full" data-disclosure-cancel>
+                  キャンセル
+                </button>
+              </div>
+            <% end %>
+          </div>
         </div>
       <% else %>
         <div class="space-y-3 rounded-lg border border-red-100 bg-red-50 px-3 py-3">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -75,47 +75,7 @@
                         class: "inline-flex w-full items-center justify-center rounded-lg bg-yellow-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-600" %>
           </div>
 
-          <div class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-900/40 px-4 py-6" data-disclosure-panel="finish-using" data-modal-panel role="dialog" aria-modal="true" aria-labelledby="finish-using-title-<%= @item.id %>">
-            <button type="button" class="absolute inset-0 cursor-default" data-disclosure-cancel aria-label="閉じる"></button>
-
-            <div class="relative w-full max-w-sm rounded-lg bg-white p-5 shadow-xl">
-              <div class="mb-4">
-                <p id="finish-using-title-<%= @item.id %>" class="brand-font text-lg font-bold text-slate-900">使い切り日を入力</p>
-                <p class="mt-1 text-sm text-slate-500"><%= @item.name %></p>
-              </div>
-
-              <%= form_with url: finish_using_item_path(@item), method: :patch, local: true, class: "space-y-4" do %>
-                <%= hidden_field_tag :usage_log_id, @item.current_usage_log.id %>
-
-                <div>
-                  <%= label_tag :finished_at, "使い切り日", class: "form-label" %>
-                  <%= date_field_tag :finished_at, Date.current, class: "form-input bg-white" %>
-                </div>
-
-                <% if @item.stock_available? %>
-                  <label class="flex cursor-pointer items-start gap-3 rounded-lg border border-emerald-200 bg-emerald-50 p-3">
-                    <%= check_box_tag :continue_using,
-                                      "1",
-                                      false,
-                                      class: "mt-1 h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500" %>
-                    <span>
-                      <span class="block font-semibold text-emerald-900">続けて新しく使う</span>
-                      <span class="mt-1 block text-sm leading-relaxed text-emerald-800">
-                        在庫を1個減らし、使い切り日と同じ日から次の使用を開始します。
-                      </span>
-                    </span>
-                  </label>
-                <% end %>
-
-                <div class="grid gap-2">
-                  <%= submit_tag "使い切る", class: "btn-danger w-full cursor-pointer" %>
-                  <button type="button" class="btn-secondary w-full" data-disclosure-cancel>
-                    キャンセル
-                  </button>
-                </div>
-              <% end %>
-            </div>
-          </div>
+          <%= render "finish_using_modal", item: @item %>
         </div>
       <% elsif @item.stock_available? %>
         <div class="grid gap-2 sm:grid-cols-2">
@@ -127,30 +87,7 @@
                       class: "inline-flex w-full items-center justify-center rounded-lg bg-yellow-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-600" %>
         </div>
 
-        <div class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-900/40 px-4 py-6" data-disclosure-panel="start-using" data-modal-panel role="dialog" aria-modal="true" aria-labelledby="start-using-title-<%= @item.id %>">
-          <button type="button" class="absolute inset-0 cursor-default" data-disclosure-cancel aria-label="閉じる"></button>
-
-          <div class="relative w-full max-w-sm rounded-lg bg-white p-5 shadow-xl">
-            <div class="mb-4">
-              <p id="start-using-title-<%= @item.id %>" class="brand-font text-lg font-bold text-slate-900">使い始め日を入力</p>
-              <p class="mt-1 text-sm text-slate-500"><%= @item.name %></p>
-            </div>
-
-            <%= form_with url: start_using_item_path(@item), method: :patch, local: true, class: "space-y-4" do %>
-              <div>
-                <%= label_tag :started_at, "使い始め日", class: "form-label" %>
-                <%= date_field_tag :started_at, Date.current, class: "form-input bg-white" %>
-              </div>
-
-              <div class="grid gap-2">
-                <%= submit_tag "この日から使う", class: "btn-primary w-full cursor-pointer" %>
-                <button type="button" class="btn-secondary w-full" data-disclosure-cancel>
-                  キャンセル
-                </button>
-              </div>
-            <% end %>
-          </div>
-        </div>
+        <%= render "start_using_modal", item: @item %>
       <% else %>
         <div class="space-y-3 rounded-lg border border-red-100 bg-red-50 px-3 py-3">
           <p class="text-sm font-medium text-red-700">

--- a/app/views/items/used_up.html.erb
+++ b/app/views/items/used_up.html.erb
@@ -2,11 +2,33 @@
   <%= render "shared/search_form",
              url: used_up_items_path,
              query: @search_query,
-             hidden_params: {},
+             hidden_params: {
+               category_id: @selected_category_id.presence
+             },
              show_reset: @search_query.present?,
-             reset_url: used_up_items_path %>
+             reset_url: used_up_items_path(category_id: @selected_category_id.presence) %>
 
   <%= render "shared/history_tabs" %>
+
+  <div class="mb-4">
+    <% category_filter_params = {
+      q: @search_query.presence
+    } %>
+    <div class="mb-2 text-xs font-semibold text-slate-500">カテゴリ</div>
+    <div class="flex flex-wrap gap-2">
+      <%= link_to "すべて",
+                  used_up_items_path(category_filter_params),
+                  class: category_filter_class(@selected_category_id, nil) %>
+      <% @categories.each do |category| %>
+        <%= link_to category.name,
+                    used_up_items_path(category_filter_params.merge(category_id: category.id)),
+                    class: category_filter_class(@selected_category_id, category.id) %>
+      <% end %>
+      <%= link_to "未設定",
+                  used_up_items_path(category_filter_params.merge(category_id: "uncategorized")),
+                  class: category_filter_class(@selected_category_id, "uncategorized") %>
+    </div>
+  </div>
 
   <% if @usage_logs.any? %>
     <div class="grid gap-3">

--- a/app/views/usage_logs/edit.html.erb
+++ b/app/views/usage_logs/edit.html.erb
@@ -23,7 +23,7 @@
         <div>
           <%= form.label :rating, "星評価（レビューする場合は必須）", class: "form-label" %>
           <%= form.select :rating,
-                          [["評価なし", ""]] + (1..5).map { |rating| ["#{rating} ★", rating] },
+                          [["評価なし", ""]] + (1..5).map { |rating| ["⭐️ #{rating}", rating] },
                           {},
                           class: "form-input" %>
         </div>

--- a/app/views/usage_logs/reviews.html.erb
+++ b/app/views/usage_logs/reviews.html.erb
@@ -2,11 +2,58 @@
   <%= render "shared/search_form",
              url: reviews_usage_logs_path,
              query: @search_query,
-             hidden_params: {},
+             hidden_params: {
+               category_id: @selected_category_id.presence,
+               rating: @selected_rating.presence
+             },
              show_reset: @search_query.present?,
-             reset_url: reviews_usage_logs_path %>
+             reset_url: reviews_usage_logs_path(
+               category_id: @selected_category_id.presence,
+               rating: @selected_rating.presence
+             ) %>
 
   <%= render "shared/history_tabs" %>
+
+  <div class="mb-4">
+    <% category_filter_params = {
+      q: @search_query.presence,
+      rating: @selected_rating.presence
+    } %>
+    <div class="mb-2 text-xs font-semibold text-slate-500">カテゴリ</div>
+    <div class="flex flex-wrap gap-2">
+      <%= link_to "すべて",
+                  reviews_usage_logs_path(category_filter_params),
+                  class: category_filter_class(@selected_category_id, nil) %>
+      <% @categories.each do |category| %>
+        <%= link_to category.name,
+                    reviews_usage_logs_path(category_filter_params.merge(category_id: category.id)),
+                    class: category_filter_class(@selected_category_id, category.id) %>
+      <% end %>
+      <%= link_to "未設定",
+                  reviews_usage_logs_path(category_filter_params.merge(category_id: "uncategorized")),
+                  class: category_filter_class(@selected_category_id, "uncategorized") %>
+    </div>
+  </div>
+
+  <div class="mb-4">
+    <% rating_filter_params = {
+      q: @search_query.presence,
+      category_id: @selected_category_id.presence
+    } %>
+    <div class="mb-2 text-xs font-semibold text-slate-500">評価</div>
+    <div class="flex flex-wrap gap-2">
+      <%= link_to "すべて",
+                  reviews_usage_logs_path(rating_filter_params),
+                  class: category_filter_class(@selected_rating, nil) %>
+      <% 5.downto(1) do |rating| %>
+        <%= link_to reviews_usage_logs_path(rating_filter_params.merge(rating: rating)),
+                    class: category_filter_class(@selected_rating, rating) do %>
+          <span aria-hidden="true">⭐️</span>
+          <span class="font-sans font-bold"><%= rating %></span>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
 
   <% if @usage_logs.any? %>
     <div class="grid gap-3">
@@ -54,15 +101,15 @@
           </div>
 
           <% if usage_log.review.present? %>
-            <p class="mt-3 line-clamp-2 whitespace-pre-wrap rounded-lg bg-slate-50 px-3 py-2 text-sm leading-6 text-slate-700">
-              <span class="font-semibold text-slate-500">レビュー</span>
-              <span class="ml-2"><%= usage_log.review %></span>
-            </p>
+            <div class="mt-3 rounded-lg bg-slate-50 px-3 py-2 text-sm leading-6">
+              <p class="font-semibold text-slate-500">レビュー</p>
+              <p class="mt-1 line-clamp-2 whitespace-pre-wrap break-words text-slate-700"><%= usage_log.review %></p>
+            </div>
           <% else %>
-            <p class="mt-3 rounded-lg bg-slate-50 px-3 py-2 text-sm leading-6 text-slate-500">
-              <span class="font-semibold">レビュー</span>
-              <span class="ml-2">レビューなし</span>
-            </p>
+            <div class="mt-3 rounded-lg bg-slate-50 px-3 py-2 text-sm leading-6 text-slate-500">
+              <p class="font-semibold">レビュー</p>
+              <p class="mt-1">レビューなし</p>
+            </div>
           <% end %>
         </article>
       <% end %>

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -100,14 +100,16 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_no_match items(:two).name, response.body
   end
 
-  test "index shows finish using link for in-use item" do
+  test "index shows finish using modal for in-use item" do
     item = items(:one)
     item.start_using!(@user, Time.current)
 
     get items_path, params: { status: "in_use" }
 
     assert_response :success
-    assert_select "a[href='#{finish_using_form_item_path(item)}']", text: "使い切る"
+    assert_select "button[data-disclosure-target='finish-using']", text: "使い切る"
+    assert_select "form[action='#{finish_using_item_path(item)}'] input[name='finished_at']"
+    assert_select "form[action='#{finish_using_item_path(item)}'] input[name='usage_log_id']"
   end
 
   test "index filters out-of-stock items by status" do
@@ -671,6 +673,8 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, matching_item.name
     assert_no_match other_item.name, response.body
+    assert_select "a.bg-emerald-600[href='#{discontinued_items_path(category_id: categories(:hair_care).id)}']", text: categories(:hair_care).name
+    assert_select "a[href='#{discontinued_items_path(category_id: "uncategorized")}']", text: "未設定"
   end
 
   test "discontinued page combines item name and category filters" do
@@ -689,7 +693,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, items(:one).name
     assert_no_match items(:two).name, response.body
-    assert_select "input[type='hidden'][name='category_id']", count: 0
+    assert_select "input[type='hidden'][name='category_id'][value='#{categories(:hair_care).id}']"
   end
 
   test "discontinued page filters usage logs for uncategorized items" do
@@ -745,6 +749,19 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "article", count: 1
     assert_includes response.body, "2回"
+  end
+
+  test "used_up page shows legacy finished logs without finish reason" do
+    item = items(:one)
+    item.start_using!(@user, Time.zone.local(2026, 5, 10))
+    item.finish_using!(Time.zone.local(2026, 5, 12), rating: 4)
+    item.usage_logs.finished.first.update!(finish_reason: nil)
+
+    get used_up_items_path
+
+    assert_response :success
+    assert_includes response.body, item.name
+    assert_includes response.body, "1回"
   end
 
   test "used_up page searches used up logs by item name" do
@@ -805,6 +822,8 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, matching_item.name
     assert_no_match other_item.name, response.body
+    assert_select "a.bg-emerald-600[href='#{used_up_items_path(category_id: categories(:hair_care).id)}']", text: categories(:hair_care).name
+    assert_select "a[href='#{used_up_items_path(category_id: "uncategorized")}']", text: "未設定"
   end
 
   test "used_up page combines item name and category filters" do
@@ -823,7 +842,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, items(:one).name
     assert_no_match items(:two).name, response.body
-    assert_select "input[type='hidden'][name='category_id']", count: 0
+    assert_select "input[type='hidden'][name='category_id'][value='#{categories(:hair_care).id}']"
   end
 
   test "used_up page filters usage logs for uncategorized items" do

--- a/test/controllers/usage_logs_controller_test.rb
+++ b/test/controllers/usage_logs_controller_test.rb
@@ -16,6 +16,7 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "select[name='usage_log[rating]']"
+    assert_select "option[value='5']", text: "⭐️ 5"
     assert_select "textarea[name='usage_log[review]']"
     assert_select "a[href='#{used_up_items_path}']", text: "レビューしない"
   end
@@ -116,6 +117,8 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, @item.name
     assert_no_match other_item.name, response.body
+    assert_select "a.bg-emerald-600[href='#{reviews_usage_logs_path(category_id: categories(:hair_care).id)}']", text: categories(:hair_care).name
+    assert_select "a[href='#{reviews_usage_logs_path(category_id: "uncategorized")}']", text: "未設定"
   end
 
   test "reviews combines item name and category filters" do
@@ -134,7 +137,42 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, @item.name
     assert_no_match other_item.name, response.body
-    assert_select "input[type='hidden'][name='category_id']", count: 0
+    assert_select "input[type='hidden'][name='category_id'][value='#{categories(:hair_care).id}']"
+  end
+
+  test "reviews filters usage logs by rating" do
+    @usage_log.update!(rating: 4, review: "また使いたい")
+    other_item = items(:two)
+    other_item.update!(stock_quantity: 1)
+    other_item.start_using!(@user, Time.zone.local(2026, 5, 11))
+    other_item.finish_using!(Time.zone.local(2026, 5, 13), rating: 5)
+
+    get reviews_usage_logs_path, params: { rating: "4" }
+
+    assert_response :success
+    assert_includes response.body, @item.name
+    assert_no_match other_item.name, response.body
+    assert_select "a.bg-emerald-600[href='#{reviews_usage_logs_path(rating: 4)}']", text: /⭐️\s*4/
+  end
+
+  test "reviews search form keeps selected rating" do
+    @usage_log.update!(rating: 4)
+
+    get reviews_usage_logs_path, params: { rating: "4" }
+
+    assert_response :success
+    assert_select "input[type='hidden'][name='rating'][value='4']"
+  end
+
+  test "reviews rating filters keep selected category" do
+    category = categories(:hair_care)
+    @item.update!(category: category)
+    @usage_log.update!(rating: 4)
+
+    get reviews_usage_logs_path, params: { category_id: category.id }
+
+    assert_response :success
+    assert_select "a[href='#{reviews_usage_logs_path(category_id: category.id, rating: 4)}']", text: /⭐️\s*4/
   end
 
   test "reviews filters usage logs for uncategorized items" do
@@ -152,7 +190,7 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
     assert_no_match @item.name, response.body
   end
 
-  test "reviews keeps search and category filters in pagination links" do
+  test "reviews keeps search category and rating filters in pagination links" do
     category = categories(:hair_care)
     11.times do |number|
       item = @user.items.create!(
@@ -166,14 +204,16 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
 
     get reviews_usage_logs_path, params: {
       q: "検索対象",
-      category_id: category.id
+      category_id: category.id,
+      rating: "4"
     }
 
     assert_response :success
     assert_select "a[href='#{reviews_usage_logs_path(
       page: 2,
       q: "検索対象",
-      category_id: category.id
+      category_id: category.id,
+      rating: "4"
     )}']"
   end
 


### PR DESCRIPTION
## 概要
- 使い始める/使い切る操作をモーダル化
- 使い切り履歴で過去の finish_reason 未設定ログも表示
- レビュー履歴を星評価で絞り込めるように追加
- 使い切り/使用中止/レビュー履歴にカテゴリフィルターを追加
- 評価表示を ⭐️ 5 形式に統一
- 使用操作モーダルを partial 化して重複を整理

## 確認
- docker compose exec web bin/rails test

## プレビューで確認したいこと
- 使い始める/使い切るモーダルが中央に表示されること
- モーダルのキャンセル、背景クリック、Escapeで閉じられること
- 使い切り履歴に既存の使い切りログが表示されること
- 履歴ページのカテゴリフィルターが使いやすいこと
- レビュー履歴の星評価フィルターが見やすいこと
- スマホ幅で横スクロールや詰まりがないこと

## 関連issue
- #84