### PR TITLE
編集画面で在庫数をステッパー調整できるようにする

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -38,6 +38,19 @@ document.addEventListener("submit", (event) => {
 })
 
 document.addEventListener("click", (event) => {
+  const stepperButton = event.target.closest("[data-stock-stepper-action]")
+  if (stepperButton) {
+    const stepper = stepperButton.closest("[data-stock-stepper]")
+    const input = stepper?.querySelector("[data-stock-stepper-input]")
+    if (!input) return
+
+    const currentValue = Number.parseInt(input.value || "0", 10)
+    const direction = stepperButton.dataset.stockStepperAction === "increment" ? 1 : -1
+    input.value = Math.max(0, currentValue + direction)
+    input.dispatchEvent(new Event("change", { bubbles: true }))
+    return
+  }
+
   const toggleButton = event.target.closest("[data-disclosure-toggle]")
   const cancelButton = event.target.closest("[data-disclosure-cancel]")
   const button = toggleButton || cancelButton

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -110,11 +110,29 @@
           <div class="alert-success hidden" data-upload-progress></div>
         </div>
 
-        <!-- 価格 -->
-        <div class="flex gap-4">
+        <!-- 価格・在庫数 -->
+        <div class="grid gap-4 sm:grid-cols-2">
           <div class="flex-1">
             <%= f.label :price, class: "form-label" %>
-            <%= f.text_field :price, class: "form-input", placeholder: "例: 1000" %>
+            <%= f.text_field :price, class: "form-input h-12", placeholder: "例: 1000" %>
+          </div>
+
+          <div>
+            <%= f.label :stock_quantity, "在庫数", class: "form-label" %>
+            <div class="grid grid-cols-[3rem_minmax(0,1fr)_3rem] overflow-hidden rounded-lg border border-slate-300 bg-white focus-within:border-emerald-500 focus-within:ring-2 focus-within:ring-emerald-100" data-stock-stepper>
+              <button type="button" class="flex h-12 items-center justify-center border-r border-slate-200 text-xl font-semibold text-slate-600 transition hover:bg-slate-50" data-stock-stepper-action="decrement" aria-label="在庫数を1減らす">
+                -
+              </button>
+              <%= f.number_field :stock_quantity,
+                                 min: 0,
+                                 step: 1,
+                                 class: "h-12 w-full border-0 bg-white text-center text-base font-semibold text-slate-900 focus:ring-0",
+                                 data: { stock_stepper_input: true } %>
+              <button type="button" class="flex h-12 items-center justify-center border-l border-slate-200 text-xl font-semibold text-emerald-700 transition hover:bg-emerald-50" data-stock-stepper-action="increment" aria-label="在庫数を1増やす">
+                +
+              </button>
+            </div>
+            <p class="form-help">手元の数に合わせて調整できます。</p>
           </div>
         </div>
 

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -1032,6 +1032,19 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-submit-loading]", text: "アイテム情報を更新しています..."
   end
 
+  test "edit page has stock quantity stepper" do
+    item = items(:one)
+
+    get edit_item_path(item)
+
+    assert_response :success
+    assert_select "label[for='item_stock_quantity']", text: "在庫数"
+    assert_select "[data-stock-stepper]"
+    assert_select "button[data-stock-stepper-action='decrement'][aria-label='在庫数を1減らす']", text: "-"
+    assert_select "input[name='item[stock_quantity]'][min='0'][step='1'][value='#{item.stock_quantity}'][data-stock-stepper-input]"
+    assert_select "button[data-stock-stepper-action='increment'][aria-label='在庫数を1増やす']", text: "+"
+  end
+
   test "edit page image input supports camera capture" do
     get edit_item_path(items(:one))
 
@@ -1181,6 +1194,21 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to items_path
     assert_equal "ものログコスメ", item.reload.brand_name
+  end
+
+  test "update changes stock quantity" do
+    item = items(:one)
+
+    patch item_path(item), params: {
+      item: {
+        name: item.name,
+        price: item.price,
+        stock_quantity: 4
+      }
+    }
+
+    assert_redirected_to items_path
+    assert_equal 4, item.reload.stock_quantity
   end
 
   test "update creates new category and assigns it to item" do


### PR DESCRIPTION
## 概要
- アイテム編集画面に在庫数欄を追加
- + / - ボタンで在庫数を1ずつ増減できるステッパーUIを追加
- 在庫数が0未満にならないようにJS側で制御
- 保存時に `stock_quantity` が更新されることをテストで確認

## 確認
- `docker compose exec web bin/rails test test/controllers/items_controller_test.rb`
- `docker compose exec web bin/rails test`

Closes #204