### PR TITLE
使用開始日が不明な場合でも使用開始できるようにする

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -155,7 +155,7 @@ class ItemsController < ApplicationController
       return
     end
 
-    @item.start_using!(current_user, params[:started_at])
+    @item.start_using!(current_user, params[:started_at], started_at_unknown: params[:started_at_unknown].present?)
     redirect_to in_use_items_path, notice: "使用を開始しました"
   end
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -24,6 +24,13 @@ document.addEventListener("change", (event) => {
   }
 })
 
+document.addEventListener("change", (event) => {
+  if (!event.target.matches("[data-unknown-date-toggle]")) return
+
+  const dateInput = event.target.closest("form")?.querySelector("[data-unknown-date-field]")
+  if (dateInput) dateInput.disabled = event.target.checked
+})
+
 document.addEventListener("submit", (event) => {
   const form = event.target
   const submitLoading = form.querySelector("[data-submit-loading]")

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -73,6 +73,7 @@ class Item < ApplicationRecord
 
   def predicted_finish_date
     return unless using?
+    return if current_usage_log.started_at.blank?
 
     average_days = average_usage_days
     return if average_days.blank?
@@ -80,11 +81,11 @@ class Item < ApplicationRecord
     current_usage_log.started_at.to_date + (average_days - 1).days
   end
 
-  def start_using!(user, started_at)
+  def start_using!(user, started_at, started_at_unknown: false)
     transaction do
       usage_logs.create!(
         user: user,
-        started_at: started_at.presence || Time.current
+        started_at: started_at_unknown ? nil : (started_at.presence || Time.current)
       )
 
       decrement!(:stock_quantity)

--- a/app/models/usage_log.rb
+++ b/app/models/usage_log.rb
@@ -50,7 +50,6 @@ class UsageLog < ApplicationRecord
     joins(:item).where(items: { category_id: category_id })
   }
 
-  validates :started_at, presence: true
   validates :rating, inclusion: { in: 1..5 }, allow_nil: true
   validates :discontinued_reason, length: { maximum: 500 }, allow_blank: true
 

--- a/app/views/items/_start_using_modal.html.erb
+++ b/app/views/items/_start_using_modal.html.erb
@@ -3,15 +3,20 @@
 
   <div class="relative w-full max-w-sm rounded-lg bg-white p-5 shadow-xl">
     <div class="mb-4">
-      <p id="start-using-title-<%= item.id %>" class="brand-font text-lg font-bold text-slate-900">使い始め日を入力</p>
+      <p id="start-using-title-<%= item.id %>" class="brand-font text-lg font-bold text-slate-900">使用開始日を入力</p>
       <p class="mt-1 text-sm text-slate-500"><%= item.name %></p>
     </div>
 
     <%= form_with url: start_using_item_path(item), method: :patch, local: true, class: "space-y-4" do %>
       <div>
-        <%= label_tag :started_at, "使い始め日", class: "form-label" %>
-        <%= date_field_tag :started_at, Date.current, class: "form-input bg-white" %>
+        <%= label_tag :started_at, "使用開始日", class: "form-label" %>
+        <%= date_field_tag :started_at, Date.current, class: "form-input bg-white disabled:bg-slate-100 disabled:text-slate-400", data: { unknown_date_field: true } %>
       </div>
+
+      <label class="flex items-center gap-2 text-sm text-slate-700">
+        <%= check_box_tag :started_at_unknown, "1", false, data: { unknown_date_toggle: true } %>
+        使用開始日がわからない
+      </label>
 
       <div class="grid gap-2">
         <%= submit_tag "この日から使う", class: "btn-primary w-full cursor-pointer" %>

--- a/db/migrate/20260714000000_change_usage_logs_started_at_to_optional.rb
+++ b/db/migrate/20260714000000_change_usage_logs_started_at_to_optional.rb
@@ -1,0 +1,5 @@
+class ChangeUsageLogsStartedAtToOptional < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :usage_logs, :started_at, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_24_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_14_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -70,7 +70,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_24_000000) do
   end
 
   create_table "usage_logs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "started_at", null: false
+    t.datetime "started_at"
     t.datetime "finished_at"
     t.integer "rating"
     t.text "review"

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -327,6 +327,17 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, item.reload.stock_quantity
   end
 
+  test "start_using with started_at_unknown creates usage log without started_at" do
+    item = items(:one)
+
+    assert_difference -> { item.usage_logs.count }, 1 do
+      patch start_using_item_path(item), params: { started_at: "2026-05-12", started_at_unknown: "1" }
+    end
+
+    assert_redirected_to in_use_items_path
+    assert_nil item.reload.current_usage_log.started_at
+  end
+
   test "start_using does not create usage log when stock is empty" do
     item = items(:two)
 

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -40,6 +40,14 @@ class ItemTest < ActiveSupport::TestCase
     assert_equal users(:one), item.current_usage_log.user
   end
 
+  test "start_using! with started_at_unknown creates usage log without started_at" do
+    item = items(:one)
+
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 12), started_at_unknown: true)
+
+    assert_nil item.current_usage_log.started_at
+  end
+
   test "finish_using! finishes current usage log" do
     item = items(:one)
     item.start_using!(users(:one), Time.zone.local(2026, 5, 10))
@@ -224,6 +232,16 @@ class ItemTest < ActiveSupport::TestCase
   test "predicted_finish_date returns nil when used-up history is missing" do
     item = items(:one)
     item.start_using!(users(:one), Time.zone.local(2026, 6, 1))
+
+    assert_nil item.predicted_finish_date
+  end
+
+  test "predicted_finish_date returns nil when current usage started_at is unknown" do
+    item = items(:one)
+    item.update!(stock_quantity: 2)
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 1))
+    item.finish_using!(Time.zone.local(2026, 5, 10))
+    item.start_using!(users(:one), Time.zone.local(2026, 6, 1), started_at_unknown: true)
 
     assert_nil item.predicted_finish_date
   end

--- a/test/models/usage_log_test.rb
+++ b/test/models/usage_log_test.rb
@@ -204,6 +204,15 @@ class UsageLogTest < ActiveSupport::TestCase
     assert usage_log.valid?
   end
 
+  test "usage log is valid without started_at" do
+    usage_log = @item.usage_logs.build(
+      user: @user,
+      started_at: nil
+    )
+
+    assert usage_log.valid?
+  end
+
   test "usage log accepts used up finish reason" do
     usage_log = @item.usage_logs.build(
       user: @user,


### PR DESCRIPTION
## 概要
使用開始画面で「使用開始日がわからない」を選べるようにし、開始日を空のまま使用開始を記録できるようにする。

Closes #218

## 変更内容
- `usage_logs.started_at` のNOT NULL制約を解除するマイグレーションを追加
- `UsageLog` の `started_at` presenceバリデーションを削除
- `Item#start_using!` に `started_at_unknown:` オプションを追加し、指定時は `started_at` を `nil` で保存
- `Item#predicted_finish_date` は開始日不明の使用中ログがある場合 `nil` を返す（計算不能なため）
- 使用開始モーダルに「使用開始日がわからない」チェックボックスを追加し、チェック時は日付入力欄をdisabled化

## 完了条件（issue #218より）
- [x] 「開始日不明」を選んで使用開始できる
- [x] 開始日不明の履歴が一覧・詳細画面で表示崩れなく確認できる（既存の `&.strftime(...) || "-"` 表示で対応済み）
- [x] 開始日不明の履歴が平均使用日数・使い切り予測に影響しない
- [x] 通常どおり開始日を指定する操作に影響がない
- [x] model / controller のテストが追加されている

## Test plan
- [x] `bin/rails test`（206 runs, 0 failures）