### PR TITLE
使い切り予測日をitemsテーブルにキャッシュする

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -74,30 +74,27 @@ class Item < ApplicationRecord
   # 「もうすぐ無くなりそう」とみなす予測日までの日数
   FINISH_PREDICTED_SOON_DAYS = 7
 
+  # 使い切り予測日（キャッシュされたカラムを返す）
   def predicted_finish_date
-    return unless using?
-    return if current_usage_log.started_at.blank?
+    predicted_finish_on
+  end
 
-    average_days = average_usage_days
-    return if average_days.blank?
-
-    current_usage_log.started_at.to_date + (average_days - 1).days
+  # 使い切り予測日を再計算してカラムに保存する。使用履歴の変更時に呼ばれる
+  def refresh_predicted_finish_on!
+    update_column(:predicted_finish_on, calculate_predicted_finish_on)
   end
 
   # 使い切り予測日が近い（7日以内。予測日を過ぎている場合も含む）かどうか
   def finish_predicted_soon?
-    predicted_finish_date.present? &&
-      predicted_finish_date <= Date.current + FINISH_PREDICTED_SOON_DAYS.days
+    predicted_finish_on.present? &&
+      predicted_finish_on <= Date.current + FINISH_PREDICTED_SOON_DAYS.days
   end
 
-  # 使用中のアイテムのうち、予測日が近いものを予測日の早い順で返す。
-  # 予測日はRubyで計算するため、対象を使用中のアイテムに絞ってから読み込む
+  # 予測日が近いアイテムを予測日の早い順で返す
   def self.finish_predicted_soon
-    joins(:usage_logs)
-      .merge(UsageLog.in_use)
-      .distinct
-      .select(&:finish_predicted_soon?)
-      .sort_by(&:predicted_finish_date)
+    where.not(predicted_finish_on: nil)
+         .where(predicted_finish_on: ..(Date.current + FINISH_PREDICTED_SOON_DAYS.days))
+         .order(:predicted_finish_on)
   end
 
   # カテゴリを割り当てる。新規カテゴリ名があれば作成して設定し、
@@ -176,6 +173,17 @@ class Item < ApplicationRecord
   end
 
   private
+
+  # 使用履歴から使い切り予測日を計算する。予測できない場合は nil
+  def calculate_predicted_finish_on
+    return unless using?
+    return if current_usage_log.started_at.blank?
+
+    average_days = average_usage_days
+    return if average_days.blank?
+
+    current_usage_log.started_at.to_date + (average_days - 1).days
+  end
 
   def image_content_type
     return unless image.attached?

--- a/app/models/usage_log.rb
+++ b/app/models/usage_log.rb
@@ -61,6 +61,10 @@ class UsageLog < ApplicationRecord
   validate :finished_at_must_be_after_started_at
   validate :review_requires_rating
 
+  # 使用履歴が変わったら、アイテムの使い切り予測日キャッシュを再計算する
+  after_save :refresh_item_prediction
+  after_destroy :refresh_item_prediction
+
   def in_use?
     finished_at.nil?
   end
@@ -84,6 +88,10 @@ class UsageLog < ApplicationRecord
   end
 
   private
+
+  def refresh_item_prediction
+    item.refresh_predicted_finish_on!
+  end
 
   def finished_at_must_be_after_started_at
     return if started_at.blank? || finished_at.blank?

--- a/db/migrate/20260717000000_add_predicted_finish_on_to_items.rb
+++ b/db/migrate/20260717000000_add_predicted_finish_on_to_items.rb
@@ -1,0 +1,7 @@
+class AddPredictedFinishOnToItems < ActiveRecord::Migration[7.1]
+  def change
+    # 使い切り予測日のキャッシュ。使用履歴の変更時に再計算される。予測できない場合はNULL
+    add_column :items, :predicted_finish_on, :date
+    add_index :items, :predicted_finish_on
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_07_14_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_17_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -64,8 +64,10 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_14_000000) do
     t.uuid "user_id", null: false
     t.uuid "category_id"
     t.string "brand_name"
+    t.date "predicted_finish_on"
     t.index ["archived"], name: "index_items_on_archived"
     t.index ["category_id"], name: "index_items_on_category_id"
+    t.index ["predicted_finish_on"], name: "index_items_on_predicted_finish_on"
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -367,6 +367,40 @@ class ItemTest < ActiveSupport::TestCase
     assert_not_includes result, far_item
   end
 
+  test "predicted_finish_on is saved to the column when usage starts" do
+    item = items(:one)
+    item.update!(stock_quantity: 2)
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 1))
+    item.finish_using!(Time.zone.local(2026, 5, 10))
+    item.start_using!(users(:one), Time.zone.local(2026, 6, 1))
+
+    assert_equal Date.new(2026, 6, 10), item.reload.predicted_finish_on
+  end
+
+  test "predicted_finish_on is cleared when usage finishes" do
+    item = items(:one)
+    item.update!(stock_quantity: 2)
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 1))
+    item.finish_using!(Time.zone.local(2026, 5, 10))
+    item.start_using!(users(:one), Time.zone.local(2026, 6, 1))
+    item.finish_using!(Time.zone.local(2026, 6, 5))
+
+    assert_nil item.reload.predicted_finish_on
+  end
+
+  test "predicted_finish_on is recalculated when a usage log is destroyed" do
+    item = items(:one)
+    item.update!(stock_quantity: 2)
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 1))
+    item.finish_using!(Time.zone.local(2026, 5, 10))
+    item.start_using!(users(:one), Time.zone.local(2026, 6, 1))
+
+    item.usage_logs.finished.first.destroy!
+
+    # 使い切り履歴が消えて平均が計算できなくなるため、予測日もクリアされる
+    assert_nil item.reload.predicted_finish_on
+  end
+
   test "item can be saved without image" do
     item = items(:one)
 


### PR DESCRIPTION
## 概要
毎回Rubyで計算していた使い切り予測日を `items.predicted_finish_on` カラムにキャッシュし、SQLで並び替え・絞り込みできるようにする。リマインダー機能（#58）の前提となる設計変更。

Closes #239

## 変更内容
- `items.predicted_finish_on`（date・NULL許可・インデックス付き）を追加
- 計算ロジックを `Item#calculate_predicted_finish_on`（private）に移動し、`refresh_predicted_finish_on!` で `update_column` によりキャッシュを更新
- `UsageLog` の `after_save` / `after_destroy` から再計算を呼び、履歴のあらゆる変更に自動追従（再計算の起点は1箇所）
- 読み出し側の公開メソッド `predicted_finish_date` は名前を維持してカラム参照に変更（ビュー・既存テストは無修正）
- `Item.finish_predicted_soon` をRuby計算からSQL（WHERE + ORDER BY）に置き換え
- キャッシュ追従のテスト3件を追加（使用開始で保存 / 終了でクリア / 履歴削除で再計算）

## デプロイ後の作業
本番DBで既存データの埋め戻しを一度だけ実行する:
```
bin/rails runner "Item.find_each(&:refresh_predicted_finish_on!)"
```

## 完了条件（issue #239より）
- [x] 予測日がカラムとして保存され、履歴の変更に追従して自動更新される
- [x] 既存の予測日表示・もうすぐ無くなりそうセクションの挙動が変わらない（既存テスト228件が無修正で通過）
- [x] SQLで予測日順の並び替え・絞り込みができる
- [x] model のテストが追加されている

## Test plan
- [x] `bin/rails test`（231 runs, 0 failures）
- [x] 開発DBでマイグレーション・埋め戻しを実行し確認