### PR TITLE
READMEの画像管理にCloudflare R2を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ https://monolog-note.com/
 | フロントエンド | Tailwind CSS / Hotwire（Turbo, Stimulus） |
 | データベース | PostgreSQL |
 | 認証 | Devise |
-| 画像管理 | Active Storage / image_processing / libvips |
+| 画像管理 | Active Storage / Cloudflare R2 / image_processing / libvips |
 | ページネーション | Kaminari |
 | i18n | rails-i18n / devise-i18n |
 | テスト | Minitest |


### PR DESCRIPTION
## 概要
- READMEの使用技術にCloudflare R2を追記
- 画像管理の技術スタックを現在の本番構成に合わせる

## 確認
- `git diff --check`

Refs #195