### PR TITLE
本番画像保存先をCloudflare R2に変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem "bootsnap", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 1.2"
+gem "aws-sdk-s3", require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,25 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1262.0)
+    aws-sdk-core (3.252.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.129.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.226.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     bcrypt (3.1.21)
     benchmark (0.5.0)
@@ -148,6 +167,7 @@ GEM
     jbuilder (2.14.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
+    jmespath (1.6.2)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -336,6 +356,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  aws-sdk-s3
   bootsnap
   capybara
   debug

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,6 +2,19 @@ require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  config.before_initialize do
+    required_r2_env_names = %w[
+      CLOUDFLARE_R2_ACCESS_KEY_ID
+      CLOUDFLARE_R2_SECRET_ACCESS_KEY
+      CLOUDFLARE_R2_BUCKET
+      CLOUDFLARE_R2_ENDPOINT
+    ]
+    missing_r2_env_names = required_r2_env_names.select { |name| ENV[name].blank? }
+
+    if missing_r2_env_names.any?
+      raise "Missing Cloudflare R2 environment variables: #{missing_r2_env_names.join(', ')}"
+    end
+  end
 
   # Code is not reloaded between requests.
   config.enable_reloading = false
@@ -36,8 +49,8 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  # Store uploaded files on Cloudflare R2 so they persist across deploys.
+  config.active_storage.service = :cloudflare
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,6 +6,15 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
+cloudflare:
+  service: S3
+  access_key_id: <%= ENV.fetch("CLOUDFLARE_R2_ACCESS_KEY_ID", "dummy") %>
+  secret_access_key: <%= ENV.fetch("CLOUDFLARE_R2_SECRET_ACCESS_KEY", "dummy") %>
+  region: auto
+  bucket: <%= ENV.fetch("CLOUDFLARE_R2_BUCKET", "dummy") %>
+  endpoint: <%= ENV.fetch("CLOUDFLARE_R2_ENDPOINT", "https://example.com") %>
+  force_path_style: true
+
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3


### PR DESCRIPTION
## 概要
- 本番環境のActive Storage保存先をローカルディスクからCloudflare R2へ変更
- S3互換接続用に `aws-sdk-s3` を追加
- R2用の `storage.yml` 設定を追加
- production起動時に必要なR2環境変数が未設定なら検知できるように変更

## 確認
- `docker compose exec web env CLOUDFLARE_R2_ACCESS_KEY_ID=dummy CLOUDFLARE_R2_SECRET_ACCESS_KEY=dummy CLOUDFLARE_R2_BUCKET=dummy CLOUDFLARE_R2_ENDPOINT=https://example.r2.cloudflarestorage.com RAILS_ENV=production SECRET_KEY_BASE=dummy APP_HOST=example.com bin/rails runner 'puts Rails.application.config.active_storage.service'`
- `docker compose exec web bin/rails test`

## 補足
- Render側のR2環境変数は設定済み
- 本番での画像アップロード確認はデプロイ後に実施

Refs #195