### PR TITLE
flashキーをnotice / alertに統一する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
-  add_flash_types :success, :danger
 
   # ログイン後の遷移先を設定
   def after_sign_in_path_for(resource)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -84,10 +84,10 @@ class ItemsController < ApplicationController
     @item = current_user.items.build(item_params)
 
     if assign_category(@item) && @item.save
-      redirect_to items_path, success: 'アイテムが作成されました。'
+      redirect_to items_path, notice: 'アイテムが作成されました。'
     else
       set_categories
-      flash.now[:danger] = 'アイテムの作成に失敗しました。'
+      flash.now[:alert] = 'アイテムの作成に失敗しました。'
       render :new, status: :unprocessable_content
     end
   end
@@ -113,7 +113,7 @@ class ItemsController < ApplicationController
 
   def destroy
     @item.destroy!
-    redirect_to items_path, success: 'アイテムが削除されました'
+    redirect_to items_path, notice: 'アイテムが削除されました'
   end
 
   def destroy_image

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,14 +39,11 @@
         <div class="mx-auto w-full max-w-5xl px-4 pt-4">
           <% flash.each do |message_type, message| %>
             <%
-              # Deviseのキーを共通の通知スタイルにマッピングする
               alert_class =
-                if message_type.to_s == 'notice' || message_type.to_s == 'success'
-                  'alert-success'
-                elsif message_type.to_s == 'alert' || message_type.to_s == 'danger'
-                  'alert-error'
-                else
-                  'alert-info'
+                case message_type.to_s
+                when 'notice' then 'alert-success'
+                when 'alert' then 'alert-error'
+                else 'alert-info'
                 end
             %>
             <div class="<%= alert_class %>" role="alert">


### PR DESCRIPTION
## 概要
混在していたflashキー（notice / alert / success / danger）をRails標準の notice / alert の2種に統一する。

Closes #228

## 変更内容
- `success:` 2箇所を `notice:` に、`flash.now[:danger]` を `flash.now[:alert]` に変更
- 不要になった `add_flash_types :success, :danger` を削除
- レイアウトのflash表示分岐をcase式に簡素化（表示スタイルは従来どおり）

## 完了条件（issue #228より）
- [x] 全ての通知メッセージが現状どおり表示される
- [x] コントローラのflashキーが notice / alert のみになっている

## Test plan
- [x] `bin/rails test`（212 runs, 0 failures）
- [x] `success` / `danger` キーの使用箇所が残っていないことをgrepで確認