### PR TITLE
一覧系アクションの絞り込みパラメータ設定を共通化する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,4 +12,17 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :email])
   end
+
+  private
+
+  def set_categories
+    @categories = current_user.categories.order(:name)
+  end
+
+  # 一覧画面共通の検索・カテゴリ絞り込みパラメータを設定する
+  def set_filter_params
+    set_categories
+    @search_query = params[:q].to_s.strip
+    @selected_category_id = params[:category_id].to_s
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,17 +1,15 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_categories, only: %i[new create edit update]
+  before_action :set_filter_params, only: %i[index in_use used_up discontinued]
   before_action :set_item, only: %i[show edit update destroy destroy_image toggle_favorite
                                     start_using finish_using_form finish_using
                                     discontinue_using_form discontinue_using add_stock]
 
   def index
     @items = current_user.items.visible.includes(:category).order(created_at: :desc)
-    @search_query = params[:q].to_s.strip
-    @selected_category_id = params[:category_id].to_s
     @selected_status = params[:status].to_s
     @selected_favorite = params[:favorite].to_s
-    @categories = current_user.categories.order(:name)
     @items = @items.by_name(@search_query)
                    .by_category(@selected_category_id)
     @items = @items.where(favorite: true) if @selected_favorite == "1"
@@ -32,9 +30,6 @@ class ItemsController < ApplicationController
 
   def in_use
     @page_title = "使用中アイテム"
-    @search_query = params[:q].to_s.strip
-    @selected_category_id = params[:category_id].to_s
-    @categories = current_user.categories.order(:name)
     @usage_logs = current_user.usage_logs
                               .in_use
                               .by_item_name(@search_query)
@@ -46,12 +41,9 @@ class ItemsController < ApplicationController
 
   def used_up
     @page_title = "使い切り"
-    @search_query = params[:q].to_s.strip
-    @selected_category_id = params[:category_id].to_s
     @selected_rating = params[:rating].to_s
     @selected_rating_status = params[:rating_status].to_s
     @selected_review_status = params[:review_status].to_s
-    @categories = current_user.categories.order(:name)
     finished_usage_logs = current_user.usage_logs
                                       .finished
                                       .used_up_history
@@ -74,9 +66,6 @@ class ItemsController < ApplicationController
 
   def discontinued
     @page_title = "使用中止"
-    @search_query = params[:q].to_s.strip
-    @selected_category_id = params[:category_id].to_s
-    @categories = current_user.categories.order(:name)
     @usage_logs = current_user.usage_logs
                               .finished
                               .discontinued
@@ -237,10 +226,6 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:name, :brand_name, :price, :stock_quantity, :favorite, :memo, :image)
-  end
-
-  def set_categories
-    @categories = current_user.categories.order(:name)
   end
 
   def assign_category(item)

--- a/app/controllers/usage_logs_controller.rb
+++ b/app/controllers/usage_logs_controller.rb
@@ -2,6 +2,7 @@ class UsageLogsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_usage_log, only: %i[show edit update]
   before_action :set_discontinued_usage_log, only: %i[edit_discontinued_reason update_discontinued_reason]
+  before_action :set_filter_params, only: %i[reviews]
 
   def show
   end
@@ -14,10 +15,7 @@ class UsageLogsController < ApplicationController
 
   def reviews
     @page_title = "レビュー"
-    @search_query = params[:q].to_s.strip
-    @selected_category_id = params[:category_id].to_s
     @selected_rating = params[:rating].to_s
-    @categories = current_user.categories.order(:name)
     @usage_logs = current_user.usage_logs
                               .finished
                               .rated


### PR DESCRIPTION
## 概要
5つの一覧アクションで重複していた検索・カテゴリ絞り込みパラメータの設定処理を `ApplicationController` に共通化する。

Closes #225

## 変更内容
- `ApplicationController` に `set_filter_params`（`@search_query` / `@selected_category_id` / `@categories`）を追加
- `set_categories` を items_controller から `ApplicationController` へ移動
- `items#index / in_use / used_up / discontinued` と `usage_logs#reviews` を `before_action :set_filter_params` に統一
- アクション固有のパラメータ（status / favorite / rating 等）は各アクションに残置

## 完了条件（issue #225より）
- [x] 各一覧画面の検索・カテゴリ絞り込みが現状どおり動く
- [x] パラメータ設定の記述が1箇所になっている

## Test plan
- [x] `bin/rails test`（212 runs, 0 failures）