### PR TITLE
星評価UIをhelper化する

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,6 +20,13 @@ module ApplicationHelper
     date&.strftime("%Y/%-m/%-d") || "-"
   end
 
+  # 星評価を★☆で表示する（小数の場合は四捨五入する）
+  def star_rating(rating)
+    filled = "★" * rating.round
+    empty = content_tag(:span, "☆" * (5 - rating.round), class: "text-slate-300")
+    safe_join([ filled, empty ])
+  end
+
   def category_filter_class(selected_category_id, category_id)
     if selected_category_id.to_s == category_id.to_s
       "rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white"

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -61,7 +61,7 @@
           <dt class="text-xs text-slate-500">平均評価</dt>
           <dd class="mt-1 font-semibold text-slate-800">
             <% if @average_rating.present? %>
-              <span class="text-yellow-500"><%= "★" * @average_rating.round %><span class="text-slate-300"><%= "☆" * (5 - @average_rating.round) %></span></span>
+              <span class="text-yellow-500"><%= star_rating(@average_rating) %></span>
               <span class="ml-1"><%= @average_rating %></span>
             <% else %>
               未評価

--- a/app/views/usage_logs/reviews.html.erb
+++ b/app/views/usage_logs/reviews.html.erb
@@ -98,14 +98,14 @@
                 <div class="inline-flex items-center gap-1.5 rounded-lg bg-slate-50 px-2.5 py-1">
                   <dt class="text-xs font-medium text-slate-500">今回の評価</dt>
                   <dd class="font-semibold text-yellow-500">
-                    <%= "★" * usage_log.rating %><span class="text-slate-300"><%= "☆" * (5 - usage_log.rating) %></span>
+                    <%= star_rating(usage_log.rating) %>
                   </dd>
                 </div>
                 <div class="inline-flex items-center gap-1.5 rounded-lg bg-slate-50 px-2.5 py-1 text-slate-700">
                   <dt class="text-xs font-medium text-slate-500">平均</dt>
                   <dd>
                     <% if average_rating.present? %>
-                      <span class="text-yellow-500"><%= "★" * average_rating.round %><span class="text-slate-300"><%= "☆" * (5 - average_rating.round) %></span></span>
+                      <span class="text-yellow-500"><%= star_rating(average_rating) %></span>
                       <span class="ml-1"><%= average_rating %>（<%= rating_count %>件）</span>
                     <% else %>
                       <span class="text-slate-400">未評価</span>

--- a/app/views/usage_logs/show.html.erb
+++ b/app/views/usage_logs/show.html.erb
@@ -86,7 +86,7 @@
         <h2 class="form-label">評価・レビュー</h2>
         <div class="rounded-lg bg-slate-50 p-3 text-sm">
           <p class="font-semibold text-yellow-500">
-            <%= "★" * @usage_log.rating %><span class="text-slate-300"><%= "☆" * (5 - @usage_log.rating) %></span>
+            <%= star_rating(@usage_log.rating) %>
           </p>
           <p class="mt-2 whitespace-pre-wrap text-slate-700"><%= @usage_log.review.presence || "レビューなし" %></p>
         </div>


### PR DESCRIPTION
## 概要
複数画面に重複していた星評価表示（★☆）を `ApplicationHelper#star_rating` に共通化する。

Closes #211

## 変更内容
- `ApplicationHelper#star_rating(rating)` を追加（`safe_join` で安全にHTML組み立て、小数は四捨五入）
- `usage_logs/show.html.erb`・`usage_logs/reviews.html.erb`（2箇所）・`items/show.html.erb` の計4箇所を置き換え
- issue本文を検討結果（helper化する、という判断）に合わせて更新

## 完了条件（issue #211より）
- [x] 星評価UIをhelper化するか判断できている（→ helper化する）
- [x] 既存画面の表示が維持されている
- [x] 表示崩れがない

## Test plan
- [x] `bin/rails test`（245 runs, 0 failures）
- [x] `bundle exec rubocop`（指摘0件）