### PR TITLE
購入リマインダーの定期実行機能を追加する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Rails 7.1 + PostgreSQL の在庫管理・レビューアプリ。認証は Devis
 - テスト: `docker compose exec web bin/rails test`
 - テスト（単一）: `docker compose exec web bin/rails test test/models/item_test.rb`
 - Railsコンソール: `docker compose exec web bin/rails console`
+- 購入リマインダー送信（本番はcronで1日1回実行）: `docker compose exec web bin/rails reminders:deliver`
 
 ## コードスタイル
 - Rails の標準的な MVC 構成に従う

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -74,14 +74,39 @@ class Item < ApplicationRecord
   # 「もうすぐ無くなりそう」とみなす予測日までの日数
   FINISH_PREDICTED_SOON_DAYS = 7
 
+  # 購入リマインダーの通知タイミング（予測日までの残り日数）
+  REMINDER_FIRST_DAYS = 7
+  REMINDER_SECOND_DAYS = 3
+
+  # 1回目のリマインダー対象（予測日まで7日以内・未送信）
+  scope :reminder_first_due, -> {
+    where.not(predicted_finish_on: nil)
+         .where(predicted_finish_on: ..(Date.current + REMINDER_FIRST_DAYS.days))
+         .where(reminder_first_sent_at: nil)
+  }
+  # 2回目のリマインダー対象（予測日まで3日以内・未送信）
+  scope :reminder_second_due, -> {
+    where.not(predicted_finish_on: nil)
+         .where(predicted_finish_on: ..(Date.current + REMINDER_SECOND_DAYS.days))
+         .where(reminder_second_sent_at: nil)
+  }
+
   # 使い切り予測日（キャッシュされたカラムを返す）
   def predicted_finish_date
     predicted_finish_on
   end
 
-  # 使い切り予測日を再計算してカラムに保存する。使用履歴の変更時に呼ばれる
+  # 使い切り予測日を再計算してカラムに保存する。使用履歴の変更時に呼ばれる。
+  # 予測日が変わったら、新しいサイクルとしてリマインダーの送信記録もリセットする
   def refresh_predicted_finish_on!
-    update_column(:predicted_finish_on, calculate_predicted_finish_on)
+    new_prediction = calculate_predicted_finish_on
+    return if new_prediction == predicted_finish_on
+
+    update_columns(
+      predicted_finish_on: new_prediction,
+      reminder_first_sent_at: nil,
+      reminder_second_sent_at: nil
+    )
   end
 
   # 使い切り予測日が近い（7日以内。予測日を過ぎている場合も含む）かどうか

--- a/app/services/purchase_reminder.rb
+++ b/app/services/purchase_reminder.rb
@@ -1,0 +1,56 @@
+# 購入リマインダーの対象アイテムを抽出し、ユーザーごとにまとめて通知する。
+# 通知タイミングは2回: 予測日の7日前（1回目）と3日前（2回目）
+class PurchaseReminder
+  def self.deliver_all(notifier: ReminderNotifier.new)
+    new(notifier: notifier).deliver_all
+  end
+
+  def initialize(notifier:)
+    @notifier = notifier
+  end
+
+  # 通知したアイテム数を返す
+  def deliver_all
+    now = Time.current
+    count = 0
+
+    targets_by_user.each do |user, entries|
+      @notifier.deliver(user, entries)
+      entries.each do |entry|
+        mark_sent(entry, now)
+        count += 1
+      end
+    end
+
+    count
+  end
+
+  private
+
+  # 2回目（3日前）の対象を優先し、それ以外を1回目（7日前）の対象として集める。
+  # 両方未送信のまま3日前を迎えた場合は、2回目としての1通だけを送る
+  def targets_by_user
+    second_due = Item.visible.reminder_second_due.includes(:user).to_a
+    first_due = Item.visible.reminder_first_due
+                    .where.not(id: second_due.map(&:id))
+                    .includes(:user)
+                    .to_a
+
+    entries = second_due.map { |item| { item: item, stage: :second } } +
+              first_due.map { |item| { item: item, stage: :first } }
+    entries.group_by { |entry| entry[:item].user }
+  end
+
+  def mark_sent(entry, now)
+    item = entry[:item]
+
+    if entry[:stage] == :second
+      item.update_columns(
+        reminder_second_sent_at: now,
+        reminder_first_sent_at: item.reminder_first_sent_at || now
+      )
+    else
+      item.update_columns(reminder_first_sent_at: now)
+    end
+  end
+end

--- a/app/services/reminder_notifier.rb
+++ b/app/services/reminder_notifier.rb
@@ -1,0 +1,12 @@
+# 購入リマインダーの送信役。現在はログ出力のみ（#68 でLINE送信に差し替える予定）
+class ReminderNotifier
+  def deliver(user, entries)
+    entries.each do |entry|
+      item = entry[:item]
+      Rails.logger.info(
+        "[購入リマインダー] user=#{user.email} item=#{item.name} " \
+        "予測日=#{item.predicted_finish_on} 在庫=#{item.stock_quantity} 通知=#{entry[:stage]}"
+      )
+    end
+  end
+end

--- a/db/migrate/20260719000000_add_reminder_sent_at_to_items.rb
+++ b/db/migrate/20260719000000_add_reminder_sent_at_to_items.rb
@@ -1,0 +1,8 @@
+class AddReminderSentAtToItems < ActiveRecord::Migration[7.1]
+  def change
+    # 購入リマインダーの送信記録。1回目=予測日7日前、2回目=予測日3日前。
+    # 予測日が変わったらリセットされる
+    add_column :items, :reminder_first_sent_at, :datetime
+    add_column :items, :reminder_second_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_07_17_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_19_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -65,6 +65,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_17_000000) do
     t.uuid "category_id"
     t.string "brand_name"
     t.date "predicted_finish_on"
+    t.datetime "reminder_first_sent_at"
+    t.datetime "reminder_second_sent_at"
     t.index ["archived"], name: "index_items_on_archived"
     t.index ["category_id"], name: "index_items_on_category_id"
     t.index ["predicted_finish_on"], name: "index_items_on_predicted_finish_on"

--- a/lib/tasks/reminders.rake
+++ b/lib/tasks/reminders.rake
@@ -1,0 +1,7 @@
+namespace :reminders do
+  desc "購入リマインダーの対象アイテムを抽出して通知する（1日1回の定期実行を想定）"
+  task deliver: :environment do
+    count = PurchaseReminder.deliver_all
+    puts "購入リマインダー: #{count}件のアイテムを通知しました"
+  end
+end

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -401,6 +401,57 @@ class ItemTest < ActiveSupport::TestCase
     assert_nil item.reload.predicted_finish_on
   end
 
+  test "reminder_first_due returns items within 7 days of predicted finish" do
+    item = items(:one)
+    item.update!(predicted_finish_on: Date.current + 7.days)
+
+    assert_includes Item.reminder_first_due, item
+  end
+
+  test "reminder_first_due excludes items already notified" do
+    item = items(:one)
+    item.update!(predicted_finish_on: Date.current + 7.days, reminder_first_sent_at: Time.current)
+
+    assert_not_includes Item.reminder_first_due, item
+  end
+
+  test "reminder_first_due excludes items with far or no prediction" do
+    far_item = items(:one)
+    far_item.update!(predicted_finish_on: Date.current + 8.days)
+    no_prediction_item = items(:two)
+    no_prediction_item.update!(predicted_finish_on: nil)
+
+    assert_not_includes Item.reminder_first_due, far_item
+    assert_not_includes Item.reminder_first_due, no_prediction_item
+  end
+
+  test "reminder_second_due returns unnotified items within 3 days" do
+    due_item = items(:one)
+    due_item.update!(predicted_finish_on: Date.current + 3.days)
+    early_item = items(:two)
+    early_item.update!(predicted_finish_on: Date.current + 4.days)
+
+    assert_includes Item.reminder_second_due, due_item
+    assert_not_includes Item.reminder_second_due, early_item
+  end
+
+  test "reminder sent timestamps are reset when prediction changes" do
+    item = items(:one)
+    item.update!(
+      stock_quantity: 2,
+      reminder_first_sent_at: Time.current,
+      reminder_second_sent_at: Time.current
+    )
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 1))
+    item.finish_using!(Time.zone.local(2026, 5, 10))
+    item.start_using!(users(:one), Time.zone.local(2026, 6, 1))
+
+    item.reload
+    assert_equal Date.new(2026, 6, 10), item.predicted_finish_on
+    assert_nil item.reminder_first_sent_at
+    assert_nil item.reminder_second_sent_at
+  end
+
   test "item can be saved without image" do
     item = items(:one)
 

--- a/test/services/purchase_reminder_test.rb
+++ b/test/services/purchase_reminder_test.rb
@@ -1,0 +1,101 @@
+require "test_helper"
+
+class PurchaseReminderTest < ActiveSupport::TestCase
+  # 通知内容を記録するだけのテスト用Notifier
+  class FakeNotifier
+    attr_reader :deliveries
+
+    def initialize
+      @deliveries = []
+    end
+
+    def deliver(user, entries)
+      @deliveries << [user, entries]
+    end
+  end
+
+  setup do
+    @notifier = FakeNotifier.new
+  end
+
+  test "sends first reminder for items within 7 days and marks it sent" do
+    item = items(:one)
+    item.update!(predicted_finish_on: Date.current + 7.days)
+
+    count = PurchaseReminder.deliver_all(notifier: @notifier)
+
+    assert_equal 1, count
+    user, entries = @notifier.deliveries.first
+    assert_equal item.user, user
+    assert_equal [{ item: item, stage: :first }], entries
+    item.reload
+    assert item.reminder_first_sent_at.present?
+    assert_nil item.reminder_second_sent_at
+  end
+
+  test "sends a single second reminder when both stages are due" do
+    item = items(:one)
+    item.update!(predicted_finish_on: Date.current + 2.days)
+
+    count = PurchaseReminder.deliver_all(notifier: @notifier)
+
+    assert_equal 1, count
+    _user, entries = @notifier.deliveries.first
+    assert_equal :second, entries.first[:stage]
+    item.reload
+    assert item.reminder_first_sent_at.present?
+    assert item.reminder_second_sent_at.present?
+  end
+
+  test "sends second reminder after first was already sent" do
+    item = items(:one)
+    first_sent_at = 4.days.ago
+    item.update!(
+      predicted_finish_on: Date.current + 3.days,
+      reminder_first_sent_at: first_sent_at
+    )
+
+    count = PurchaseReminder.deliver_all(notifier: @notifier)
+
+    assert_equal 1, count
+    _user, entries = @notifier.deliveries.first
+    assert_equal :second, entries.first[:stage]
+    item.reload
+    assert item.reminder_second_sent_at.present?
+    assert_in_delta first_sent_at.to_i, item.reminder_first_sent_at.to_i, 1
+  end
+
+  test "does not notify items already sent" do
+    item = items(:one)
+    item.update!(
+      predicted_finish_on: Date.current + 5.days,
+      reminder_first_sent_at: Time.current
+    )
+
+    count = PurchaseReminder.deliver_all(notifier: @notifier)
+
+    assert_equal 0, count
+    assert_empty @notifier.deliveries
+  end
+
+  test "groups entries per user into one delivery" do
+    items(:one).update!(predicted_finish_on: Date.current + 6.days)
+    items(:two).update!(predicted_finish_on: Date.current + 2.days)
+
+    count = PurchaseReminder.deliver_all(notifier: @notifier)
+
+    assert_equal 2, count
+    assert_equal 1, @notifier.deliveries.size
+    _user, entries = @notifier.deliveries.first
+    assert_equal 2, entries.size
+  end
+
+  test "excludes archived items" do
+    item = items(:one)
+    item.update!(predicted_finish_on: Date.current, archived: true)
+
+    count = PurchaseReminder.deliver_all(notifier: @notifier)
+
+    assert_equal 0, count
+  end
+end


### PR DESCRIPTION
## 概要
予測日が近いアイテムを定期的に抽出し、通知処理へ渡す仕組みを追加する。LINEへの実送信は #68 で対応し、本PRではログ出力のダミー通知までを実装する。

Closes #58

## 通知の仕様
- 対象: 使い切り予測日が近いアイテムすべて（アーカイブ済みは除外）。通知内容にその時点の在庫数を含む
- タイミング: アイテムごとに最大2回（予測日の7日前・3日前）
- 取りこぼし防止のため「ちょうどN日前」ではなく「残りN日以内かつ未送信」で判定。両方未送信のまま3日以内になった場合は1通のみ送信
- 予測日が変わったら（新しい使用サイクル等）送信記録をリセットし、再び通知可能にする

## 変更内容
- items に `reminder_first_sent_at` / `reminder_second_sent_at` を追加（前コミット）
- 抽出スコープ `reminder_first_due` / `reminder_second_due` を追加（#239 の予測日カラムによりSQLで完結）
- `PurchaseReminder`: 対象をユーザーごとにまとめて通知し、送信記録を付ける
- `ReminderNotifier`: 送信役。現在はログ出力（#68 でLINE送信に差し替える境界）
- Rakeタスク `reminders:deliver` と AGENTS.md へのコマンド追記
- model テスト5件・service テスト6件を追加

## 本番の定期実行（Render）
Render の Cron Job を作成し、1日1回（例: 毎朝9時 JST = `0 0 * * *` UTC）以下を実行する:
```
bundle exec rails reminders:deliver
```

## Test plan
- [x] `bin/rails test`（242 runs, 0 failures）
- [x] 開発環境で対象アイテムを用意して `reminders:deliver` を実行し、ログ出力・送信記録・実行結果件数を確認