### PR TITLE
スマホの画像アップロード導線を分ける

### DIFF
--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -80,11 +80,26 @@
                           class: "font-medium text-red-600 transition duration-150 hover:text-red-800" %>
             </div>
           <% end %>
-          <%= f.file_field :image,
-                           accept: "image/jpeg,image/png",
-                           capture: "environment",
-                           class: "mt-4 block w-full text-sm text-slate-700" %>
-          <p class="form-help">JPEG / PNG、10MB以下の画像を選択・撮影してください</p>
+          <div class="mt-4 grid gap-3 md:block">
+            <%= f.file_field :image,
+                             accept: "image/jpeg,image/png",
+                             capture: "environment",
+                             id: "item_image_camera",
+                             class: "sr-only md:hidden" %>
+            <label for="item_image_camera" class="btn-primary block cursor-pointer text-center md:hidden">
+              カメラを起動
+            </label>
+
+            <%= f.file_field :image,
+                             accept: "image/jpeg,image/png",
+                             id: "item_image_file",
+                             class: "sr-only md:not-sr-only md:block md:w-full md:text-sm md:text-slate-700" %>
+            <label for="item_image_file" class="btn-secondary block cursor-pointer text-center md:hidden">
+              フォルダからアップロード
+            </label>
+          </div>
+          <p class="form-help md:hidden">JPEG / PNG、10MB以下。撮影またはフォルダからアップロードできます。</p>
+          <p class="form-help hidden md:block">JPEG / PNG、10MB以下の画像を選択してください</p>
           <div class="alert-success hidden" data-upload-progress></div>
         </div>
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -51,11 +51,26 @@
             <span class="text-sm text-slate-500" data-image-preview-placeholder>画像プレビュー</span>
             <img class="hidden w-64 h-64 rounded-lg object-cover" data-image-preview>
           </div>
-          <%= f.file_field :image,
-                           accept: "image/jpeg,image/png",
-                           capture: "environment",
-                           class: "mt-4 block w-full text-sm text-slate-700" %>
-          <p class="form-help">JPEG / PNG、10MB以下の画像を選択・撮影してください</p>
+          <div class="mt-4 grid gap-3 md:block">
+            <%= f.file_field :image,
+                             accept: "image/jpeg,image/png",
+                             capture: "environment",
+                             id: "item_image_camera",
+                             class: "sr-only md:hidden" %>
+            <label for="item_image_camera" class="btn-primary block cursor-pointer text-center md:hidden">
+              カメラを起動
+            </label>
+
+            <%= f.file_field :image,
+                             accept: "image/jpeg,image/png",
+                             id: "item_image_file",
+                             class: "sr-only md:not-sr-only md:block md:w-full md:text-sm md:text-slate-700" %>
+            <label for="item_image_file" class="btn-secondary block cursor-pointer text-center md:hidden">
+              フォルダからアップロード
+            </label>
+          </div>
+          <p class="form-help md:hidden">JPEG / PNG、10MB以下。撮影またはフォルダからアップロードできます。</p>
+          <p class="form-help hidden md:block">JPEG / PNG、10MB以下の画像を選択してください</p>
           <div class="alert-success hidden" data-upload-progress></div>
         </div>
 

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -912,8 +912,12 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     get new_item_path
 
     assert_response :success
-    assert_select "input[type='file'][name='item[image]'][accept='image/jpeg,image/png'][capture='environment']"
-    assert_includes response.body, "JPEG / PNG、10MB以下の画像を選択・撮影してください"
+    assert_select "input#item_image_camera[type='file'][name='item[image]'][accept='image/jpeg,image/png'][capture='environment']"
+    assert_select "label[for='item_image_camera'].md\\:hidden", text: "カメラを起動"
+    assert_select "input#item_image_file[type='file'][name='item[image]'][accept='image/jpeg,image/png']"
+    assert_select "label[for='item_image_file'].md\\:hidden", text: "フォルダからアップロード"
+    assert_includes response.body, "撮影またはフォルダからアップロードできます"
+    assert_includes response.body, "JPEG / PNG、10MB以下の画像を選択してください"
   end
 
   test "new page has category select and new category field" do
@@ -936,8 +940,12 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     get edit_item_path(items(:one))
 
     assert_response :success
-    assert_select "input[type='file'][name='item[image]'][accept='image/jpeg,image/png'][capture='environment']"
-    assert_includes response.body, "JPEG / PNG、10MB以下の画像を選択・撮影してください"
+    assert_select "input#item_image_camera[type='file'][name='item[image]'][accept='image/jpeg,image/png'][capture='environment']"
+    assert_select "label[for='item_image_camera'].md\\:hidden", text: "カメラを起動"
+    assert_select "input#item_image_file[type='file'][name='item[image]'][accept='image/jpeg,image/png']"
+    assert_select "label[for='item_image_file'].md\\:hidden", text: "フォルダからアップロード"
+    assert_includes response.body, "撮影またはフォルダからアップロードできます"
+    assert_includes response.body, "JPEG / PNG、10MB以下の画像を選択してください"
   end
 
   test "create assigns selected category to item" do


### PR DESCRIPTION
## 概要
- スマホでは画像アップロード導線を「カメラを起動」と「フォルダからアップロード」に分ける
- PCでは従来通りファイル選択のみ表示し、撮影文言を出さない
- 登録画面と編集画面の両方に適用

## 確認
- `docker compose exec web bin/rails test test/controllers/items_controller_test.rb`
- `docker compose exec web bin/rails test`

## 関連issue
- #84