### PR TITLE
アイテムにブランド名を追加する

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -218,7 +218,7 @@ class ItemsController < ApplicationController
   end
 
   def item_params
-    params.require(:item).permit(:name, :price, :stock_quantity, :favorite, :memo, :image)
+    params.require(:item).permit(:name, :brand_name, :price, :stock_quantity, :favorite, :memo, :image)
   end
 
   def set_categories

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,6 +2,7 @@ class Item < ApplicationRecord
   attr_accessor :new_category_name, :remove_category
 
   validates :name, presence: true, length: { maximum: 100 }
+  validates :brand_name, length: { maximum: 100 }
   validates :price, numericality: { only_integer: true, allow_blank: true, greater_than_or_equal_to: 0 }
   validates :stock_quantity, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validate :image_content_type

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -25,6 +25,13 @@
           <%= f.text_field :name, class: "form-input" %>
         </div>
 
+        <!-- ブランド名 -->
+        <div>
+          <%= f.label :brand_name, "ブランド名", class: "form-label" %>
+          <%= f.text_field :brand_name, class: "form-input", placeholder: "例: ものログ製薬", maxlength: 100 %>
+          <p class="form-help">メーカー名やブランド名を残しておくと、あとから見返しやすくなります。</p>
+        </div>
+
         <!-- カテゴリ -->
         <div class="space-y-3">
           <% if @item.category.present? %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -76,8 +76,11 @@
 
               <div class="min-w-0 flex-1">
                 <h2 class="brand-font truncate text-lg font-bold text-slate-900"><%= item.name %></h2>
+                <% if item.brand_name.present? %>
+                  <p class="truncate text-xs font-medium text-emerald-700 sm:text-sm"><%= item.brand_name %></p>
+                <% end %>
 
-                <dl class="mt-0.5 grid grid-cols-2 gap-x-2 gap-y-0.5 text-[11px] text-slate-700 sm:mt-1 sm:flex sm:flex-wrap sm:items-center sm:gap-2 sm:text-xs">
+                <dl class="mt-0.5 grid grid-cols-2 gap-x-2 gap-y-1 text-[11px] text-slate-700 sm:mt-1 sm:flex sm:flex-wrap sm:items-center sm:gap-2 sm:text-xs">
                   <div class="flex min-w-0 items-center gap-1">
                     <dt class="shrink-0 font-medium text-slate-500">状態</dt>
                     <dd class="min-w-0">
@@ -92,7 +95,9 @@
                   </div>
                   <div class="flex min-w-0 items-center gap-1">
                     <dt class="shrink-0 font-medium text-slate-500">カテゴリ</dt>
-                    <dd class="min-w-0 truncate"><%= item.category&.name || "未設定" %></dd>
+                    <dd class="min-w-0 truncate <%= item.category.present? ? "text-slate-700" : "text-slate-400" %>">
+                      <%= item.category&.name || "未設定" %>
+                    </dd>
                   </div>
                 </dl>
               </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -25,6 +25,13 @@
           <%= f.text_field :name, class: "form-input" %>
         </div>
 
+        <!-- ブランド名 -->
+        <div>
+          <%= f.label :brand_name, "ブランド名", class: "form-label" %>
+          <%= f.text_field :brand_name, class: "form-input", placeholder: "例: ものログ製薬", maxlength: 100 %>
+          <p class="form-help">メーカー名やブランド名を残しておくと、あとから見返しやすくなります。</p>
+        </div>
+
         <!-- カテゴリ -->
         <div class="space-y-3">
           <div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -37,7 +37,7 @@
 
         <div class="rounded-lg bg-slate-50 p-3">
           <dt class="text-xs text-slate-500">在庫数</dt>
-          <dd class="mt-1 font-sans text-2xl font-bold tracking-wide <%= @item.out_of_stock? ? "text-red-700" : "text-slate-900" %>">
+          <dd class="mt-1 font-semibold <%= @item.out_of_stock? ? "text-red-700" : "text-slate-800" %>">
             <%= @item.stock_quantity %>
           </dd>
         </div>
@@ -45,6 +45,11 @@
         <div class="rounded-lg bg-slate-50 p-3">
           <dt class="text-xs text-slate-500">カテゴリ</dt>
           <dd class="mt-1 font-semibold text-slate-800"><%= @item.category&.name || "未設定" %></dd>
+        </div>
+
+        <div class="rounded-lg bg-slate-50 p-3">
+          <dt class="text-xs text-slate-500">ブランド名</dt>
+          <dd class="mt-1 font-semibold text-slate-800"><%= @item.brand_name.presence || "未設定" %></dd>
         </div>
       </dl>
     </div>

--- a/db/migrate/20260624000000_add_brand_name_to_items.rb
+++ b/db/migrate/20260624000000_add_brand_name_to_items.rb
@@ -1,0 +1,5 @@
+class AddBrandNameToItems < ActiveRecord::Migration[7.1]
+  def change
+    add_column :items, :brand_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_05_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_24_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -63,6 +63,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_05_000000) do
     t.boolean "archived", default: false, null: false
     t.uuid "user_id", null: false
     t.uuid "category_id"
+    t.string "brand_name"
     t.index ["archived"], name: "index_items_on_archived"
     t.index ["category_id"], name: "index_items_on_category_id"
     t.index ["user_id"], name: "index_items_on_user_id"

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -958,6 +958,22 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "JPEG / PNG、10MB以下の画像を選択してください"
   end
 
+  test "new page has brand name field" do
+    get new_item_path
+
+    assert_response :success
+    assert_select "label[for='item_brand_name']", "ブランド名"
+    assert_select "input[name='item[brand_name]'][maxlength='100']"
+  end
+
+  test "edit page has brand name field" do
+    get edit_item_path(items(:one))
+
+    assert_response :success
+    assert_select "label[for='item_brand_name']", "ブランド名"
+    assert_select "input[name='item[brand_name]'][maxlength='100']"
+  end
+
   test "create assigns selected category to item" do
     category = categories(:hair_care)
 
@@ -975,6 +991,40 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     item = @user.items.order(:created_at).last
     assert_redirected_to items_path
     assert_equal category, item.category
+  end
+
+  test "create saves brand name" do
+    assert_difference -> { @user.items.count }, 1 do
+      post items_path, params: {
+        item: {
+          name: "シャンプー",
+          brand_name: "ものログ製薬",
+          price: 1200,
+          stock_quantity: 1
+        }
+      }
+    end
+
+    item = @user.items.order(:created_at).last
+    assert_redirected_to items_path
+    assert_equal "ものログ製薬", item.brand_name
+  end
+
+  test "create saves item without brand name" do
+    assert_difference -> { @user.items.count }, 1 do
+      post items_path, params: {
+        item: {
+          name: "無印アイテム",
+          brand_name: "",
+          price: 500,
+          stock_quantity: 1
+        }
+      }
+    end
+
+    item = @user.items.order(:created_at).last
+    assert_redirected_to items_path
+    assert item.brand_name.blank?
   end
 
   test "create creates new category and assigns it to item" do
@@ -1029,6 +1079,22 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to items_path
     assert_equal category, item.reload.category
+  end
+
+  test "update changes brand name" do
+    item = items(:one)
+
+    patch item_path(item), params: {
+      item: {
+        name: item.name,
+        brand_name: "ものログコスメ",
+        price: item.price,
+        stock_quantity: item.stock_quantity
+      }
+    }
+
+    assert_redirected_to items_path
+    assert_equal "ものログコスメ", item.reload.brand_name
   end
 
   test "update creates new category and assigns it to item" do
@@ -1093,6 +1159,16 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, categories(:hair_care).name
   end
 
+  test "index shows item brand name" do
+    item = items(:one)
+    item.update!(brand_name: "ものログ製薬")
+
+    get items_path
+
+    assert_response :success
+    assert_includes response.body, "ものログ製薬"
+  end
+
   test "index paginates items with ten items per page" do
     9.times do |number|
       @user.items.create!(
@@ -1123,6 +1199,17 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, categories(:hair_care).name
   end
 
+  test "show shows item brand name" do
+    item = items(:one)
+    item.update!(brand_name: "ものログ製薬")
+
+    get item_path(item)
+
+    assert_response :success
+    assert_includes response.body, "ブランド名"
+    assert_includes response.body, "ものログ製薬"
+  end
+
   test "show uses consistent finish using button label for in-use item" do
     item = items(:one)
     item.start_using!(@user, Time.zone.local(2026, 5, 10))
@@ -1141,7 +1228,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "span.bg-red-50", text: "在庫なし"
-    assert_select "dd.font-bold.text-red-700", text: item.stock_quantity.to_s
+    assert_select "dd.text-red-700", text: item.stock_quantity.to_s
     assert_select "a[href='#{edit_item_path(item)}']", text: "在庫を追加"
   end
 

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -166,6 +166,21 @@ class ItemTest < ActiveSupport::TestCase
     assert item.valid?
   end
 
+  test "item can be saved without brand name" do
+    item = items(:one)
+    item.brand_name = nil
+
+    assert item.valid?
+  end
+
+  test "item rejects brand name over 100 characters" do
+    item = items(:one)
+    item.brand_name = "あ" * 101
+
+    assert_not item.valid?
+    assert_includes item.errors[:brand_name], "は100文字以内で入力してください"
+  end
+
   test "item accepts png image" do
     item = items(:one)
     item.image.attach(


### PR DESCRIPTION
## 概要
- アイテムにブランド名を登録できるようにする
- 登録・編集フォームにブランド名欄を追加
- 詳細画面と一覧画面にブランド名を表示
- ブランド名の保存・更新・未入力・表示・バリデーションのテストを追加

## 確認
- `docker compose exec web bin/rails db:migrate`
- `docker compose exec web bin/rails test`

Closes #190
