### PR TITLE
R2アップロード時のチェックサム設定を調整

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -14,6 +14,8 @@ cloudflare:
   bucket: <%= ENV.fetch("CLOUDFLARE_R2_BUCKET", "dummy") %>
   endpoint: <%= ENV.fetch("CLOUDFLARE_R2_ENDPOINT", "https://example.com") %>
   force_path_style: true
+  request_checksum_calculation: when_required
+  response_checksum_validation: when_required
 
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:


### PR DESCRIPTION
## 概要
- Cloudflare R2へのアップロード時にチェックサム指定が衝突する問題を修正
- S3互換ストレージ向けにAWS SDKのチェックサム計算/検証を必要時のみ行う設定を追加

## 原因
本番の画像更新時に `Aws::S3::Errors::InvalidRequest (You can only specify one non-default checksum at a time.)` が発生していました。
Active Storageが送る `Content-MD5` と、aws-sdk-s3側の追加チェックサム指定がR2で衝突していた可能性が高いです。

## 確認
- `docker compose exec web env CLOUDFLARE_R2_ACCESS_KEY_ID=dummy CLOUDFLARE_R2_SECRET_ACCESS_KEY=dummy CLOUDFLARE_R2_BUCKET=dummy CLOUDFLARE_R2_ENDPOINT=https://example.r2.cloudflarestorage.com RAILS_ENV=production SECRET_KEY_BASE=dummy APP_HOST=example.com bin/rails runner 'puts Rails.application.config.active_storage.service'`
- `docker compose exec web bin/rails test`

Refs #195