### PR TITLE
使い切り履歴の評価・レビュー絞り込みを追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -45,12 +45,18 @@ class ItemsController < ApplicationController
     @page_title = "使い切り"
     @search_query = params[:q].to_s.strip
     @selected_category_id = params[:category_id].to_s
+    @selected_rating = params[:rating].to_s
+    @selected_rating_status = params[:rating_status].to_s
+    @selected_review_status = params[:review_status].to_s
     @categories = current_user.categories.order(:name)
     finished_usage_logs = current_user.usage_logs
                                       .finished
                                       .used_up_history
                                       .by_item_name(@search_query)
                                       .by_item_category(@selected_category_id)
+                                      .by_rating(@selected_rating)
+                                      .by_rating_status(@selected_rating_status)
+                                      .by_review_status(@selected_review_status)
                                       .includes(:item)
                                       .order(finished_at: :desc)
     @usage_logs = Kaminari.paginate_array(

--- a/app/models/usage_log.rb
+++ b/app/models/usage_log.rb
@@ -18,6 +18,26 @@ class UsageLog < ApplicationRecord
 
     where(rating: rating)
   }
+  scope :by_rating_status, ->(status) {
+    case status
+    when "rated"
+      where.not(rating: nil)
+    when "unrated"
+      where(rating: nil)
+    else
+      all
+    end
+  }
+  scope :by_review_status, ->(status) {
+    case status
+    when "reviewed"
+      where.not(review: nil).where.not(review: "")
+    when "unreviewed"
+      where(review: [nil, ""])
+    else
+      all
+    end
+  }
   scope :by_item_name, ->(query) {
     return all if query.blank?
 

--- a/app/views/items/used_up.html.erb
+++ b/app/views/items/used_up.html.erb
@@ -3,10 +3,18 @@
              url: used_up_items_path,
              query: @search_query,
              hidden_params: {
-               category_id: @selected_category_id.presence
+               category_id: @selected_category_id.presence,
+               rating: @selected_rating.presence,
+               rating_status: @selected_rating_status.presence,
+               review_status: @selected_review_status.presence
              },
              show_reset: @search_query.present?,
-             reset_url: used_up_items_path(category_id: @selected_category_id.presence) %>
+             reset_url: used_up_items_path(
+               category_id: @selected_category_id.presence,
+               rating: @selected_rating.presence,
+               rating_status: @selected_rating_status.presence,
+               review_status: @selected_review_status.presence
+             ) %>
 
   <%= render "shared/history_tabs" %>
 
@@ -20,7 +28,10 @@
         <section>
           <h3 class="mb-3 text-xs font-bold uppercase tracking-wide text-slate-400">Category</h3>
     <% category_filter_params = {
-      q: @search_query.presence
+      q: @search_query.presence,
+      rating: @selected_rating.presence,
+      rating_status: @selected_rating_status.presence,
+      review_status: @selected_review_status.presence
     } %>
           <div class="grid gap-2">
             <%= link_to "すべて",
@@ -34,6 +45,65 @@
             <%= link_to "未設定",
                         used_up_items_path(category_filter_params.merge(category_id: "uncategorized")),
                         class: category_filter_class(@selected_category_id, "uncategorized") %>
+          </div>
+        </section>
+
+        <section>
+          <h3 class="mb-3 text-xs font-bold uppercase tracking-wide text-slate-400">Rating</h3>
+    <% rating_status_filter_params = {
+      q: @search_query.presence,
+      category_id: @selected_category_id.presence,
+      review_status: @selected_review_status.presence
+    } %>
+          <div class="grid gap-2">
+            <%= link_to "すべて",
+                        used_up_items_path(rating_status_filter_params),
+                        class: category_filter_class(@selected_rating_status.presence || @selected_rating.presence, nil) %>
+            <%= link_to "評価あり",
+                        used_up_items_path(rating_status_filter_params.merge(rating_status: "rated")),
+                        class: category_filter_class(@selected_rating_status, "rated") %>
+            <%= link_to "評価なし",
+                        used_up_items_path(rating_status_filter_params.merge(rating_status: "unrated")),
+                        class: category_filter_class(@selected_rating_status, "unrated") %>
+          </div>
+        </section>
+
+        <section>
+          <h3 class="mb-3 text-xs font-bold uppercase tracking-wide text-slate-400">Stars</h3>
+    <% rating_filter_params = {
+      q: @search_query.presence,
+      category_id: @selected_category_id.presence,
+      review_status: @selected_review_status.presence
+    } %>
+          <div class="grid gap-2">
+            <% 5.downto(1) do |rating| %>
+              <%= link_to used_up_items_path(rating_filter_params.merge(rating: rating)),
+                          class: category_filter_class(@selected_rating, rating) do %>
+                <span aria-hidden="true">⭐️</span>
+                <span class="font-sans font-bold"><%= rating %></span>
+              <% end %>
+            <% end %>
+          </div>
+        </section>
+
+        <section>
+          <h3 class="mb-3 text-xs font-bold uppercase tracking-wide text-slate-400">Review</h3>
+    <% review_filter_params = {
+      q: @search_query.presence,
+      category_id: @selected_category_id.presence,
+      rating: @selected_rating.presence,
+      rating_status: @selected_rating_status.presence
+    } %>
+          <div class="grid gap-2">
+            <%= link_to "すべて",
+                        used_up_items_path(review_filter_params),
+                        class: category_filter_class(@selected_review_status, nil) %>
+            <%= link_to "レビューあり",
+                        used_up_items_path(review_filter_params.merge(review_status: "reviewed")),
+                        class: category_filter_class(@selected_review_status, "reviewed") %>
+            <%= link_to "レビューなし",
+                        used_up_items_path(review_filter_params.merge(review_status: "unreviewed")),
+                        class: category_filter_class(@selected_review_status, "unreviewed") %>
           </div>
         </section>
   <% end %>
@@ -98,7 +168,7 @@
     </div>
   <% else %>
     <div class="ui-empty-state">
-      <% if @search_query.present? %>
+      <% if @search_query.present? || @selected_category_id.present? || @selected_rating.present? || @selected_rating_status.present? || @selected_review_status.present? %>
         <p class="text-lg">条件に合う使い切り履歴がありません</p>
         <p class="mt-2 text-sm">検索条件を変更して、もう一度お試しください。</p>
         <%= link_to "検索条件をリセット", used_up_items_path, class: "btn-secondary mt-5" %>

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -956,6 +956,86 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_no_match items(:one).name, response.body
   end
 
+  test "used_up page filters usage logs by rating status" do
+    rated_item = items(:one)
+    rated_item.start_using!(@user, Time.zone.local(2026, 5, 10))
+    rated_item.finish_using!(Time.zone.local(2026, 5, 12), rating: 4)
+    unrated_item = items(:two)
+    unrated_item.update!(stock_quantity: 1)
+    unrated_item.start_using!(@user, Time.zone.local(2026, 5, 11))
+    unrated_item.finish_using!(Time.zone.local(2026, 5, 13))
+
+    get used_up_items_path, params: { rating_status: "rated" }
+
+    assert_response :success
+    assert_includes response.body, rated_item.name
+    assert_no_match unrated_item.name, response.body
+    assert_select "a.bg-emerald-600[href='#{used_up_items_path(rating_status: "rated")}']", text: "評価あり"
+
+    get used_up_items_path, params: { rating_status: "unrated" }
+
+    assert_response :success
+    assert_includes response.body, unrated_item.name
+    assert_no_match rated_item.name, response.body
+  end
+
+  test "used_up page filters usage logs by rating" do
+    matching_item = items(:one)
+    matching_item.start_using!(@user, Time.zone.local(2026, 5, 10))
+    matching_item.finish_using!(Time.zone.local(2026, 5, 12), rating: 4)
+    other_item = items(:two)
+    other_item.update!(stock_quantity: 1)
+    other_item.start_using!(@user, Time.zone.local(2026, 5, 11))
+    other_item.finish_using!(Time.zone.local(2026, 5, 13), rating: 5)
+
+    get used_up_items_path, params: { rating: "4" }
+
+    assert_response :success
+    assert_includes response.body, matching_item.name
+    assert_no_match other_item.name, response.body
+    assert_select "a.bg-emerald-600[href='#{used_up_items_path(rating: 4)}']", text: /⭐️\s*4/
+  end
+
+  test "used_up page filters usage logs by review status" do
+    reviewed_item = items(:one)
+    reviewed_item.start_using!(@user, Time.zone.local(2026, 5, 10))
+    reviewed_item.finish_using!(
+      Time.zone.local(2026, 5, 12),
+      rating: 4,
+      review: "また使いたい"
+    )
+    no_review_item = items(:two)
+    no_review_item.update!(stock_quantity: 1)
+    no_review_item.start_using!(@user, Time.zone.local(2026, 5, 11))
+    no_review_item.finish_using!(Time.zone.local(2026, 5, 13), rating: 5)
+
+    get used_up_items_path, params: { review_status: "reviewed" }
+
+    assert_response :success
+    assert_includes response.body, reviewed_item.name
+    assert_no_match no_review_item.name, response.body
+    assert_select "a.bg-emerald-600[href='#{used_up_items_path(review_status: "reviewed")}']", text: "レビューあり"
+
+    get used_up_items_path, params: { review_status: "unreviewed" }
+
+    assert_response :success
+    assert_includes response.body, no_review_item.name
+    assert_no_match reviewed_item.name, response.body
+  end
+
+  test "used_up page search form keeps selected rating and review filters" do
+    get used_up_items_path, params: {
+      rating: "4",
+      rating_status: "rated",
+      review_status: "reviewed"
+    }
+
+    assert_response :success
+    assert_select "input[type='hidden'][name='rating'][value='4']"
+    assert_select "input[type='hidden'][name='rating_status'][value='rated']"
+    assert_select "input[type='hidden'][name='review_status'][value='reviewed']"
+  end
+
   test "used_up page keeps search and category filters in pagination links" do
     category = categories(:hair_care)
     11.times do |number|
@@ -978,6 +1058,35 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
       page: 2,
       q: "検索対象",
       category_id: category.id
+    )}']"
+  end
+
+  test "used_up page keeps rating and review filters in pagination links" do
+    11.times do |number|
+      item = @user.items.create!(
+        name: "レビュー検索対象#{number}",
+        stock_quantity: 1
+      )
+      item.start_using!(@user, Time.zone.local(2026, 5, 10))
+      item.finish_using!(
+        Time.zone.local(2026, 5, 12),
+        rating: 4,
+        review: "また使いたい"
+      )
+    end
+
+    get used_up_items_path, params: {
+      q: "レビュー検索対象",
+      rating: "4",
+      review_status: "reviewed"
+    }
+
+    assert_response :success
+    assert_select "a[href='#{used_up_items_path(
+      page: 2,
+      q: "レビュー検索対象",
+      rating: "4",
+      review_status: "reviewed"
     )}']"
   end
 

--- a/test/models/usage_log_test.rb
+++ b/test/models/usage_log_test.rb
@@ -87,6 +87,78 @@ class UsageLogTest < ActiveSupport::TestCase
     assert_not_includes UsageLog.rated, unrated_log
   end
 
+  test "by_rating_status filters rated usage logs" do
+    rated_log = @item.usage_logs.create!(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 10),
+      finished_at: Time.zone.local(2026, 5, 12),
+      rating: 4
+    )
+    unrated_log = @item.usage_logs.create!(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 13),
+      finished_at: Time.zone.local(2026, 5, 15)
+    )
+
+    assert_includes UsageLog.by_rating_status("rated"), rated_log
+    assert_not_includes UsageLog.by_rating_status("rated"), unrated_log
+  end
+
+  test "by_rating_status filters unrated usage logs" do
+    rated_log = @item.usage_logs.create!(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 10),
+      finished_at: Time.zone.local(2026, 5, 12),
+      rating: 4
+    )
+    unrated_log = @item.usage_logs.create!(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 13),
+      finished_at: Time.zone.local(2026, 5, 15)
+    )
+
+    assert_includes UsageLog.by_rating_status("unrated"), unrated_log
+    assert_not_includes UsageLog.by_rating_status("unrated"), rated_log
+  end
+
+  test "by_review_status filters reviewed usage logs" do
+    reviewed_log = @item.usage_logs.create!(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 10),
+      finished_at: Time.zone.local(2026, 5, 12),
+      rating: 4,
+      review: "また使いたい"
+    )
+    no_review_log = @item.usage_logs.create!(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 13),
+      finished_at: Time.zone.local(2026, 5, 15),
+      rating: 5
+    )
+
+    assert_includes UsageLog.by_review_status("reviewed"), reviewed_log
+    assert_not_includes UsageLog.by_review_status("reviewed"), no_review_log
+  end
+
+  test "by_review_status filters usage logs without review" do
+    reviewed_log = @item.usage_logs.create!(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 10),
+      finished_at: Time.zone.local(2026, 5, 12),
+      rating: 4,
+      review: "また使いたい"
+    )
+    no_review_log = @item.usage_logs.create!(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 13),
+      finished_at: Time.zone.local(2026, 5, 15),
+      rating: 5
+    )
+
+    assert_includes UsageLog.by_review_status("unreviewed"), no_review_log
+    assert_not_includes UsageLog.by_review_status("unreviewed"), reviewed_log
+  end
+
   test "review requires rating" do
     usage_log = @item.usage_logs.build(
       user: @user,


### PR DESCRIPTION
## 概要
- 使い切り履歴に評価あり/なし、星評価、レビューあり/なしの絞り込みを追加
- 絞り込み条件を検索フォームやページネーションに引き継ぐように調整
- UsageLog の絞り込み scope と関連テストを追加

## 確認
- `docker compose exec web bin/rails test test/models/usage_log_test.rb test/controllers/items_controller_test.rb`
- `docker compose exec web bin/rails test`

Closes #114
