### PR TITLE
日付表示のフォーマットをヘルパーに共通化する

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,6 +15,11 @@ module ApplicationHelper
     image_url(content_for?(:og_image) ? content_for(:og_image) : DEFAULT_OG_IMAGE)
   end
 
+  # 日付を「2026/5/1」形式で返す。nilの場合は「-」を返す
+  def format_date(date)
+    date&.strftime("%Y/%-m/%-d") || "-"
+  end
+
   def category_filter_class(selected_category_id, category_id)
     if selected_category_id.to_s == category_id.to_s
       "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white"

--- a/app/views/items/discontinued.html.erb
+++ b/app/views/items/discontinued.html.erb
@@ -65,7 +65,7 @@
                 <div class="inline-flex items-center gap-1.5 rounded-lg bg-slate-50 px-2.5 py-1 text-slate-700">
                   <dt class="text-xs font-medium text-slate-500">使用中止日</dt>
                   <dd>
-                    <%= usage_log.finished_at&.strftime("%Y/%-m/%-d") || "-" %>
+                    <%= format_date(usage_log.finished_at) %>
                   </dd>
                 </div>
                 <div class="inline-flex items-center gap-1.5 rounded-lg bg-slate-50 px-2.5 py-1 text-slate-700">

--- a/app/views/items/in_use.html.erb
+++ b/app/views/items/in_use.html.erb
@@ -42,7 +42,7 @@
                 <div>
                   <dt class="text-xs text-slate-500">使い始め日</dt>
                   <dd class="mt-1 text-slate-700">
-                    <%= usage_log.started_at&.strftime("%Y/%-m/%-d") || "-" %>
+                    <%= format_date(usage_log.started_at) %>
                   </dd>
                 </div>
 

--- a/app/views/items/used_up.html.erb
+++ b/app/views/items/used_up.html.erb
@@ -135,7 +135,7 @@
                 <div class="inline-flex items-center gap-1.5 rounded-lg bg-slate-50 px-2.5 py-1 text-slate-700">
                   <dt class="text-xs font-medium text-slate-500">使い切り日</dt>
                   <dd>
-                    <%= usage_log.finished_at&.strftime("%Y/%-m/%-d") || "-" %>
+                    <%= format_date(usage_log.finished_at) %>
                   </dd>
                 </div>
                 <div class="inline-flex items-center gap-1.5 rounded-lg bg-slate-50 px-2.5 py-1 text-slate-700">

--- a/app/views/usage_logs/reviews.html.erb
+++ b/app/views/usage_logs/reviews.html.erb
@@ -92,7 +92,7 @@
                 <div class="inline-flex items-center gap-1.5 rounded-lg bg-slate-50 px-2.5 py-1 text-slate-700">
                   <dt class="text-xs font-medium text-slate-500">使い切り日</dt>
                   <dd>
-                    <%= usage_log.finished_at&.strftime("%Y/%-m/%-d") || "-" %>
+                    <%= format_date(usage_log.finished_at) %>
                   </dd>
                 </div>
                 <div class="inline-flex items-center gap-1.5 rounded-lg bg-slate-50 px-2.5 py-1">

--- a/app/views/usage_logs/show.html.erb
+++ b/app/views/usage_logs/show.html.erb
@@ -33,14 +33,14 @@
         <div class="rounded-lg bg-slate-50 p-3">
           <dt class="text-xs text-slate-500">使い始め日</dt>
           <dd class="mt-1 font-semibold text-slate-800">
-            <%= @usage_log.started_at&.strftime("%Y/%-m/%-d") || "-" %>
+            <%= format_date(@usage_log.started_at) %>
           </dd>
         </div>
 
         <div class="rounded-lg bg-slate-50 p-3">
           <dt class="text-xs text-slate-500"><%= @usage_log.discontinued? ? "使用中止日" : "終了日" %></dt>
           <dd class="mt-1 font-semibold text-slate-800">
-            <%= @usage_log.finished_at&.strftime("%Y/%-m/%-d") || "-" %>
+            <%= format_date(@usage_log.finished_at) %>
           </dd>
         </div>
 


### PR DESCRIPTION
## 概要
ビュー6箇所に重複していた日付表示 `&.strftime("%Y/%-m/%-d") || "-"` を `format_date` ヘルパーに共通化する。

Closes #229

## 変更内容
- `ApplicationHelper#format_date` を追加（nilのときは「-」を返す）
- ビュー5ファイル・6箇所をヘルパー呼び出しに置き換え
- usage_logs 側のビューでも使うため、置き場所は ItemsHelper ではなく ApplicationHelper とした

## 完了条件（issue #229より）
- [x] 各画面の日付表示が現状と変わらない
- [x] フォーマットの記述が1箇所になっている

## Test plan
- [x] `bin/rails test`（212 runs, 0 failures）