### PR TITLE
スマホヘッダーに主要導線を表示

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,29 +10,17 @@
       </div>
 
       <% if user_signed_in? %>
-        <% active_nav_class = "rounded-full bg-emerald-50 px-3 py-1.5 font-medium text-emerald-700 transition hover:bg-emerald-100" %>
-        <% inactive_nav_class = "rounded-full bg-slate-100 px-3 py-1.5 font-medium text-slate-700 transition hover:bg-slate-200" %>
+        <% active_nav_class = "rounded-md bg-emerald-50 px-3 py-1.5 font-medium text-emerald-700 transition hover:bg-emerald-100" %>
+        <% inactive_nav_class = "rounded-md bg-slate-100 px-3 py-1.5 font-medium text-slate-700 transition hover:bg-slate-200" %>
         <% item_index_page = controller_name == "items" && action_name == "index" %>
         <% history_nav_active = controller_name == "items" && action_name.in?(%w[used_up discontinued]) %>
         <% reviews_active = controller_name == "usage_logs" && action_name == "reviews" %>
         <% history_active = history_nav_active || reviews_active %>
 
-        <details class="md:hidden">
-          <summary class="flex cursor-pointer list-none items-center justify-center gap-2 rounded-lg bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-200">
-            <svg class="h-5 w-5" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
-            </svg>
-            メニュー
-          </summary>
-
-          <nav class="mt-2 divide-y divide-slate-100 rounded-lg border border-slate-200 bg-white px-3 text-sm" aria-label="スマートフォンメニュー">
-            <div class="grid gap-2 py-3">
-              <%= link_to "アイテム", items_path, class: item_index_page ? active_nav_class : inactive_nav_class %>
-              <%= link_to "履歴", used_up_items_path, class: history_active ? active_nav_class : inactive_nav_class %>
-            </div>
-
-          </nav>
-        </details>
+        <nav class="grid grid-cols-2 gap-2 text-center text-sm md:hidden" aria-label="スマートフォンメニュー">
+          <%= link_to "アイテム", items_path, class: item_index_page ? active_nav_class : inactive_nav_class %>
+          <%= link_to "履歴", used_up_items_path, class: history_active ? active_nav_class : inactive_nav_class %>
+        </nav>
 
         <nav class="hidden items-start gap-2 text-sm md:flex" aria-label="メインメニュー">
           <%= link_to "アイテム", items_path, class: item_index_page ? active_nav_class : inactive_nav_class %>

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -29,20 +29,19 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{items_path}']", text: "リセット"
   end
 
-  test "header shows mobile menu and desktop navigation" do
+  test "header shows mobile and desktop navigation" do
     get items_path
 
     assert_response :success
-    assert_select "details.md\\:hidden" do
-      assert_select "summary", text: /メニュー/
-      assert_select "nav[aria-label='スマートフォンメニュー']" do
-        assert_select "a[href='#{items_path}']", text: "アイテム"
-        assert_select "a[href='#{items_path(status: "available")}']", text: "在庫あり", count: 0
-        assert_select "a[href='#{in_use_items_path}']", text: "使用中", count: 0
-        assert_select "a[href='#{used_up_items_path}']", text: "履歴"
-        assert_select "a[href='#{reviews_usage_logs_path}']", text: "レビュー", count: 0
-        assert_select "details[data-menu-group='other']", count: 0
-      end
+    assert_select "details.md\\:hidden", count: 0
+    assert_select "summary", text: /メニュー/, count: 0
+    assert_select "nav[aria-label='スマートフォンメニュー'].md\\:hidden" do
+      assert_select "a.bg-emerald-50[href='#{items_path}']", text: "アイテム"
+      assert_select "a[href='#{items_path(status: "available")}']", text: "在庫あり", count: 0
+      assert_select "a[href='#{in_use_items_path}']", text: "使用中", count: 0
+      assert_select "a[href='#{used_up_items_path}']", text: "履歴"
+      assert_select "a[href='#{reviews_usage_logs_path}']", text: "レビュー", count: 0
+      assert_select "details[data-menu-group='other']", count: 0
     end
     assert_select "nav[aria-label='メインメニュー'].md\\:flex" do
       assert_select "a.bg-emerald-50[href='#{items_path}']", text: "アイテム"


### PR DESCRIPTION
## 概要
- スマホ版ヘッダーの折りたたみメニューをやめる
- アイテム / 履歴をスマホでも直接表示する
- ナビの角丸を少し四角寄りに調整する

## 確認
- `docker compose exec web bin/rails test test/controllers/items_controller_test.rb`
- `docker compose exec web env PARALLEL_WORKERS=1 bin/rails test`

## 関連issue
- #84