### PR TITLE
CIにRubocopを組み込む

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,22 @@ on:
       - main
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2.2
+          bundler-cache: true
+
+      - name: Run Rubocop
+        run: bundle exec rubocop
+
   test:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## 概要
GitHub ActionsのCIに、既存の `test` ジョブと並行で走る `lint` ジョブ（Rubocop実行）を追加する。

Closes #246

## 変更内容
- `.github/workflows/ci.yml` に `lint` ジョブを追加（Ruby環境セットアップ→ `bundle exec rubocop`）
- `test` ジョブとは独立させ、どちらか一方が失敗しても他方の結果が分かるようにした

## 完了条件（issue #246より）
- [x] PR作成・pushのたびにRubocopが自動実行される
- [x] 指摘があればCIが失敗する

## Test plan
- [x] ローカルで `bundle exec rubocop`（指摘0件）
- [x] このPR自体のCI実行結果で `lint` ジョブが通ることを確認