### PR TITLE
GitHub Actionsから手動でRenderへデプロイできる設定を追加する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,74 @@
+name: Deploy to Render
+
+on:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2.2
+          bundler-cache: true
+
+      - name: Run Rubocop
+        run: bundle exec rubocop
+
+  test:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: user
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: app_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U user -d app_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      RAILS_ENV: test
+      POSTGRES_HOST: localhost
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2.2
+          bundler-cache: true
+
+      - name: Prepare database
+        run: bin/rails db:prepare
+
+      - name: Run tests
+        run: bin/rails test
+
+  deploy:
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Trigger Render deploy
+        run: curl --fail -X POST "$RENDER_DEPLOY_HOOK_URL"
+        env:
+          RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}

--- a/README.md
+++ b/README.md
@@ -155,6 +155,19 @@ https://monolog-note.com/
 | テスト | Minitest |
 | CI | GitHub Actions |
 
+## デプロイ
+
+- アプリ: Render / DB: Neon
+- `main` へのマージ時は GitHub Actions の CI（テスト・Rubocop）のみ実行され、自動デプロイはされない
+- デプロイは GitHub Actions の `Deploy to Render` ワークフロー（`.github/workflows/deploy.yml`）を手動実行（`workflow_dispatch`）することで行う。実行するとテスト・Rubocopが通った場合のみ Render の Deploy Hook を叩く
+- マイグレーションは Render 上のコンテナ起動時（`bin/docker-entrypoint`）に `bin/rails db:prepare` として自動実行される
+
+### 必要な GitHub repository secrets
+
+| 名前 | 内容 |
+| --- | --- |
+| `RENDER_DEPLOY_HOOK_URL` | Render のサービス設定にある Deploy Hook のURL |
+
 ## 使用技術の選定理由
 
 ### Ruby on Rails


### PR DESCRIPTION
## 概要
`main` マージ時に自動デプロイせず、GitHub Actionsの手動実行からRenderへデプロイできるようにする。

Closes #215

## 事前調査で分かったこと
- 本番（Render + Neon）は既に稼働中で、直近デプロイまでのmigrationは適用済みであることをNeonのSQL Editorで確認済み
- マイグレーションは `bin/docker-entrypoint` の `bin/rails db:prepare` により、コンテナ起動のたびに自動実行される仕組みが既に存在していた（Renderの有料機能であるShell/Pre-Deploy Commandの設定は不要）

## 変更内容
- `.github/workflows/deploy.yml` を追加（`workflow_dispatch` のみで起動、push/PRでは動かない）
- `lint`（Rubocop）→ `test` → 両方成功したら `deploy`（Render Deploy Hookを叩く）の順で実行
- README に「デプロイ」節を追加し、必要な GitHub secret（`RENDER_DEPLOY_HOOK_URL`）を明記

## デプロイ後にお願いしたい作業（ダッシュボード操作のため）
- Renderのサービス設定から Deploy Hook URL を取得
- GitHubリポジトリの Settings → Secrets and variables → Actions に `RENDER_DEPLOY_HOOK_URL` を登録
- Render側の Auto-Deploy 設定がOFFになっていることを確認（ONの場合はOFFに変更）

## 完了条件（issue #215より）
- [x] `main` にマージしても、Renderへ即時デプロイされない
- [ ] `Deploy to Render` workflowを手動実行するとRenderのデプロイが開始される（secret登録後に実施確認）
- [x] Renderが Neon のDBに接続して本番起動できる（確認済み）
- [x] 必要な secrets / 環境変数がREADMEで確認できる
- [x] デプロイ失敗時にGitHub Actionsのログから原因を確認できる（テスト・Rubocopが先に失敗すればそこで止まる）

## Test plan
- [x] YAML構文チェック
- [x] このPRのCI（既存の`lint`/`test`ジョブ）が通ることを確認