### PR TITLE
使用中操作をモーダル化し、在庫追加もその場でできるようにする

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -221,6 +221,18 @@ class ItemsController < ApplicationController
     redirect_to in_use_items_path, notice: "使用を中止しました"
   end
 
+  def add_stock
+    item = current_user.items.find(params[:id])
+    quantity = params[:quantity].to_i
+
+    if quantity.positive?
+      item.increment!(:stock_quantity, quantity)
+      redirect_back fallback_location: items_path, notice: "在庫を追加しました"
+    else
+      redirect_back fallback_location: items_path, alert: "追加する個数を入力してください"
+    end
+  end
+
   private
 
   def set_item

--- a/app/views/items/_add_stock_button.html.erb
+++ b/app/views/items/_add_stock_button.html.erb
@@ -1,0 +1,5 @@
+<% button_class = local_assigns.fetch(:button_class, "inline-flex items-center justify-center rounded-lg bg-yellow-500 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-amber-600") %>
+
+<button type="button" class="<%= button_class %>" data-disclosure-toggle data-disclosure-target="add-stock">
+  在庫を追加
+</button>

--- a/app/views/items/_add_stock_modal.html.erb
+++ b/app/views/items/_add_stock_modal.html.erb
@@ -1,0 +1,28 @@
+<div class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-900/40 px-4 py-6" data-disclosure-panel="add-stock" data-modal-panel role="dialog" aria-modal="true" aria-labelledby="add-stock-title-<%= item.id %>">
+  <button type="button" class="absolute inset-0 cursor-default" data-disclosure-cancel aria-label="閉じる"></button>
+
+  <div class="relative w-full max-w-sm rounded-lg bg-white p-5 shadow-xl">
+    <div class="mb-4">
+      <p id="add-stock-title-<%= item.id %>" class="brand-font text-lg font-bold text-slate-900">在庫を追加</p>
+      <p class="mt-1 text-sm text-slate-500"><%= item.name %></p>
+    </div>
+
+    <div class="mb-4 rounded-lg bg-slate-50 px-3 py-2 text-sm text-slate-700">
+      現在の在庫数: <span class="font-semibold"><%= item.stock_quantity %></span>
+    </div>
+
+    <%= form_with url: add_stock_item_path(item), method: :patch, local: true, class: "space-y-4" do %>
+      <div>
+        <%= label_tag :quantity, "追加する個数", class: "form-label" %>
+        <%= number_field_tag :quantity, 1, min: 1, class: "form-input bg-white" %>
+      </div>
+
+      <div class="grid gap-2">
+        <%= submit_tag "在庫を追加する", class: "btn-primary w-full cursor-pointer" %>
+        <button type="button" class="btn-secondary w-full" data-disclosure-cancel>
+          キャンセル
+        </button>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/items/_discontinue_using_modal.html.erb
+++ b/app/views/items/_discontinue_using_modal.html.erb
@@ -1,0 +1,39 @@
+<div class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-900/40 px-4 py-6" data-disclosure-panel="discontinue-using" data-modal-panel role="dialog" aria-modal="true" aria-labelledby="discontinue-using-title-<%= item.id %>">
+  <button type="button" class="absolute inset-0 cursor-default" data-disclosure-cancel aria-label="閉じる"></button>
+
+  <div class="relative w-full max-w-sm rounded-lg bg-white p-5 shadow-xl">
+    <div class="mb-4">
+      <p id="discontinue-using-title-<%= item.id %>" class="brand-font text-lg font-bold text-slate-900">使用中止日を入力</p>
+      <p class="mt-1 text-sm text-slate-500"><%= item.name %></p>
+    </div>
+
+    <p class="mb-4 rounded-lg bg-red-50 px-3 py-2 text-sm leading-relaxed text-red-700">
+      肌に合わない、香りが苦手など、使い切らずにやめる場合はこちらで記録します。
+    </p>
+
+    <%= form_with url: discontinue_using_item_path(item), method: :patch, local: true, class: "space-y-4" do %>
+      <div>
+        <%= label_tag :finished_at, "使用中止日", class: "form-label" %>
+        <%= date_field_tag :finished_at, Date.current, class: "form-input bg-white" %>
+      </div>
+
+      <div>
+        <%= label_tag :discontinued_reason, "使用中止理由（任意）", class: "form-label" %>
+        <%= text_area_tag :discontinued_reason,
+                          nil,
+                          rows: 4,
+                          maxlength: 500,
+                          class: "form-input",
+                          placeholder: "例: 肌に合わなかった、香りが苦手だった など" %>
+        <p class="form-help">理由はあとから見返すためのメモです。空欄でも使用中止できます。</p>
+      </div>
+
+      <div class="grid gap-2">
+        <%= submit_tag "使用を中止する", class: "btn-danger w-full cursor-pointer", data: { turbo_confirm: "使用中止として記録しますか?" } %>
+        <button type="button" class="btn-secondary w-full" data-disclosure-cancel>
+          キャンセル
+        </button>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/items/in_use.html.erb
+++ b/app/views/items/in_use.html.erb
@@ -20,7 +20,7 @@
       <% @usage_logs.each do |usage_log| %>
         <% item = usage_log.item %>
 
-        <article class="ui-card">
+        <article class="ui-card" data-disclosure>
           <div class="flex gap-4">
             <div class="shrink-0">
               <%= render "image",
@@ -56,20 +56,36 @@
                     <% end %>
                   </dd>
                 </div>
+
+                <div>
+                  <dt class="text-xs text-slate-500">在庫数</dt>
+                  <dd class="mt-1 font-semibold <%= item.out_of_stock? ? "text-red-700" : "text-slate-700" %>">
+                    <%= item.stock_quantity %>
+                  </dd>
+                </div>
               </dl>
             </div>
           </div>
 
           <div class="mt-4 border-t border-slate-100 pt-4">
             <div class="grid gap-2 sm:grid-cols-2">
-              <%= link_to "使い切る", finish_using_form_item_path(item), class: "btn-primary text-center" %>
-              <%= link_to "使用を中止する", discontinue_using_form_item_path(item), class: "btn-danger text-center" %>
+              <button type="button" class="btn-primary text-center" data-disclosure-toggle data-disclosure-target="finish-using">
+                使い切る
+              </button>
+              <button type="button" class="btn-danger text-center" data-disclosure-toggle data-disclosure-target="discontinue-using">
+                使用を中止する
+              </button>
             </div>
 
-            <div class="mt-3 flex items-center justify-end gap-4">
+            <div class="mt-3 flex flex-wrap items-center justify-end gap-3">
+              <%= render "add_stock_button" %>
               <%= link_to "詳細を見る", item_path(item), class: "btn-secondary px-3 py-1.5" %>
             </div>
           </div>
+
+          <%= render "add_stock_modal", item: item %>
+          <%= render "finish_using_modal", item: item %>
+          <%= render "discontinue_using_modal", item: item %>
         </article>
       <% end %>
     </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -202,20 +202,17 @@
                     <button type="button" class="btn-danger px-2 py-1.5 text-xs leading-tight sm:px-3 sm:text-sm" data-disclosure-toggle data-disclosure-target="finish-using">
                       使い切る
                     </button>
-                    <%= link_to "在庫を追加",
-                                edit_item_path(item),
-                                class: "inline-flex items-center justify-center rounded-lg bg-yellow-500 px-2 py-1.5 text-center text-xs font-semibold leading-tight text-white transition hover:bg-amber-600 sm:px-3 sm:py-2 sm:text-sm" %>
+                    <%= render "add_stock_button",
+                               button_class: "inline-flex items-center justify-center rounded-lg bg-yellow-500 px-2 py-1.5 text-center text-xs font-semibold leading-tight text-white transition hover:bg-amber-600 sm:px-3 sm:py-2 sm:text-sm" %>
                   <% elsif item.stock_available? %>
                     <button type="button" class="btn-primary px-2 py-1.5 text-xs leading-tight sm:px-3 sm:text-sm" data-disclosure-toggle data-disclosure-target="start-using">
                       使い始める
                     </button>
-                    <%= link_to "在庫を追加",
-                                edit_item_path(item),
-                                class: "inline-flex items-center justify-center rounded-lg bg-yellow-500 px-2 py-1.5 text-center text-xs font-semibold leading-tight text-white transition hover:bg-amber-600 sm:px-3 sm:py-2 sm:text-sm" %>
+                    <%= render "add_stock_button",
+                               button_class: "inline-flex items-center justify-center rounded-lg bg-yellow-500 px-2 py-1.5 text-center text-xs font-semibold leading-tight text-white transition hover:bg-amber-600 sm:px-3 sm:py-2 sm:text-sm" %>
                   <% else %>
-                    <%= link_to "在庫を追加",
-                                edit_item_path(item),
-                                class: "inline-flex items-center justify-center rounded-lg bg-yellow-500 px-2 py-1.5 text-center text-xs font-semibold leading-tight text-white transition hover:bg-amber-600 sm:px-3 sm:py-2 sm:text-sm" %>
+                    <%= render "add_stock_button",
+                               button_class: "inline-flex items-center justify-center rounded-lg bg-yellow-500 px-2 py-1.5 text-center text-xs font-semibold leading-tight text-white transition hover:bg-amber-600 sm:px-3 sm:py-2 sm:text-sm" %>
                   <% end %>
                 </div>
 
@@ -231,6 +228,8 @@
           <% if item.stock_available? %>
             <%= render "start_using_modal", item: item %>
           <% end %>
+
+          <%= render "add_stock_modal", item: item %>
         </article>
       <% end %>
     </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -95,9 +95,8 @@
             <button type="button" class="btn-danger w-full" data-disclosure-toggle data-disclosure-target="finish-using">
               使い切る
             </button>
-            <%= link_to "在庫を追加",
-                        edit_item_path(@item),
-                        class: "inline-flex w-full items-center justify-center rounded-lg bg-yellow-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-600" %>
+            <%= render "add_stock_button",
+                       button_class: "inline-flex w-full items-center justify-center rounded-lg bg-yellow-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-600" %>
           </div>
 
           <%= render "finish_using_modal", item: @item %>
@@ -107,9 +106,8 @@
           <button type="button" class="btn-primary w-full" data-disclosure-toggle data-disclosure-target="start-using">
             使い始める
           </button>
-          <%= link_to "在庫を追加",
-                      edit_item_path(@item),
-                      class: "inline-flex w-full items-center justify-center rounded-lg bg-yellow-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-600" %>
+          <%= render "add_stock_button",
+                     button_class: "inline-flex w-full items-center justify-center rounded-lg bg-yellow-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-600" %>
         </div>
 
         <%= render "start_using_modal", item: @item %>
@@ -118,11 +116,12 @@
           <p class="text-sm font-medium text-red-700">
             在庫がないため、使用を開始できません。
           </p>
-          <%= link_to "在庫を追加",
-                      edit_item_path(@item),
-                      class: "inline-flex w-full items-center justify-center rounded-lg bg-yellow-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-600" %>
+          <%= render "add_stock_button",
+                     button_class: "inline-flex w-full items-center justify-center rounded-lg bg-yellow-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-600" %>
         </div>
       <% end %>
+
+      <%= render "add_stock_modal", item: @item %>
     </div>
 
     <div class="border-t border-slate-100 pt-5">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
       patch :finish_using
       get :discontinue_using_form, path: :discontinue_using
       patch :discontinue_using
+      patch :add_stock
       patch :toggle_favorite
       delete :image, action: :destroy_image
     end

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -170,15 +170,16 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_no_match items(:one).name, response.body
   end
 
-  test "index shows restock link for every item" do
+  test "index shows add stock modal for every item" do
     item = items(:one)
     out_of_stock_item = items(:two)
 
     get items_path
 
     assert_response :success
-    assert_select "a[href='#{edit_item_path(item)}']", text: "在庫を追加"
-    assert_select "a[href='#{edit_item_path(out_of_stock_item)}']", text: "在庫を追加"
+    assert_select "button[data-disclosure-target='add-stock']", text: "在庫を追加"
+    assert_select "form[action='#{add_stock_item_path(item)}'] input[name='quantity']"
+    assert_select "form[action='#{add_stock_item_path(out_of_stock_item)}'] input[name='quantity']"
   end
 
   test "index links item information to detail page and hides detail button on mobile" do
@@ -349,6 +350,28 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, item.reload.stock_quantity
   end
 
+  test "add_stock increases stock quantity" do
+    item = items(:two)
+
+    assert_difference -> { item.reload.stock_quantity }, 3 do
+      patch add_stock_item_path(item), params: { quantity: 3 }
+    end
+
+    assert_redirected_to items_path
+    assert_equal "在庫を追加しました", flash[:notice]
+  end
+
+  test "add_stock does not change stock quantity when quantity is invalid" do
+    item = items(:two)
+
+    assert_no_difference -> { item.reload.stock_quantity } do
+      patch add_stock_item_path(item), params: { quantity: 0 }
+    end
+
+    assert_redirected_to items_path
+    assert_equal "追加する個数を入力してください", flash[:alert]
+  end
+
   test "finish_using finishes current usage log and redirects to used-up page" do
     item = items(:one)
     item.start_using!(@user, Time.zone.local(2026, 5, 10))
@@ -503,24 +526,34 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to in_use_items_path
   end
 
-  test "in_use page has finish using link in item card" do
+  test "in_use page shows finish using modal in item card" do
     item = items(:one)
     item.start_using!(@user, Time.zone.local(2026, 5, 10))
 
     get in_use_items_path
 
     assert_response :success
-    assert_select "a[href='#{finish_using_form_item_path(item)}']", text: "使い切る"
+    assert_select "dt", text: "在庫数"
+    assert_select "button[data-disclosure-target='add-stock']", text: "在庫を追加"
+    assert_select "form[action='#{add_stock_item_path(item)}'] input[name='quantity']"
+    assert_includes response.body, "現在の在庫数"
+    assert_select "button[data-disclosure-target='finish-using']", text: "使い切る"
+    assert_select "form[action='#{finish_using_item_path(item)}'] input[name='finished_at']"
+    assert_select "form[action='#{finish_using_item_path(item)}'] input[name='usage_log_id']"
+    assert_select "button[data-disclosure-cancel]", text: "キャンセル"
   end
 
-  test "in_use page has discontinue using link in item card" do
+  test "in_use page shows discontinue using modal in item card" do
     item = items(:one)
     item.start_using!(@user, Time.zone.local(2026, 5, 10))
 
     get in_use_items_path
 
     assert_response :success
-    assert_select "a[href='#{discontinue_using_form_item_path(item)}']", text: "使用を中止する"
+    assert_select "button[data-disclosure-target='discontinue-using']", text: "使用を中止する"
+    assert_select "form[action='#{discontinue_using_item_path(item)}'] input[name='finished_at']"
+    assert_select "form[action='#{discontinue_using_item_path(item)}'] textarea[name='discontinued_reason']"
+    assert_select "button[data-disclosure-cancel]", text: "キャンセル"
   end
 
   test "in_use page searches current user's usage logs by item name" do
@@ -1300,7 +1333,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "使い切り履歴が足りないため、まだ予測できません。"
   end
 
-  test "show highlights out of stock item and shows restock link" do
+  test "show highlights out of stock item and shows add stock modal" do
     item = items(:two)
 
     get item_path(item)
@@ -1308,16 +1341,18 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "span.bg-red-50", text: "在庫なし"
     assert_select "dd.text-red-700", text: item.stock_quantity.to_s
-    assert_select "a[href='#{edit_item_path(item)}']", text: "在庫を追加"
+    assert_select "button[data-disclosure-target='add-stock']", text: "在庫を追加"
+    assert_select "form[action='#{add_stock_item_path(item)}'] input[name='quantity']"
   end
 
-  test "show shows restock link for item with stock" do
+  test "show shows add stock modal for item with stock" do
     item = items(:one)
 
     get item_path(item)
 
     assert_response :success
-    assert_select "a[href='#{edit_item_path(item)}']", text: "在庫を追加"
+    assert_select "button[data-disclosure-target='add-stock']", text: "在庫を追加"
+    assert_select "form[action='#{add_stock_item_path(item)}'] input[name='quantity']"
   end
 
   test "update with invalid image rerenders edit page" do


### PR DESCRIPTION
## 概要
- 使用中一覧の「使い切る」「使用を中止する」を、別ページ遷移ではなくモーダル表示に変更
- 使用中一覧に在庫数を表示
- 「在庫を追加」を一覧・詳細・使用中一覧で共通のモーダル操作に変更
- 入力した個数だけ `stock_quantity` を増やす `add_stock` action を追加

## 背景
使用中一覧から操作するときに別ページへ移動してしまうと、一覧を見ながら作業する流れが途切れていました。
また「在庫を追加」は在庫を増やすためだけの操作なのに編集画面へ遷移しており、在庫数の確認や追加がしづらかったため、専用モーダルに揃えました。

## 確認
- `docker compose exec web bin/rails test test/controllers/items_controller_test.rb`
- `docker compose exec web bin/rails test`

Closes #145