### PR TITLE
レビュータブにアイテム平均評価を表示する

### DIFF
--- a/app/controllers/usage_logs_controller.rb
+++ b/app/controllers/usage_logs_controller.rb
@@ -27,6 +27,10 @@ class UsageLogsController < ApplicationController
                               .includes(:item)
                               .order(finished_at: :desc)
                               .page(params[:page])
+    reviewed_item_ids = @usage_logs.map(&:item_id)
+    rated_usage_logs = current_user.usage_logs.rated.where(item_id: reviewed_item_ids)
+    @average_ratings_by_item_id = rated_usage_logs.group(:item_id).average(:rating)
+    @rating_counts_by_item_id = rated_usage_logs.group(:item_id).count
   end
 
   def update

--- a/app/views/usage_logs/reviews.html.erb
+++ b/app/views/usage_logs/reviews.html.erb
@@ -67,6 +67,8 @@
     <div class="grid gap-3">
       <% @usage_logs.each do |usage_log| %>
         <% item = usage_log.item %>
+        <% average_rating = @average_ratings_by_item_id[item.id]&.round(1) %>
+        <% rating_count = @rating_counts_by_item_id[item.id].to_i %>
 
         <article class="border-b border-slate-200 bg-white py-3 shadow-none sm:rounded-lg sm:border sm:p-4 sm:shadow-sm">
           <div class="flex items-center gap-3">
@@ -94,9 +96,20 @@
                   </dd>
                 </div>
                 <div class="inline-flex items-center gap-1.5 rounded-lg bg-slate-50 px-2.5 py-1">
-                  <dt class="text-xs font-medium text-slate-500">評価</dt>
+                  <dt class="text-xs font-medium text-slate-500">今回の評価</dt>
                   <dd class="font-semibold text-yellow-500">
                     <%= "★" * usage_log.rating %><span class="text-slate-300"><%= "☆" * (5 - usage_log.rating) %></span>
+                  </dd>
+                </div>
+                <div class="inline-flex items-center gap-1.5 rounded-lg bg-slate-50 px-2.5 py-1 text-slate-700">
+                  <dt class="text-xs font-medium text-slate-500">平均</dt>
+                  <dd>
+                    <% if average_rating.present? %>
+                      <span class="text-yellow-500"><%= "★" * average_rating.round %><span class="text-slate-300"><%= "☆" * (5 - average_rating.round) %></span></span>
+                      <span class="ml-1"><%= average_rating %>（<%= rating_count %>件）</span>
+                    <% else %>
+                      <span class="text-slate-400">未評価</span>
+                    <% end %>
                   </dd>
                 </div>
               </dl>

--- a/test/controllers/usage_logs_controller_test.rb
+++ b/test/controllers/usage_logs_controller_test.rb
@@ -40,9 +40,41 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "a.bg-emerald-600[href='#{reviews_usage_logs_path}']", text: "レビュー"
     assert_includes response.body, @item.name
+    assert_includes response.body, "今回の評価"
     assert_select "dd", text: /★★★★\s*☆/
     assert_includes response.body, "また使いたい"
     assert_select "a[href='#{edit_usage_log_path(@usage_log)}']", text: "編集"
+  end
+
+  test "reviews shows item average rating and rating count" do
+    @item.update!(stock_quantity: 2)
+    @usage_log.update!(rating: 4, review: "また使いたい")
+    @item.start_using!(@user, Time.zone.local(2026, 5, 20))
+    @item.finish_using!(Time.zone.local(2026, 5, 25), rating: 5)
+
+    get reviews_usage_logs_path
+
+    assert_response :success
+    assert_includes response.body, "平均"
+    assert_includes response.body, "4.5"
+    assert_includes response.body, "2件"
+  end
+
+  test "reviews average rating does not include other user's ratings" do
+    @usage_log.update!(rating: 4, review: "また使いたい")
+    other_user = users(:two)
+    other_item = other_user.items.create!(
+      name: @item.name,
+      stock_quantity: 1
+    )
+    other_item.start_using!(other_user, Time.zone.local(2026, 5, 10))
+    other_item.finish_using!(Time.zone.local(2026, 5, 12), rating: 1)
+
+    get reviews_usage_logs_path
+
+    assert_response :success
+    assert_includes response.body, "4.0（1件）"
+    refute_includes response.body, "2.5（"
   end
 
   test "reviews shows rated usage log without review as no review" do


### PR DESCRIPTION
## 概要
- レビュータブで、各レビューの今回の評価に加えてアイテム全体の平均評価を表示
- 表示中レビューのアイテムIDをもとに平均評価と評価件数をまとめて取得
- 他ユーザーの評価が平均に混ざらないことをテストで確認

## 確認
- docker compose exec web bin/rails test test/controllers/usage_logs_controller_test.rb