### PR TITLE
使い切り一覧のページネーションをDB側で行う

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -44,19 +44,18 @@ class ItemsController < ApplicationController
     @selected_rating = params[:rating].to_s
     @selected_rating_status = params[:rating_status].to_s
     @selected_review_status = params[:review_status].to_s
-    finished_usage_logs = current_user.usage_logs
-                                      .finished
-                                      .used_up_history
-                                      .by_item_name(@search_query)
-                                      .by_item_category(@selected_category_id)
-                                      .by_rating(@selected_rating)
-                                      .by_rating_status(@selected_rating_status)
-                                      .by_review_status(@selected_review_status)
-                                      .includes(:item)
-                                      .order(finished_at: :desc)
-    @usage_logs = Kaminari.paginate_array(
-      finished_usage_logs.to_a.uniq(&:item_id)
-    ).page(params[:page])
+    @usage_logs = current_user.usage_logs
+                              .finished
+                              .used_up_history
+                              .by_item_name(@search_query)
+                              .by_item_category(@selected_category_id)
+                              .by_rating(@selected_rating)
+                              .by_rating_status(@selected_rating_status)
+                              .by_review_status(@selected_review_status)
+                              .latest_per_item
+                              .includes(:item)
+                              .order(finished_at: :desc)
+                              .page(params[:page])
     @used_up_counts_by_item_id = current_user.usage_logs
                                              .finished
                                              .used_up_history

--- a/app/models/usage_log.rb
+++ b/app/models/usage_log.rb
@@ -49,6 +49,11 @@ class UsageLog < ApplicationRecord
 
     joins(:item).where(items: { category_id: category_id })
   }
+  # アイテムごとに finished_at が最も新しい1件だけに絞り込む（PostgreSQLのDISTINCT ONを利用）
+  scope :latest_per_item, -> {
+    where(id: reorder(item_id: :asc, finished_at: :desc)
+                .select("DISTINCT ON (usage_logs.item_id) usage_logs.id"))
+  }
 
   validates :rating, inclusion: { in: 1..5 }, allow_nil: true
   validates :discontinued_reason, length: { maximum: 500 }, allow_blank: true

--- a/test/models/usage_log_test.rb
+++ b/test/models/usage_log_test.rb
@@ -204,6 +204,33 @@ class UsageLogTest < ActiveSupport::TestCase
     assert usage_log.valid?
   end
 
+  test "latest_per_item returns only the latest finished log per item" do
+    old_log = @item.usage_logs.create!(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 1),
+      finished_at: Time.zone.local(2026, 5, 10),
+      finish_reason: :used_up
+    )
+    new_log = @item.usage_logs.create!(
+      user: @user,
+      started_at: Time.zone.local(2026, 6, 1),
+      finished_at: Time.zone.local(2026, 6, 10),
+      finish_reason: :used_up
+    )
+    other_item_log = items(:two).usage_logs.create!(
+      user: @user,
+      started_at: Time.zone.local(2026, 5, 1),
+      finished_at: Time.zone.local(2026, 5, 5),
+      finish_reason: :used_up
+    )
+
+    result = UsageLog.finished.latest_per_item
+
+    assert_includes result, new_log
+    assert_includes result, other_item_log
+    assert_not_includes result, old_log
+  end
+
   test "usage_days returns days including both start and finish dates" do
     usage_log = @item.usage_logs.build(
       user: @user,


### PR DESCRIPTION
## 概要
`items#used_up` の「アイテムごとに最新1件」の絞り込みを、Ruby側の全件読み込み＋`uniq` から、PostgreSQLの `DISTINCT ON` を使ったDB側の処理に変更する。

Closes #230

## 変更内容
- `UsageLog.latest_per_item` スコープを追加（`DISTINCT ON (item_id)` で各アイテムの最新履歴のみに絞る）
- `used_up` アクションから `to_a.uniq(&:item_id)` と `Kaminari.paginate_array` を排除し、通常のリレーションとして `.page` を使用
- model テスト1件を追加（アイテムごとに最新のみ返ること）

## 完了条件（issue #230より）
- [x] 使い切り一覧の表示内容・並び順が現状と変わらない
- [x] 全件を配列化する処理（`to_a.uniq`）がなくなっている
- [x] controller のテストが通る

## Test plan
- [x] `bin/rails test`（220 runs, 0 failures）