### PR TITLE
Rubocopを導入する（rubocop-rails-omakase）

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+# Omakase Ruby styling for Rails
+inherit_gem: { rubocop-rails-omakase: rubocop.yml }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ Rails 7.1 + PostgreSQL の在庫管理・レビューアプリ。認証は Devis
 - テスト（単一）: `docker compose exec web bin/rails test test/models/item_test.rb`
 - Railsコンソール: `docker compose exec web bin/rails console`
 - 購入リマインダー送信（本番はcronで1日1回実行）: `docker compose exec web bin/rails reminders:deliver`
+- Rubocop（コードスタイルチェック）: `docker compose exec web bundle exec rubocop`
+- Rubocop（自動修正）: `docker compose exec web bundle exec rubocop -a`
 
 ## コードスタイル
 - Rails の標準的な MVC 構成に従う

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ group :development do
   gem "web-console"
   gem "letter_opener_web"
 
+  # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
+  gem "rubocop-rails-omakase", require: false
+
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     aws-eventstream (1.4.0)
     aws-partitions (1.1262.0)
     aws-sdk-core (3.252.0)
@@ -168,6 +169,7 @@ GEM
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     jmespath (1.6.2)
+    json (2.21.1)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -180,6 +182,7 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
+    language_server-protocol (3.17.0.6)
     launchy (3.1.1)
       addressable (~> 2.8)
       childprocess (~> 5.0)
@@ -191,6 +194,7 @@ GEM
       letter_opener (~> 1.9)
       railties (>= 6.1)
       rexml
+    lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.25.0)
       crass (~> 1.0.2)
@@ -228,12 +232,17 @@ GEM
     nokogiri (1.19.0-x86_64-linux-gnu)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
     pg (1.6.2-aarch64-linux)
     pg (1.6.2-arm64-darwin)
     pg (1.6.2-x86_64-linux)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
+    prism (1.9.0)
     psych (5.3.1)
       date
       stringio
@@ -283,6 +292,7 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
+    rainbow (3.1.1)
     rake (13.3.1)
     rdoc (7.0.3)
       erb
@@ -298,6 +308,35 @@ GEM
       actionpack (>= 7.0)
       railties (>= 7.0)
     rexml (3.4.4)
+    rubocop (1.88.2)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (>= 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    rubocop-performance (1.26.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
+    rubocop-rails (2.36.0)
+      activesupport (>= 4.2.0)
+      lint_roller (~> 1.1)
+      rack (>= 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.44.0, < 2.0)
+    rubocop-rails-omakase (1.1.0)
+      rubocop (>= 1.72)
+      rubocop-performance (>= 1.24)
+      rubocop-rails (>= 2.30)
+    ruby-progressbar (1.13.0)
     ruby-vips (2.3.0)
       ffi (~> 1.12)
       logger
@@ -334,6 +373,9 @@ GEM
       railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -373,6 +415,7 @@ DEPENDENCIES
   rails (~> 7.1.6)
   rails-i18n
   resend
+  rubocop-rails-omakase
   selenium-webdriver
   sprockets-rails
   stimulus-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :email])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name, :email ])
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -84,10 +84,10 @@ class ItemsController < ApplicationController
     @item = current_user.items.build(item_params)
 
     if assign_category && @item.save
-      redirect_to items_path, notice: 'アイテムが作成されました。'
+      redirect_to items_path, notice: "アイテムが作成されました。"
     else
       set_categories
-      flash.now[:alert] = 'アイテムの作成に失敗しました。'
+      flash.now[:alert] = "アイテムの作成に失敗しました。"
       render :new, status: :unprocessable_content
     end
   end
@@ -104,7 +104,7 @@ class ItemsController < ApplicationController
     @item.assign_attributes(item_params)
 
     if assign_category && @item.save
-      redirect_to items_path, notice: 'アイテム情報を更新しました'
+      redirect_to items_path, notice: "アイテム情報を更新しました"
     else
       set_categories
       render :edit, status: :unprocessable_content
@@ -113,7 +113,7 @@ class ItemsController < ApplicationController
 
   def destroy
     @item.destroy!
-    redirect_to items_path, notice: 'アイテムが削除されました'
+    redirect_to items_path, notice: "アイテムが削除されました"
   end
 
   def destroy_image

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,8 +12,8 @@ class Item < ApplicationRecord
   belongs_to :category, optional: true
   has_many :usage_logs, dependent: :destroy
   has_one_attached :image do |attachable|
-    attachable.variant :thumbnail, resize_to_fill: [160, 160], format: :webp, saver: { quality: 80 }
-    attachable.variant :preview, resize_to_fill: [512, 512], format: :webp, saver: { quality: 82 }
+    attachable.variant :thumbnail, resize_to_fill: [ 160, 160 ], format: :webp, saver: { quality: 80 }
+    attachable.variant :preview, resize_to_fill: [ 512, 512 ], format: :webp, saver: { quality: 82 }
   end
 
   # スコープ

--- a/app/models/usage_log.rb
+++ b/app/models/usage_log.rb
@@ -11,7 +11,7 @@ class UsageLog < ApplicationRecord
 
   scope :in_use, -> { where(finished_at: nil) }
   scope :finished, -> { where.not(finished_at: nil) }
-  scope :used_up_history, -> { where(finish_reason: [finish_reasons[:used_up], nil]) }
+  scope :used_up_history, -> { where(finish_reason: [ finish_reasons[:used_up], nil ]) }
   scope :rated, -> { where.not(rating: nil) }
   scope :by_rating, ->(rating) {
     return all if rating.blank?
@@ -33,7 +33,7 @@ class UsageLog < ApplicationRecord
     when "reviewed"
       where.not(review: nil).where.not(review: "")
     when "unreviewed"
-      where(review: [nil, ""])
+      where(review: [ nil, "" ])
     else
       all
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ module App
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w(assets tasks))
+    config.autoload_lib(ignore: %w[assets tasks])
 
     # Configuration for the application, engines, and railties goes here.
     #
@@ -32,10 +32,10 @@ module App
     config.i18n.default_locale = :ja
 
     # 利用可能なロケールを設定
-    config.i18n.available_locales = [:ja, :en]
+    config.i18n.available_locales = [ :ja, :en ]
 
     # i18nの読み込みパスを追加
-    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
+    config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]
 
     # Active Storageの画像加工にlibvipsを使う
     config.active_storage.variant_processor = :vips

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -36,7 +36,7 @@ Devise.setup do |config|
   # Load and configure the ORM. Supports :active_record (default) and
   # :mongoid (bson_ext recommended) by default. Other ORMs may be
   # available as additional gems.
-  require 'devise/orm/active_record'
+  require "devise/orm/active_record"
 
   # ==> Configuration for any authentication mechanism
   # Configure which keys are used when authenticating a user. The default is
@@ -46,7 +46,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  config.authentication_keys = [:email]
+  config.authentication_keys = [ :email ]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the
@@ -58,12 +58,12 @@ Devise.setup do |config|
   # Configure which authentication keys should be case-insensitive.
   # These keys will be downcased upon creating or modifying a user and when used
   # to authenticate or find a user. Default is :email.
-  config.case_insensitive_keys = [:email]
+  config.case_insensitive_keys = [ :email ]
 
   # Configure which authentication keys should have whitespace stripped.
   # These keys will have whitespace before and after removed upon creating or
   # modifying a user and when used to authenticate or find a user. Default is :email.
-  config.strip_whitespace_keys = [:email]
+  config.strip_whitespace_keys = [ :email ]
 
   # Tell if authentication through request.params is enabled. True by default.
   # It can be set to an array that will enable params authentication only for the
@@ -97,7 +97,7 @@ Devise.setup do |config|
   # Notice that if you are skipping storage for all authentication paths, you
   # may want to disable generating routes to Devise's sessions controller by
   # passing skip: :sessions to `devise_for` in your config/routes.rb
-  config.skip_session_storage = [:http_auth]
+  config.skip_session_storage = [ :http_auth ]
 
   # By default, Devise cleans up the CSRF token on authentication to
   # avoid CSRF token fixation attacks. This means that, when using AJAX

--- a/db/migrate/20260507161000_create_usage_logs.rb
+++ b/db/migrate/20260507161000_create_usage_logs.rb
@@ -11,8 +11,8 @@ class CreateUsageLogs < ActiveRecord::Migration[7.1]
       t.timestamps
     end
 
-    add_index :usage_logs, [:item_id, :finished_at]
-    add_index :usage_logs, [:user_id, :finished_at]
+    add_index :usage_logs, [ :item_id, :finished_at ]
+    add_index :usage_logs, [ :user_id, :finished_at ]
     add_index :usage_logs, :item_id,
               unique: true,
               where: "finished_at IS NULL",

--- a/db/migrate/20260514054702_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20260514054702_create_active_storage_tables.active_storage.rb
@@ -52,6 +52,6 @@ class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
       setting = config.options[config.orm][:primary_key_type]
       primary_key_type = setting || :primary_key
       foreign_key_type = setting || :bigint
-      [primary_key_type, foreign_key_type]
+      [ primary_key_type, foreign_key_type ]
     end
 end

--- a/db/migrate/20260601021000_convert_primary_keys_to_uuid.rb
+++ b/db/migrate/20260601021000_convert_primary_keys_to_uuid.rb
@@ -172,21 +172,21 @@ class ConvertPrimaryKeysToUuid < ActiveRecord::Migration[7.1]
     change_column_null :active_storage_variant_records, :blob_id, false
 
     add_index :items, :user_id
-    add_index :usage_logs, [:item_id, :finished_at]
+    add_index :usage_logs, [ :item_id, :finished_at ]
     add_index :usage_logs, :item_id
     add_index :usage_logs, :item_id,
               unique: true,
               where: "finished_at IS NULL",
               name: :index_usage_logs_on_item_id_where_in_use
-    add_index :usage_logs, [:user_id, :finished_at]
+    add_index :usage_logs, [ :user_id, :finished_at ]
     add_index :usage_logs, :user_id
     add_index :active_storage_attachments, :blob_id
     add_index :active_storage_attachments,
-              [:record_type, :record_id, :name, :blob_id],
+              [ :record_type, :record_id, :name, :blob_id ],
               name: :index_active_storage_attachments_uniqueness,
               unique: true
     add_index :active_storage_variant_records,
-              [:blob_id, :variation_digest],
+              [ :blob_id, :variation_digest ],
               name: :index_active_storage_variant_records_uniqueness,
               unique: true
 

--- a/db/migrate/20260602000000_create_categories.rb
+++ b/db/migrate/20260602000000_create_categories.rb
@@ -7,6 +7,6 @@ class CreateCategories < ActiveRecord::Migration[7.1]
       t.timestamps
     end
 
-    add_index :categories, [:user_id, :name], unique: true
+    add_index :categories, [ :user_id, :name ], unique: true
   end
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,5 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  driven_by :selenium, using: :chrome, screen_size: [ 1400, 1400 ]
 end

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -4,7 +4,7 @@ class ItemTest < ActiveSupport::TestCase
   include ActionDispatch::TestProcess::FixtureFile
 
   test "by_name returns items whose names partially match" do
-    assert_equal [items(:one)], Item.by_name("化粧").to_a
+    assert_equal [ items(:one) ], Item.by_name("化粧").to_a
   end
 
   test "by_name returns all items when query is blank" do
@@ -15,13 +15,13 @@ class ItemTest < ActiveSupport::TestCase
     item = items(:one)
     item.update!(category: categories(:hair_care))
 
-    assert_equal [item], Item.by_category(categories(:hair_care).id.to_s).to_a
+    assert_equal [ item ], Item.by_category(categories(:hair_care).id.to_s).to_a
   end
 
   test "by_category returns uncategorized items" do
     items(:one).update!(category: categories(:hair_care))
 
-    assert_equal [items(:two)], Item.by_category("uncategorized").to_a
+    assert_equal [ items(:two) ], Item.by_category("uncategorized").to_a
   end
 
   test "by_category returns all items when category is blank" do
@@ -485,9 +485,9 @@ class ItemTest < ActiveSupport::TestCase
   test "item image has display variants" do
     variants = Item.reflect_on_attachment(:image).named_variants
 
-    assert_equal [160, 160], variants[:thumbnail].transformations[:resize_to_fill]
+    assert_equal [ 160, 160 ], variants[:thumbnail].transformations[:resize_to_fill]
     assert_equal :webp, variants[:thumbnail].transformations[:format]
-    assert_equal [512, 512], variants[:preview].transformations[:resize_to_fill]
+    assert_equal [ 512, 512 ], variants[:preview].transformations[:resize_to_fill]
     assert_equal :webp, variants[:preview].transformations[:format]
   end
 
@@ -516,5 +516,4 @@ class ItemTest < ActiveSupport::TestCase
     assert_not item.valid?
     assert_includes item.errors[:image], "は10MB以下にしてください"
   end
-
 end

--- a/test/models/usage_log_test.rb
+++ b/test/models/usage_log_test.rb
@@ -16,7 +16,7 @@ class UsageLogTest < ActiveSupport::TestCase
       started_at: Time.zone.local(2026, 5, 11)
     )
 
-    assert_equal [matching_log], UsageLog.by_item_name("化粧").to_a
+    assert_equal [ matching_log ], UsageLog.by_item_name("化粧").to_a
     assert_not_includes UsageLog.by_item_name("化粧"), other_log
   end
 
@@ -41,7 +41,7 @@ class UsageLogTest < ActiveSupport::TestCase
       started_at: Time.zone.local(2026, 5, 11)
     )
 
-    assert_equal [matching_log],
+    assert_equal [ matching_log ],
                  UsageLog.by_item_category(categories(:hair_care).id.to_s).to_a
   end
 
@@ -56,7 +56,7 @@ class UsageLogTest < ActiveSupport::TestCase
       started_at: Time.zone.local(2026, 5, 11)
     )
 
-    assert_equal [uncategorized_log],
+    assert_equal [ uncategorized_log ],
                  UsageLog.by_item_category("uncategorized").to_a
   end
 

--- a/test/services/purchase_reminder_test.rb
+++ b/test/services/purchase_reminder_test.rb
@@ -10,7 +10,7 @@ class PurchaseReminderTest < ActiveSupport::TestCase
     end
 
     def deliver(user, entries)
-      @deliveries << [user, entries]
+      @deliveries << [ user, entries ]
     end
   end
 
@@ -27,7 +27,7 @@ class PurchaseReminderTest < ActiveSupport::TestCase
     assert_equal 1, count
     user, entries = @notifier.deliveries.first
     assert_equal item.user, user
-    assert_equal [{ item: item, stage: :first }], entries
+    assert_equal [ { item: item, stage: :first } ], entries
     item.reload
     assert item.reminder_first_sent_at.present?
     assert_nil item.reminder_second_sent_at


### PR DESCRIPTION
## 概要
コードスタイルの自動チェックとして Rubocop（rubocop-rails-omakase）を導入する。

Closes #79

## ルールセットについて
ルールを個別に選定せず、Rails公式が提供する `rubocop-rails-omakase` を採用した。判断の手間がなく、Rails 7.1以降の新規アプリでの採用例も多い。

## 変更内容
- `Gemfile` に `rubocop-rails-omakase` を development グループへ追加
- `.rubocop.yml` を追加（omakaseルールセットを継承するのみ）
- 既存コードの指摘69件（全て自動修正可能）を `rubocop -a` で解消
  - 配列リテラル内側の空白除去（58件）
  - 文字列クォートのダブルクォート統一（9件）
  - クラス末尾の余分な空行（1件）
  - `%w()` → `%w[]` の区切り文字統一（1件）
  - ロジックの変更は無し
- AGENTS.md に実行コマンドを追記

## 完了条件
- [x] Rubocopが導入され、コマンド一つでスタイルチェックできる
- [x] 既存コードの指摘が解消されている
- [x] 既存テストが壊れていない

## Test plan
- [x] `bundle exec rubocop`（指摘0件）
- [x] `bin/rails test`（245 runs, 0 failures）