### PR TITLE
使用日数の計算ロジックをUsageLogモデルに集約する

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -52,7 +52,7 @@ class Item < ApplicationRecord
                 .finished
                 .used_up_history
                 .where.not(started_at: nil)
-                .map { |log| (log.finished_at.to_date - log.started_at.to_date).to_i + 1 }
+                .map(&:usage_days)
                 .select(&:positive?)
 
     return if durations.blank?

--- a/app/models/usage_log.rb
+++ b/app/models/usage_log.rb
@@ -64,6 +64,20 @@ class UsageLog < ApplicationRecord
     finished_at.present?
   end
 
+  # 使用開始から終了までの日数（開始日・終了日を含む）。日付が欠けている場合は nil
+  def usage_days
+    return if started_at.blank? || finished_at.blank?
+
+    (finished_at.to_date - started_at.to_date).to_i + 1
+  end
+
+  # 使用開始から今日までの経過日数（使用中の「◯日目」表示用）。開始日不明の場合は nil
+  def days_in_use
+    return if started_at.blank?
+
+    (Date.current - started_at.to_date).to_i + 1
+  end
+
   private
 
   def finished_at_must_be_after_started_at

--- a/app/views/items/discontinued.html.erb
+++ b/app/views/items/discontinued.html.erb
@@ -71,8 +71,8 @@
                 <div class="inline-flex items-center gap-1.5 rounded-lg bg-slate-50 px-2.5 py-1 text-slate-700">
                   <dt class="text-xs font-medium text-slate-500">使用期間</dt>
                   <dd>
-                    <% if usage_log.started_at.present? && usage_log.finished_at.present? %>
-                      <%= "#{(usage_log.finished_at.to_date - usage_log.started_at.to_date).to_i + 1}日" %>
+                    <% if usage_log.usage_days %>
+                      <%= "#{usage_log.usage_days}日" %>
                     <% else %>
                       -
                     <% end %>

--- a/app/views/items/in_use.html.erb
+++ b/app/views/items/in_use.html.erb
@@ -49,8 +49,8 @@
                 <div>
                   <dt class="text-xs text-slate-500">使用日数</dt>
                   <dd class="mt-1 text-slate-700">
-                    <% if usage_log.started_at.present? %>
-                      <%= "#{(Date.current - usage_log.started_at.to_date).to_i + 1}日目" %>
+                    <% if usage_log.days_in_use %>
+                      <%= "#{usage_log.days_in_use}日目" %>
                     <% else %>
                       -
                     <% end %>

--- a/app/views/items/used_up.html.erb
+++ b/app/views/items/used_up.html.erb
@@ -141,8 +141,8 @@
                 <div class="inline-flex items-center gap-1.5 rounded-lg bg-slate-50 px-2.5 py-1 text-slate-700">
                   <dt class="text-xs font-medium text-slate-500">使用期間</dt>
                   <dd>
-                    <% if usage_log.started_at.present? && usage_log.finished_at.present? %>
-                      <%= "#{(usage_log.finished_at.to_date - usage_log.started_at.to_date).to_i + 1}日" %>
+                    <% if usage_log.usage_days %>
+                      <%= "#{usage_log.usage_days}日" %>
                     <% else %>
                       -
                     <% end %>

--- a/app/views/usage_logs/show.html.erb
+++ b/app/views/usage_logs/show.html.erb
@@ -47,8 +47,8 @@
         <div class="rounded-lg bg-slate-50 p-3">
           <dt class="text-xs text-slate-500">使用期間</dt>
           <dd class="mt-1 font-semibold text-slate-800">
-            <% if @usage_log.started_at.present? && @usage_log.finished_at.present? %>
-              <%= "#{(@usage_log.finished_at.to_date - @usage_log.started_at.to_date).to_i + 1}日" %>
+            <% if @usage_log.usage_days %>
+              <%= "#{@usage_log.usage_days}日" %>
             <% else %>
               -
             <% end %>

--- a/test/models/usage_log_test.rb
+++ b/test/models/usage_log_test.rb
@@ -204,6 +204,53 @@ class UsageLogTest < ActiveSupport::TestCase
     assert usage_log.valid?
   end
 
+  test "usage_days returns days including both start and finish dates" do
+    usage_log = @item.usage_logs.build(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 1),
+      finished_at: Time.zone.local(2026, 5, 10)
+    )
+
+    assert_equal 10, usage_log.usage_days
+  end
+
+  test "usage_days returns nil when started_at is missing" do
+    usage_log = @item.usage_logs.build(
+      user: @user,
+      started_at: nil,
+      finished_at: Time.zone.local(2026, 5, 10)
+    )
+
+    assert_nil usage_log.usage_days
+  end
+
+  test "usage_days returns nil when finished_at is missing" do
+    usage_log = @item.usage_logs.build(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 1)
+    )
+
+    assert_nil usage_log.usage_days
+  end
+
+  test "days_in_use returns elapsed days including the start date" do
+    usage_log = @item.usage_logs.build(
+      user: @user,
+      started_at: 2.days.ago
+    )
+
+    assert_equal 3, usage_log.days_in_use
+  end
+
+  test "days_in_use returns nil when started_at is missing" do
+    usage_log = @item.usage_logs.build(
+      user: @user,
+      started_at: nil
+    )
+
+    assert_nil usage_log.days_in_use
+  end
+
   test "usage log is valid without started_at" do
     usage_log = @item.usage_logs.build(
       user: @user,


### PR DESCRIPTION
## 概要
ビュー4箇所とモデル1箇所に散らばっていた使用日数の計算式を、`UsageLog` のメソッドに集約する。

Closes #224

## 変更内容
- `UsageLog#usage_days` を追加（使用開始〜終了の日数。開始日・終了日を含む。日付が欠けていれば nil）
- `UsageLog#days_in_use` を追加（使用開始〜今日の経過日数。「◯日目」表示用。開始日不明なら nil）
- ビュー4ファイル（used_up / discontinued / in_use / usage_logs/show）の計算式をメソッド呼び出しに置き換え
- `Item#average_usage_days` の計算式を `usage_days` 呼び出しに置き換え
- model テスト5件を追加（正常計算・日付欠落時の nil）

## 完了条件（issue #224より）
- [x] 各画面の日数表示が現状と変わらない
- [x] 計算式の記述がモデル1箇所になっている
- [x] model のテストが追加されている

## Test plan
- [x] `bin/rails test`（212 runs, 0 failures）