### PR TITLE
使い切り予測を表示

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -47,6 +47,28 @@ class Item < ApplicationRecord
     stock_quantity.to_i.zero?
   end
 
+  def average_usage_days
+    durations = usage_logs
+                .finished
+                .used_up_history
+                .where.not(started_at: nil)
+                .map { |log| (log.finished_at.to_date - log.started_at.to_date).to_i + 1 }
+                .select(&:positive?)
+
+    return if durations.blank?
+
+    (durations.sum.to_f / durations.size).round
+  end
+
+  def predicted_finish_date
+    return unless using?
+
+    average_days = average_usage_days
+    return if average_days.blank?
+
+    current_usage_log.started_at.to_date + (average_days - 1).days
+  end
+
   def start_using!(user, started_at)
     transaction do
       usage_logs.create!(

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -169,6 +169,18 @@
                       <%= item.category&.name || "未設定" %>
                     </dd>
                   </div>
+                  <% if item.using? %>
+                    <div class="flex min-w-0 items-center gap-1">
+                      <dt class="shrink-0 font-medium text-slate-500">使い切り予測</dt>
+                      <dd class="min-w-0 truncate text-emerald-700">
+                        <% if item.predicted_finish_date.present? %>
+                          <%= item.predicted_finish_date.strftime("%-m/%-d") %>ごろ
+                        <% else %>
+                          データなし
+                        <% end %>
+                      </dd>
+                    </div>
+                  <% end %>
                 </dl>
               </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -76,6 +76,21 @@
           <p class="rounded-lg bg-amber-50 px-3 py-2 text-sm text-amber-800">
             このアイテムは使用中です。
           </p>
+          <div class="rounded-lg bg-emerald-50 px-3 py-3 text-sm text-emerald-800">
+            <p class="text-xs font-semibold text-emerald-700">使い切り予測</p>
+            <% if @item.predicted_finish_date.present? %>
+              <p class="mt-1 font-semibold">
+                <%= @item.predicted_finish_date.strftime("%Y/%-m/%-d") %>ごろ
+              </p>
+              <p class="mt-1 text-xs leading-5">
+                過去の使い切り履歴から、平均<%= @item.average_usage_days %>日で使い切る見込みです。
+              </p>
+            <% else %>
+              <p class="mt-1 text-xs leading-5">
+                使い切り履歴が足りないため、まだ予測できません。
+              </p>
+            <% end %>
+          </div>
           <div class="grid gap-2 sm:grid-cols-2">
             <button type="button" class="btn-danger w-full" data-disclosure-toggle data-disclosure-target="finish-using">
               使い切る

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -137,6 +137,31 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "form[action='#{finish_using_item_path(item)}'] input[name='usage_log_id']"
   end
 
+  test "index shows predicted finish date for in-use item with used-up history" do
+    item = items(:one)
+    item.update!(stock_quantity: 2)
+    item.start_using!(@user, Time.zone.local(2026, 5, 1))
+    item.finish_using!(Time.zone.local(2026, 5, 10))
+    item.start_using!(@user, Time.zone.local(2026, 6, 1))
+
+    get items_path
+
+    assert_response :success
+    assert_includes response.body, "使い切り予測"
+    assert_includes response.body, "6/10ごろ"
+  end
+
+  test "index shows unavailable prediction message for in-use item without used-up history" do
+    item = items(:one)
+    item.start_using!(@user, Time.zone.local(2026, 6, 1))
+
+    get items_path
+
+    assert_response :success
+    assert_includes response.body, "使い切り予測"
+    assert_includes response.body, "データなし"
+  end
+
   test "index filters out-of-stock items by status" do
     get items_path, params: { status: "out_of_stock" }
 
@@ -1247,6 +1272,32 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "button[data-disclosure-target='finish-using']", text: "使い切る"
     assert_select "button", text: "使い切り日を入力する", count: 0
+  end
+
+  test "show displays predicted finish date for in-use item with used-up history" do
+    item = items(:one)
+    item.update!(stock_quantity: 2)
+    item.start_using!(@user, Time.zone.local(2026, 5, 1))
+    item.finish_using!(Time.zone.local(2026, 5, 10))
+    item.start_using!(@user, Time.zone.local(2026, 6, 1))
+
+    get item_path(item)
+
+    assert_response :success
+    assert_includes response.body, "使い切り予測"
+    assert_includes response.body, "2026/6/10ごろ"
+    assert_includes response.body, "平均10日"
+  end
+
+  test "show displays unavailable prediction message when history is missing" do
+    item = items(:one)
+    item.start_using!(@user, Time.zone.local(2026, 6, 1))
+
+    get item_path(item)
+
+    assert_response :success
+    assert_includes response.body, "使い切り予測"
+    assert_includes response.body, "使い切り履歴が足りないため、まだ予測できません。"
   end
 
   test "show highlights out of stock item and shows restock link" do

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -160,6 +160,50 @@ class ItemTest < ActiveSupport::TestCase
     assert_nil usage_log.review
   end
 
+  test "average_usage_days uses finished used-up usage logs" do
+    item = items(:one)
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 1))
+    item.finish_using!(Time.zone.local(2026, 5, 10))
+    item.update!(stock_quantity: 1)
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 20))
+    item.finish_using!(Time.zone.local(2026, 5, 24))
+
+    assert_equal 8, item.average_usage_days
+  end
+
+  test "average_usage_days ignores discontinued usage logs" do
+    item = items(:one)
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 1))
+    item.discontinue_using!(Time.zone.local(2026, 5, 30))
+
+    assert_nil item.average_usage_days
+  end
+
+  test "predicted_finish_date returns date from current usage start and average days" do
+    item = items(:one)
+    item.update!(stock_quantity: 2)
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 1))
+    item.finish_using!(Time.zone.local(2026, 5, 10))
+    item.start_using!(users(:one), Time.zone.local(2026, 6, 1))
+
+    assert_equal Date.new(2026, 6, 10), item.predicted_finish_date
+  end
+
+  test "predicted_finish_date returns nil when item is not in use" do
+    item = items(:one)
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 1))
+    item.finish_using!(Time.zone.local(2026, 5, 10))
+
+    assert_nil item.predicted_finish_date
+  end
+
+  test "predicted_finish_date returns nil when used-up history is missing" do
+    item = items(:one)
+    item.start_using!(users(:one), Time.zone.local(2026, 6, 1))
+
+    assert_nil item.predicted_finish_date
+  end
+
   test "item can be saved without image" do
     item = items(:one)
 


### PR DESCRIPTION
## 概要
- 同一アイテムの使い切り履歴から平均使用日数を計算するようにしました
- 使用中アイテムの詳細画面に使い切り予測を表示しました
- アイテム一覧にも使い切り予測を表示しました
- 使用中止履歴は予測対象から除外します

Closes #46

## 確認
- docker compose exec web bin/rails test