### PR TITLE
アイテム一覧に「もうすぐ無くなりそう」セクションと注意表示を追加する

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -26,6 +26,7 @@ class ItemsController < ApplicationController
 
     @page_title = "アイテム"
     @items = @items.page(params[:page])
+    @finish_predicted_soon_items = current_user.items.visible.finish_predicted_soon if default_item_list?
   end
 
   def in_use
@@ -225,6 +226,12 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:name, :brand_name, :price, :stock_quantity, :favorite, :memo, :image)
+  end
+
+  # 検索・絞り込み・ページ指定のない初期表示のときだけ「もうすぐ無くなりそう」を出す
+  def default_item_list?
+    @search_query.blank? && @selected_category_id.blank? &&
+      @selected_status.blank? && @selected_favorite.blank? && params[:page].blank?
   end
 
   def assign_category

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -71,6 +71,9 @@ class Item < ApplicationRecord
     usage_logs.rated.count
   end
 
+  # 「もうすぐ無くなりそう」とみなす予測日までの日数
+  FINISH_PREDICTED_SOON_DAYS = 7
+
   def predicted_finish_date
     return unless using?
     return if current_usage_log.started_at.blank?
@@ -79,6 +82,22 @@ class Item < ApplicationRecord
     return if average_days.blank?
 
     current_usage_log.started_at.to_date + (average_days - 1).days
+  end
+
+  # 使い切り予測日が近い（7日以内。予測日を過ぎている場合も含む）かどうか
+  def finish_predicted_soon?
+    predicted_finish_date.present? &&
+      predicted_finish_date <= Date.current + FINISH_PREDICTED_SOON_DAYS.days
+  end
+
+  # 使用中のアイテムのうち、予測日が近いものを予測日の早い順で返す。
+  # 予測日はRubyで計算するため、対象を使用中のアイテムに絞ってから読み込む
+  def self.finish_predicted_soon
+    joins(:usage_logs)
+      .merge(UsageLog.in_use)
+      .distinct
+      .select(&:finish_predicted_soon?)
+      .sort_by(&:predicted_finish_date)
   end
 
   # カテゴリを割り当てる。新規カテゴリ名があれば作成して設定し、

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,6 +128,24 @@
         </section>
   <% end %>
 
+  <% if @finish_predicted_soon_items.present? %>
+    <section class="mb-4 rounded-lg border border-amber-200 bg-amber-50 p-4" aria-label="もうすぐ無くなりそうなアイテム">
+      <h2 class="brand-font text-sm font-bold text-amber-800">もうすぐ無くなりそう</h2>
+      <ul class="mt-2 space-y-1">
+        <% @finish_predicted_soon_items.each do |item| %>
+          <li>
+            <%= link_to item_path(item), class: "flex items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-sm transition hover:bg-amber-100" do %>
+              <span class="truncate font-semibold text-slate-800"><%= item.name %></span>
+              <span class="shrink-0 text-xs font-semibold text-amber-800">
+                <%= item.predicted_finish_date.strftime("%-m/%-d") %>ごろ
+              </span>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    </section>
+  <% end %>
+
   <% if @items.any? %>
     <div class="grid gap-3">
       <% @items.each do |item| %>
@@ -172,7 +190,7 @@
                   <% if item.using? %>
                     <div class="flex min-w-0 items-center gap-1">
                       <dt class="shrink-0 font-medium text-slate-500">使い切り予測</dt>
-                      <dd class="min-w-0 truncate text-emerald-700">
+                      <dd class="min-w-0 truncate <%= item.finish_predicted_soon? ? "font-semibold text-red-600" : "text-emerald-700" %>">
                         <% if item.predicted_finish_date.present? %>
                           <%= item.predicted_finish_date.strftime("%-m/%-d") %>ごろ
                         <% else %>

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -21,6 +21,41 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_no_match other_user_item.name, response.body
   end
 
+  test "index shows finish predicted soon section" do
+    item = items(:one)
+    item.update!(stock_quantity: 2)
+    item.start_using!(@user, 10.days.ago)
+    item.finish_using!(3.days.ago)
+    item.start_using!(@user, Time.current)
+
+    get items_path
+
+    assert_response :success
+    assert_select "section[aria-label='もうすぐ無くなりそうなアイテム']" do
+      assert_select "span", text: item.name
+    end
+  end
+
+  test "index does not show finish predicted soon section when filtering" do
+    item = items(:one)
+    item.update!(stock_quantity: 2)
+    item.start_using!(@user, 10.days.ago)
+    item.finish_using!(3.days.ago)
+    item.start_using!(@user, Time.current)
+
+    get items_path, params: { q: item.name }
+
+    assert_response :success
+    assert_select "section[aria-label='もうすぐ無くなりそうなアイテム']", count: 0
+  end
+
+  test "index does not show finish predicted soon section without matching items" do
+    get items_path
+
+    assert_response :success
+    assert_select "section[aria-label='もうすぐ無くなりそうなアイテム']", count: 0
+  end
+
   test "index keeps search query and shows reset link" do
     get items_path, params: { q: "化粧" }
 

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -307,6 +307,66 @@ class ItemTest < ActiveSupport::TestCase
     assert_nil item.predicted_finish_date
   end
 
+  test "finish_predicted_soon? returns true when predicted date is within 7 days" do
+    item = items(:one)
+    item.update!(stock_quantity: 2)
+    item.start_using!(users(:one), 10.days.ago)
+    item.finish_using!(3.days.ago)
+    item.start_using!(users(:one), Time.current)
+
+    # 平均使用日数8日 → 予測日は7日後
+    assert item.finish_predicted_soon?
+  end
+
+  test "finish_predicted_soon? returns true when predicted date has passed" do
+    item = items(:one)
+    item.update!(stock_quantity: 2)
+    item.start_using!(users(:one), 30.days.ago)
+    item.finish_using!(26.days.ago)
+    item.start_using!(users(:one), 20.days.ago)
+
+    # 平均使用日数5日 → 予測日は16日前（過ぎている）
+    assert item.finish_predicted_soon?
+  end
+
+  test "finish_predicted_soon? returns false when predicted date is far" do
+    item = items(:one)
+    item.update!(stock_quantity: 2)
+    item.start_using!(users(:one), 60.days.ago)
+    item.finish_using!(1.day.ago)
+    item.start_using!(users(:one), Time.current)
+
+    # 平均使用日数60日 → 予測日は59日後
+    assert_not item.finish_predicted_soon?
+  end
+
+  test "finish_predicted_soon? returns false without prediction" do
+    item = items(:one)
+    item.start_using!(users(:one), Time.current)
+
+    # 使い切り履歴がなく予測日が計算できない
+    assert_not item.finish_predicted_soon?
+  end
+
+  test "finish_predicted_soon returns matching items ordered by predicted date" do
+    near_item = items(:one)
+    near_item.update!(stock_quantity: 2)
+    near_item.start_using!(users(:one), 10.days.ago)
+    near_item.finish_using!(3.days.ago)
+    near_item.start_using!(users(:one), Time.current)
+
+    far_item = items(:two)
+    far_item.update!(stock_quantity: 2)
+    far_item.start_using!(users(:one), 60.days.ago)
+    far_item.finish_using!(1.day.ago)
+    far_item.start_using!(users(:one), Time.current)
+
+    result = users(:one).items.finish_predicted_soon
+
+    assert_includes result, near_item
+    assert_not_includes result, far_item
+  end
+
   test "item can be saved without image" do
     item = items(:one)
 


### PR DESCRIPTION
## 概要
使い切り予測日が近いアイテムをアイテム一覧で見つけやすくする。

Closes #66

## 変更内容
- `Item#finish_predicted_soon?` を追加（予測日が7日以内。超過も含む。閾値は定数 `FINISH_PREDICTED_SOON_DAYS`）
- `Item.finish_predicted_soon` を追加（使用中アイテムに絞ってから判定し、予測日の早い順で返す）
- アイテム一覧の上部に「もうすぐ無くなりそう」セクションを追加（検索・絞り込み・ページ指定のない初期表示のみ）
- 一覧カードの「使い切り予測」を、予測日が近い場合に赤字で強調表示
- model テスト5件・controller テスト3件を追加

## 設計メモ
- 予測日はRubyで計算されるため一覧全体の並び替えはせず、対象が少数の「使用中アイテム」だけを判定するセクション方式を採用
- 予測日をDBにキャッシュする設計変更は #239 として起票（リマインダー機能 #58 の前提タスク）

## 完了条件（issue #66より）
- [x] 予測日が近いアイテムを一覧で見つけやすい
- [x] 予測できないアイテムの表示は従来どおり（「データなし」）
- [x] ログイン中ユーザーのアイテムだけが対象
- [x] テストが追加されている

## Test plan
- [x] `bin/rails test`（228 runs, 0 failures）
- [x] 開発環境にサンプルデータを投入し、セクション表示・赤字強調・絞り込み時の非表示を目視確認