### PR TITLE
カテゴリ入力をコンボボックス化する

### DIFF
--- a/app/views/items/_category_combobox.html.erb
+++ b/app/views/items/_category_combobox.html.erb
@@ -1,0 +1,19 @@
+<% selected_category_name = item.new_category_name.presence || item.category&.name %>
+<% category_options_id = "item-category-options" %>
+
+<div>
+  <%= form.label :new_category_name, "カテゴリ", class: "form-label" %>
+  <%= form.text_field :new_category_name,
+                      value: selected_category_name,
+                      list: category_options_id,
+                      class: "form-input",
+                      placeholder: "例: ヘアケア",
+                      maxlength: 20,
+                      autocomplete: "off" %>
+  <datalist id="<%= category_options_id %>">
+    <% categories.each do |category| %>
+      <option value="<%= category.name %>"></option>
+    <% end %>
+  </datalist>
+  <p class="form-help">候補から選ぶか、新しいカテゴリ名を入力してください。空欄にすると未設定になります。</p>
+</div>

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -30,39 +30,7 @@
 
     <!-- カテゴリ -->
     <div class="space-y-3">
-      <% if item.persisted? && item.category.present? %>
-        <div class="rounded-lg border border-emerald-100 bg-emerald-50 p-3">
-          <p class="text-xs text-emerald-700">現在のカテゴリ</p>
-          <div class="mt-2 flex flex-wrap items-center justify-between gap-3">
-            <span class="rounded-full bg-white px-3 py-1 text-sm font-medium text-emerald-800">
-              <%= item.category.name %>
-            </span>
-            <label class="flex items-center text-sm text-slate-700">
-              <%= f.check_box :remove_category, class: "h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500" %>
-              <span class="ml-2">このカテゴリを外す</span>
-            </label>
-          </div>
-        </div>
-      <% end %>
-
-      <div>
-        <%= f.label :category_id, "カテゴリ", class: "form-label" %>
-        <%= f.collection_select :category_id,
-                                categories,
-                                :id,
-                                :name,
-                                { include_blank: "カテゴリを選択してください" },
-                                { class: "form-input" } %>
-        <% if item.persisted? %>
-          <p class="form-help">別のカテゴリを選ぶとカテゴリを変更できます。</p>
-        <% end %>
-      </div>
-
-      <div>
-        <%= f.label :new_category_name, "カテゴリが見つからない場合", class: "form-label" %>
-        <%= f.text_field :new_category_name, class: "form-input", placeholder: "例: ヘアケア", maxlength: 20 %>
-        <p class="form-help">入力すると、新しいカテゴリを追加してこのアイテムに設定します。</p>
-      </div>
+      <%= render "category_combobox", form: f, item: item, categories: categories %>
     </div>
 
     <!-- 画像プレビュー -->

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -1171,13 +1171,23 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "JPEG / PNG、10MB以下の画像を選択してください"
   end
 
-  test "new page has category select and new category field" do
+  test "new page has category combobox" do
     get new_item_path
 
     assert_response :success
-    assert_select "select[name='item[category_id]']"
-    assert_select "input[name='item[new_category_name]']"
-    assert_includes response.body, categories(:hair_care).name
+    assert_select "input[name='item[new_category_name]'][list='item-category-options']"
+    assert_select "datalist#item-category-options option[value='#{categories(:hair_care).name}']"
+    assert_includes response.body, "候補から選ぶか、新しいカテゴリ名を入力してください"
+  end
+
+  test "edit page shows current category in category combobox" do
+    item = items(:one)
+    item.update!(category: categories(:hair_care))
+
+    get edit_item_path(item)
+
+    assert_response :success
+    assert_select "input[name='item[new_category_name]'][value='#{categories(:hair_care).name}']"
   end
 
   test "edit page has submit loading message" do
@@ -1384,7 +1394,25 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "メイク", item.reload.category.name
   end
 
-  test "update removes category from item" do
+  test "update changes category from category combobox" do
+    item = items(:one)
+    item.update!(category: categories(:hair_care))
+    category = categories(:skin_care)
+
+    patch item_path(item), params: {
+      item: {
+        name: item.name,
+        price: item.price,
+        stock_quantity: item.stock_quantity,
+        new_category_name: category.name
+      }
+    }
+
+    assert_redirected_to items_path
+    assert_equal category, item.reload.category
+  end
+
+  test "update removes category from item when category combobox is blank" do
     item = items(:one)
     item.update!(category: categories(:hair_care))
 
@@ -1393,12 +1421,33 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
         name: item.name,
         price: item.price,
         stock_quantity: item.stock_quantity,
-        remove_category: "1"
+        new_category_name: ""
       }
     }
 
     assert_redirected_to items_path
     assert_nil item.reload.category
+  end
+
+  test "create assigns existing category from category combobox" do
+    category = categories(:hair_care)
+
+    assert_no_difference -> { @user.categories.count } do
+      assert_difference -> { @user.items.count }, 1 do
+        post items_path, params: {
+          item: {
+            name: "トリートメント",
+            price: 900,
+            stock_quantity: 1,
+            new_category_name: category.name
+          }
+        }
+      end
+    end
+
+    item = @user.items.order(:created_at).last
+    assert_redirected_to items_path
+    assert_equal category, item.category
   end
 
   test "create cannot assign another user's category" do


### PR DESCRIPTION
## 概要
アイテム登録・編集フォームのカテゴリ入力（プルダウン＋新規カテゴリ名欄＋現在のカテゴリ表示/外すチェックボックスの3部品）を、1つのコンボボックス（`<input list>` + `<datalist>`）に統合する。

Closes #182

## 経緯
以前 `issue-84-category-combobox` ブランチで同内容の実装が作られていたが、その後の #223（フォームのパーシャル共通化）で `new.html.erb`/`edit.html.erb` の構造が変わったため直接マージできなかった。今回 `_form.html.erb` に合わせて作り直した。

なお #227（カテゴリロジックのモデル移動）で実装した `Item#assign_category` が、既に「何も指定がなければカテゴリをクリアする」分岐を持っていたため、モデル・コントローラ側の変更は不要だった。

## 変更内容
- `app/views/items/_category_combobox.html.erb` を追加（候補は`datalist`、自由入力も可、空欄で未設定）
- `_form.html.erb` のカテゴリブロック（3部品・持続化分岐あり）を1行の render 呼び出しに置き換え
- controller テストをコンボボックスの実際のUIに合わせて更新・追加（表示2件、既存カテゴリ選択・空欄で解除・新規作成の3件）

## 完了条件
- [x] 候補から選ぶ・自由入力・空欄で未設定、のいずれも動く
- [x] 新規登録・編集画面で同じ挙動
- [x] 表示崩れがない

## Test plan
- [x] `bin/rails test`（245 runs, 0 failures）
- [x] 開発環境のブラウザで新規登録・編集画面を目視確認