### PR TITLE
アイテム詳細に平均評価を表示する

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -102,6 +102,8 @@ class ItemsController < ApplicationController
 
   def show
     @item = current_user.items.find(params[:id]) # ログイン中のユーザーのアイテムを取得
+    @average_rating = @item.average_rating
+    @rating_count = @item.rating_count
   end
 
   def edit

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -60,6 +60,17 @@ class Item < ApplicationRecord
     (durations.sum.to_f / durations.size).round
   end
 
+  def average_rating
+    ratings = usage_logs.rated.pluck(:rating)
+    return if ratings.blank?
+
+    (ratings.sum.to_f / ratings.size).round(1)
+  end
+
+  def rating_count
+    usage_logs.rated.count
+  end
+
   def predicted_finish_date
     return unless using?
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -56,6 +56,23 @@
           <dt class="text-xs text-slate-500">ブランド名</dt>
           <dd class="mt-1 font-semibold text-slate-800"><%= @item.brand_name.presence || "未設定" %></dd>
         </div>
+
+        <div class="rounded-lg bg-slate-50 p-3">
+          <dt class="text-xs text-slate-500">平均評価</dt>
+          <dd class="mt-1 font-semibold text-slate-800">
+            <% if @average_rating.present? %>
+              <span class="text-yellow-500"><%= "★" * @average_rating.round %><span class="text-slate-300"><%= "☆" * (5 - @average_rating.round) %></span></span>
+              <span class="ml-1"><%= @average_rating %></span>
+            <% else %>
+              未評価
+            <% end %>
+          </dd>
+        </div>
+
+        <div class="rounded-lg bg-slate-50 p-3">
+          <dt class="text-xs text-slate-500">評価件数</dt>
+          <dd class="mt-1 font-semibold text-slate-800"><%= "#{@rating_count}件" %></dd>
+        </div>
       </dl>
     </div>
 

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -1433,6 +1433,36 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "ものログ製薬"
   end
 
+  test "show displays average rating and rating count" do
+    item = items(:one)
+    item.update!(stock_quantity: 3)
+    item.start_using!(@user, Time.zone.local(2026, 5, 1))
+    item.finish_using!(Time.zone.local(2026, 5, 10), rating: 5, review: "よかった")
+    item.start_using!(@user, Time.zone.local(2026, 5, 20))
+    item.finish_using!(Time.zone.local(2026, 5, 24), rating: 3)
+    item.start_using!(@user, Time.zone.local(2026, 6, 1))
+    item.finish_using!(Time.zone.local(2026, 6, 5))
+
+    get item_path(item)
+
+    assert_response :success
+    assert_includes response.body, "平均評価"
+    assert_includes response.body, "4.0"
+    assert_includes response.body, "評価件数"
+    assert_includes response.body, "2件"
+  end
+
+  test "show displays unrated message when item has no ratings" do
+    item = items(:one)
+
+    get item_path(item)
+
+    assert_response :success
+    assert_includes response.body, "平均評価"
+    assert_includes response.body, "未評価"
+    assert_includes response.body, "0件"
+  end
+
   test "show uses consistent finish using button label for in-use item" do
     item = items(:one)
     item.start_using!(@user, Time.zone.local(2026, 5, 10))

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -179,6 +179,30 @@ class ItemTest < ActiveSupport::TestCase
     assert_nil item.average_usage_days
   end
 
+  test "average_rating uses only usage logs with rating" do
+    item = items(:one)
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 1))
+    item.finish_using!(Time.zone.local(2026, 5, 10), rating: 5)
+    item.update!(stock_quantity: 1)
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 20))
+    item.finish_using!(Time.zone.local(2026, 5, 24), rating: 3)
+    item.update!(stock_quantity: 1)
+    item.start_using!(users(:one), Time.zone.local(2026, 6, 1))
+    item.finish_using!(Time.zone.local(2026, 6, 5))
+
+    assert_equal 4.0, item.average_rating
+    assert_equal 2, item.rating_count
+  end
+
+  test "average_rating returns nil when item has no ratings" do
+    item = items(:one)
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 1))
+    item.finish_using!(Time.zone.local(2026, 5, 10))
+
+    assert_nil item.average_rating
+    assert_equal 0, item.rating_count
+  end
+
   test "predicted_finish_date returns date from current usage start and average days" do
     item = items(:one)
     item.update!(stock_quantity: 2)


### PR DESCRIPTION
## 概要
- Item model に平均評価と評価件数を返すメソッドを追加
- アイテム詳細に平均評価、評価件数、未評価表示を追加
- 平均評価は rating がある usage_logs のみを対象にするようテストを追加

## 確認
- `docker compose exec web bin/rails test test/models/item_test.rb test/controllers/items_controller_test.rb`
- `docker compose exec web bin/rails test`

Closes #118
