### PR TITLE
ページごとのmeta titleを@page_titleから設定できるようにする

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,8 @@ module ApplicationHelper
   DEFAULT_OG_IMAGE = "ogp.png".freeze
 
   def meta_title
-    content_for?(:title) ? "#{content_for(:title)} | #{DEFAULT_META_TITLE}" : DEFAULT_META_TITLE
+    title = content_for(:title).presence || @page_title.presence
+    title.present? ? "#{title} | #{DEFAULT_META_TITLE}" : DEFAULT_META_TITLE
   end
 
   def meta_description

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -572,6 +572,14 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to in_use_items_path
   end
 
+  test "in_use page sets meta title from page title" do
+    get in_use_items_path
+
+    assert_response :success
+    assert_select "title", text: "使用中アイテム | ものログ"
+    assert_select "meta[property='og:title'][content='使用中アイテム | ものログ']"
+  end
+
   test "in_use page shows finish using modal in item card" do
     item = items(:one)
     item.start_using!(@user, Time.zone.local(2026, 5, 10))


### PR DESCRIPTION
## 概要
OGP/メタ情報の管理を体系化する。既存の `meta_title` ヘルパーが `@page_title` も見るようにし、既存のページタイトルをブラウザタブ・OGPにも反映させる。

Closes #207

## 変更内容
- `ApplicationHelper#meta_title` を `content_for(:title) || @page_title` にフォールバック
- ビュー・コントローラの変更は無し（既存の `@page_title` をそのまま活用）
- controller テストを1件追加（使用中アイテムページのtitle/OGPを確認）
- issue本文を検討結果に合わせて更新

## 完了条件（issue #207より）
- [x] OGP/メタ情報の出力が共通helperで管理されている
- [x] デフォルトのメタ情報が設定されている
- [x] ページごとのtitle情報を差し替えられる
- [x] 主要ページで期待したmeta tagが出力されることを確認できている

## Test plan
- [x] `bin/rails test`（246 runs, 0 failures）
- [x] `bundle exec rubocop`（指摘0件）