### PR TITLE
カテゴリ割り当てロジックをコントローラからモデルへ移動する

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -83,7 +83,7 @@ class ItemsController < ApplicationController
   def create
     @item = current_user.items.build(item_params)
 
-    if assign_category(@item) && @item.save
+    if assign_category && @item.save
       redirect_to items_path, notice: 'アイテムが作成されました。'
     else
       set_categories
@@ -103,7 +103,7 @@ class ItemsController < ApplicationController
   def update
     @item.assign_attributes(item_params)
 
-    if assign_category(@item) && @item.save
+    if assign_category && @item.save
       redirect_to items_path, notice: 'アイテム情報を更新しました'
     else
       set_categories
@@ -228,30 +228,12 @@ class ItemsController < ApplicationController
     params.require(:item).permit(:name, :brand_name, :price, :stock_quantity, :favorite, :memo, :image)
   end
 
-  def assign_category(item)
-    category_name = params.dig(:item, :new_category_name).to_s.strip
-    category_id = params.dig(:item, :category_id)
-    remove_category = ActiveModel::Type::Boolean.new.cast(params.dig(:item, :remove_category))
-
-    item.new_category_name = category_name
-    item.remove_category = remove_category
-
-    if category_name.present?
-      category = current_user.categories.find_or_initialize_by(name: category_name)
-      unless category.save
-        category.errors[:name].each { |message| item.errors.add(:new_category_name, message) }
-        return false
-      end
-
-      item.category = category
-    elsif remove_category
-      item.category = nil
-    elsif category_id.present?
-      item.category = current_user.categories.find(category_id)
-    else
-      item.category = nil
-    end
-
-    true
+  def assign_category
+    @item.assign_category(
+      current_user,
+      category_id: params.dig(:item, :category_id),
+      new_category_name: params.dig(:item, :new_category_name),
+      remove_category: params.dig(:item, :remove_category)
+    )
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -81,6 +81,31 @@ class Item < ApplicationRecord
     current_usage_log.started_at.to_date + (average_days - 1).days
   end
 
+  # カテゴリを割り当てる。新規カテゴリ名があれば作成して設定し、
+  # 作成に失敗した場合は errors に引き継いで false を返す
+  def assign_category(user, category_id:, new_category_name:, remove_category:)
+    self.new_category_name = new_category_name.to_s.strip
+    self.remove_category = ActiveModel::Type::Boolean.new.cast(remove_category)
+
+    if self.new_category_name.present?
+      new_category = user.categories.find_or_initialize_by(name: self.new_category_name)
+      unless new_category.save
+        new_category.errors[:name].each { |message| errors.add(:new_category_name, message) }
+        return false
+      end
+
+      self.category = new_category
+    elsif self.remove_category
+      self.category = nil
+    elsif category_id.present?
+      self.category = user.categories.find(category_id)
+    else
+      self.category = nil
+    end
+
+    true
+  end
+
   def start_using!(user, started_at, started_at_unknown: false)
     transaction do
       usage_logs.create!(

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -40,6 +40,67 @@ class ItemTest < ActiveSupport::TestCase
     assert_equal users(:one), item.current_usage_log.user
   end
 
+  test "assign_category creates and assigns a new category by name" do
+    item = items(:one)
+    user = users(:one)
+
+    assert_difference -> { user.categories.count }, 1 do
+      assert item.assign_category(user, category_id: nil, new_category_name: "日用品", remove_category: nil)
+    end
+    assert_equal "日用品", item.category.name
+  end
+
+  test "assign_category reuses an existing category with the same name" do
+    item = items(:one)
+    user = users(:one)
+    existing = user.categories.create!(name: "日用品")
+
+    assert_no_difference -> { user.categories.count } do
+      assert item.assign_category(user, category_id: nil, new_category_name: "日用品", remove_category: nil)
+    end
+    assert_equal existing, item.category
+  end
+
+  test "assign_category returns false and adds error when new category name is invalid" do
+    item = items(:one)
+    user = users(:one)
+
+    assert_not item.assign_category(user, category_id: nil, new_category_name: "あ" * 21, remove_category: nil)
+    assert item.errors[:new_category_name].any?
+  end
+
+  test "assign_category removes category when remove_category is set" do
+    item = items(:one)
+    item.update!(category: categories(:hair_care))
+
+    assert item.assign_category(users(:one), category_id: nil, new_category_name: nil, remove_category: "1")
+    assert_nil item.category
+  end
+
+  test "assign_category assigns category by id scoped to the user" do
+    item = items(:one)
+
+    assert item.assign_category(users(:one), category_id: categories(:hair_care).id, new_category_name: nil, remove_category: nil)
+    assert_equal categories(:hair_care), item.category
+  end
+
+  test "assign_category raises for another user's category id" do
+    item = items(:one)
+    other_category = users(:two).categories.create!(name: "他ユーザーカテゴリ")
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      item.assign_category(users(:one), category_id: other_category.id, new_category_name: nil, remove_category: nil)
+    end
+  end
+
+  test "assign_category clears category when nothing is given" do
+    item = items(:one)
+    item.update!(category: categories(:hair_care))
+
+    assert item.assign_category(users(:one), category_id: nil, new_category_name: nil, remove_category: nil)
+    assert_nil item.category
+  end
+
   test "start_using! with started_at_unknown creates usage log without started_at" do
     item = items(:one)
 


### PR DESCRIPTION
## 概要
items_controller の `assign_category`（新規作成・付け替え・解除の分岐処理）を `Item` モデルへ移動する。

Closes #227

## 変更内容
- `Item#assign_category(user, category_id:, new_category_name:, remove_category:)` を追加（ロジックは従来のまま移動、`current_user` は引数で受け取る）
- コントローラ側はparamsの取り出しとモデル呼び出しのみ（26行→8行）
- モデル単体テスト7件を追加（新規作成 / 同名カテゴリ再利用 / 不正な名前 / 解除 / ID指定 / 他ユーザーのカテゴリ拒否 / 未指定時のクリア）

## 完了条件（issue #227より）
- [x] カテゴリの新規作成・変更・解除が現状どおり動く
- [x] コントローラの判定ロジックが削除されている
- [x] model のテストが追加されている

## Test plan
- [x] `bin/rails test`（219 runs, 0 failures）