### PR TITLE
画像アップロードでスマホ撮影に対応

### DIFF
--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -80,8 +80,11 @@
                           class: "font-medium text-red-600 transition duration-150 hover:text-red-800" %>
             </div>
           <% end %>
-          <%= f.file_field :image, accept: "image/jpeg,image/png", class: "mt-4 block w-full text-sm text-slate-700" %>
-          <p class="form-help">JPEG / PNG、10MB以下の画像を選択してください</p>
+          <%= f.file_field :image,
+                           accept: "image/jpeg,image/png",
+                           capture: "environment",
+                           class: "mt-4 block w-full text-sm text-slate-700" %>
+          <p class="form-help">JPEG / PNG、10MB以下の画像を選択・撮影してください</p>
           <div class="alert-success hidden" data-upload-progress></div>
         </div>
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -51,8 +51,11 @@
             <span class="text-sm text-slate-500" data-image-preview-placeholder>画像プレビュー</span>
             <img class="hidden w-64 h-64 rounded-lg object-cover" data-image-preview>
           </div>
-          <%= f.file_field :image, accept: "image/jpeg,image/png", class: "mt-4 block w-full text-sm text-slate-700" %>
-          <p class="form-help">JPEG / PNG、10MB以下の画像を選択してください</p>
+          <%= f.file_field :image,
+                           accept: "image/jpeg,image/png",
+                           capture: "environment",
+                           class: "mt-4 block w-full text-sm text-slate-700" %>
+          <p class="form-help">JPEG / PNG、10MB以下の画像を選択・撮影してください</p>
           <div class="alert-success hidden" data-upload-progress></div>
         </div>
 

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -908,6 +908,14 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-submit-loading]", text: "アイテムを登録しています..."
   end
 
+  test "new page image input supports camera capture" do
+    get new_item_path
+
+    assert_response :success
+    assert_select "input[type='file'][name='item[image]'][accept='image/jpeg,image/png'][capture='environment']"
+    assert_includes response.body, "JPEG / PNG、10MB以下の画像を選択・撮影してください"
+  end
+
   test "new page has category select and new category field" do
     get new_item_path
 
@@ -922,6 +930,14 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "[data-submit-loading]", text: "アイテム情報を更新しています..."
+  end
+
+  test "edit page image input supports camera capture" do
+    get edit_item_path(items(:one))
+
+    assert_response :success
+    assert_select "input[type='file'][name='item[image]'][accept='image/jpeg,image/png'][capture='environment']"
+    assert_includes response.body, "JPEG / PNG、10MB以下の画像を選択・撮影してください"
   end
 
   test "create assigns selected category to item" do


### PR DESCRIPTION
## 概要
- アイテム登録・編集画面の画像アップロードでスマホ撮影を選びやすくする
- 画像入力に `capture="environment"` を追加
- 補足文を「選択・撮影」に変更

## 確認
- `docker compose exec web bin/rails test test/controllers/items_controller_test.rb`
- `docker compose exec web bin/rails test`

## 関連issue
- #84