### PR TITLE
画像選択時にフロント側でファイル形式・サイズをチェックする

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,9 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 
+const ALLOWED_IMAGE_TYPES = ["image/jpeg", "image/png"]
+const MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024
+
 document.addEventListener("change", (event) => {
   if (event.target.type !== "file") return
 
@@ -10,12 +13,35 @@ document.addEventListener("change", (event) => {
   const imagePreviewPlaceholder = form.querySelector("[data-image-preview-placeholder]")
   const file = event.target.files[0]
 
-  if (uploadProgress) {
-    uploadProgress.textContent = "画像が選択されました"
-    uploadProgress.classList.remove("hidden")
+  if (!file) return
+
+  if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+    event.target.value = ""
+    if (uploadProgress) {
+      uploadProgress.textContent = "JPEGまたはPNG形式の画像を選択してください"
+      uploadProgress.classList.remove("hidden", "alert-success")
+      uploadProgress.classList.add("alert-error")
+    }
+    return
   }
 
-  if (imagePreview && file) {
+  if (file.size > MAX_IMAGE_SIZE_BYTES) {
+    event.target.value = ""
+    if (uploadProgress) {
+      uploadProgress.textContent = "画像は10MB以下にしてください"
+      uploadProgress.classList.remove("hidden", "alert-success")
+      uploadProgress.classList.add("alert-error")
+    }
+    return
+  }
+
+  if (uploadProgress) {
+    uploadProgress.textContent = "画像が選択されました"
+    uploadProgress.classList.remove("hidden", "alert-error")
+    uploadProgress.classList.add("alert-success")
+  }
+
+  if (imagePreview) {
     imagePreview.src = URL.createObjectURL(file)
     imagePreview.classList.remove("hidden")
     if (imagePreviewPlaceholder) {


### PR DESCRIPTION
## 概要
アイテム登録・編集画面で画像を選択した時点で、JPEG/PNG形式・10MB以下かをフロント側でチェックする。

Closes #109

## 変更内容
- `app/javascript/application.js` の画像選択ハンドラに形式チェック（`file.type`）とサイズチェック（10MB）を追加
- 不正なファイルの場合は選択をクリアし、画像欄近くに赤色でエラーメッセージを表示（プレビュー・選択済み表示は変更しない）
- 正しい画像を選び直すとエラー表示が解除され、通常どおりプレビュー表示に戻る
- new/edit は共通パーシャル（#223）・共通JSのため同じ挙動

## 対象外（issue #109より）
- サーバー側画像バリデーションの変更
- 画像の自動リサイズ・WebP変換
- 実際のアップロード進捗バー

## 完了条件（issue #109より）
- [x] 画像選択時点で形式エラーが分かる
- [x] 画像選択時点でサイズエラーが分かる
- [x] 不正な画像を選んだまま保存処理へ進めない（選択がクリアされるため送信されない）
- [x] 正しい画像を選び直すと通常どおり登録・更新できる

## Test plan
- [x] `bin/rails test`（242 runs, 0 failures。JSのみの変更のため無影響）
- [x] 開発環境のブラウザで、新規登録・編集画面それぞれ手動確認（不正形式・10MB超・エラー後の選び直し）