### PR TITLE
お問い合わせフォームへの導線を追加

### DIFF
--- a/app/views/static_pages/contact.html.erb
+++ b/app/views/static_pages/contact.html.erb
@@ -2,20 +2,28 @@
   <div class="space-y-5">
     <h1 class="brand-font text-center text-2xl font-bold text-slate-900">お問い合わせ</h1>
 
-    <div class="ui-card space-y-4 text-sm leading-relaxed text-slate-700">
+    <div class="ui-card space-y-5 text-sm leading-relaxed text-slate-700">
       <p>
         「ものログ」をご利用いただき、ありがとうございます。
       </p>
 
-      <div class="rounded-lg bg-slate-50 px-4 py-4">
-        <p class="font-bold text-slate-900">お問い合わせ窓口を準備中です</p>
+      <div class="rounded-lg bg-emerald-50 px-4 py-4">
+        <p class="font-bold text-slate-900">お問い合わせフォーム</p>
         <p class="mt-2">
-          現在、お問い合わせ先を準備しています。ご案内まで今しばらくお待ちください。
+          ご意見・不具合のご報告・その他のお問い合わせは、Googleフォームからお送りください。
         </p>
       </div>
 
-      <p class="text-slate-500">
-        お問い合わせ方法が決まり次第、このページでお知らせします。
+      <div class="text-center">
+        <%= link_to "Googleフォームを開く",
+                    "https://docs.google.com/forms/d/e/1FAIpQLSe-FQYI10R-WciP1i4lLKHGLXYOwPtCESXjUN-mP2s5MKZhTA/viewform?usp=publish-editor",
+                    target: "_blank",
+                    rel: "noopener",
+                    class: "inline-flex w-full items-center justify-center rounded-lg bg-emerald-600 px-4 py-3 font-bold text-white transition hover:bg-emerald-700 sm:w-auto" %>
+      </div>
+
+      <p class="text-xs text-slate-500">
+        内容を確認のうえ、必要に応じて返信いたします。
       </p>
     </div>
   </div>

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -80,7 +80,8 @@ class StaticPagesControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "h1", "お問い合わせ"
-    assert_select "p", "お問い合わせ窓口を準備中です"
+    assert_select "p", "お問い合わせフォーム"
+    assert_select "a[href*='docs.google.com/forms']", "Googleフォームを開く"
   end
 
   test "フッターからお問い合わせページに移動できる" do


### PR DESCRIPTION
## 概要
- お問い合わせページを準備中表示からGoogleフォームへの案内に変更
- Googleフォームへのリンクを中央揃えのボタンとして表示
- お問い合わせページの表示テストを更新

## 確認
- `docker compose exec web bin/rails test test/controllers/static_pages_controller_test.rb`
- `docker compose exec web bin/rails test`

Closes #136