### PR TITLE
検索欄にオートコンプリートを追加する

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -76,6 +76,19 @@ class ItemsController < ApplicationController
                               .page(params[:page])
   end
 
+  # 検索欄のオートコンプリート候補（アイテム名）をJSONで返す
+  def autocomplete
+    query = params[:q].to_s.strip
+    names =
+      if query.length >= 2
+        current_user.items.by_name(query).order(:name).distinct.limit(10).pluck(:name)
+      else
+        []
+      end
+
+    render json: names
+  end
+
   def new
     @item = current_user.items.new
   end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -119,3 +119,108 @@ document.addEventListener("keydown", (event) => {
   })
   document.body.classList.remove("overflow-hidden")
 })
+
+const AUTOCOMPLETE_MIN_LENGTH = 2
+const AUTOCOMPLETE_DEBOUNCE_MS = 300
+const AUTOCOMPLETE_ITEM_CLASS =
+  "cursor-pointer px-3 py-2 text-sm text-slate-700 hover:bg-emerald-50 aria-selected:bg-emerald-100"
+const autocompleteTimers = new WeakMap()
+
+function closeAutocompleteList(list) {
+  list.innerHTML = ""
+  list.classList.add("hidden")
+}
+
+function renderAutocompleteList(list, names) {
+  if (names.length === 0) {
+    closeAutocompleteList(list)
+    return
+  }
+
+  list.innerHTML = ""
+  names.forEach((name) => {
+    const item = document.createElement("li")
+    item.textContent = name
+    item.setAttribute("role", "option")
+    item.setAttribute("aria-selected", "false")
+    item.dataset.autocompleteItem = "true"
+    item.className = AUTOCOMPLETE_ITEM_CLASS
+    list.appendChild(item)
+  })
+
+  list.classList.remove("hidden")
+}
+
+document.addEventListener("input", (event) => {
+  const input = event.target
+  if (!input.matches("[data-autocomplete-input]")) return
+
+  const list = input.closest("[data-autocomplete-container]")?.querySelector("[data-autocomplete-list]")
+  if (!list) return
+
+  clearTimeout(autocompleteTimers.get(input))
+
+  const query = input.value.trim()
+  if (query.length < AUTOCOMPLETE_MIN_LENGTH) {
+    closeAutocompleteList(list)
+    return
+  }
+
+  autocompleteTimers.set(
+    input,
+    setTimeout(() => {
+      list.innerHTML = "<li class=\"px-3 py-2 text-sm text-slate-400\">検索中...</li>"
+      list.classList.remove("hidden")
+
+      fetch(`/items/autocomplete?q=${encodeURIComponent(query)}`, { headers: { Accept: "application/json" } })
+        .then((response) => response.json())
+        .then((names) => renderAutocompleteList(list, names))
+        .catch(() => closeAutocompleteList(list))
+    }, AUTOCOMPLETE_DEBOUNCE_MS)
+  )
+})
+
+document.addEventListener("keydown", (event) => {
+  if (!event.target.matches("[data-autocomplete-input]")) return
+
+  const list = event.target.closest("[data-autocomplete-container]")?.querySelector("[data-autocomplete-list]")
+  if (!list || list.classList.contains("hidden")) return
+
+  const items = Array.from(list.querySelectorAll("[data-autocomplete-item]"))
+  if (items.length === 0) return
+
+  const activeIndex = items.findIndex((item) => item.getAttribute("aria-selected") === "true")
+
+  if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+    event.preventDefault()
+    const step = event.key === "ArrowDown" ? 1 : -1
+    const nextIndex = (activeIndex + step + items.length) % items.length
+    items.forEach((item) => item.setAttribute("aria-selected", "false"))
+    items[nextIndex].setAttribute("aria-selected", "true")
+    items[nextIndex].scrollIntoView({ block: "nearest" })
+  } else if (event.key === "Enter" && activeIndex >= 0) {
+    event.preventDefault()
+    event.target.value = items[activeIndex].textContent
+    closeAutocompleteList(list)
+  } else if (event.key === "Escape") {
+    closeAutocompleteList(list)
+  }
+})
+
+document.addEventListener("click", (event) => {
+  const selectedItem = event.target.closest("[data-autocomplete-item]")
+  if (selectedItem) {
+    const list = selectedItem.closest("[data-autocomplete-list]")
+    const input = selectedItem.closest("[data-autocomplete-container]")?.querySelector("[data-autocomplete-input]")
+    if (input) input.value = selectedItem.textContent
+    closeAutocompleteList(list)
+    return
+  }
+
+  document.querySelectorAll("[data-autocomplete-container]").forEach((container) => {
+    if (container.contains(event.target)) return
+
+    const list = container.querySelector("[data-autocomplete-list]")
+    if (list) closeAutocompleteList(list)
+  })
+})

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -14,11 +14,16 @@
         </svg>
       </span>
 
-      <div class="flex-1">
+      <div class="relative flex-1" data-autocomplete-container>
         <%= search_field_tag :q,
                              query,
                              placeholder: "アイテム名で検索",
-                             class: "form-input h-10" %>
+                             class: "form-input h-10",
+                             autocomplete: "off",
+                             data: { autocomplete_input: true } %>
+        <ul class="absolute z-10 mt-1 hidden max-h-60 w-full overflow-auto rounded-lg border border-slate-200 bg-white py-1 shadow-lg"
+            role="listbox"
+            data-autocomplete-list></ul>
       </div>
     </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
       get :used_up
       get :discontinued
       get :in_use
+      get :autocomplete
     end
   end
 

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -90,6 +90,47 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "autocomplete returns matching item names for current user" do
+    @user.items.create!(name: "化粧水A", stock_quantity: 1)
+    @user.items.create!(name: "化粧水B", stock_quantity: 1)
+    @user.items.create!(name: "歯ブラシ", stock_quantity: 1)
+
+    get autocomplete_items_path, params: { q: "化粧" }
+
+    assert_response :success
+    names = JSON.parse(response.body)
+    assert_includes names, "化粧水A"
+    assert_includes names, "化粧水B"
+    assert_not_includes names, "歯ブラシ"
+  end
+
+  test "autocomplete excludes other user's items" do
+    users(:two).items.create!(name: "化粧水X", stock_quantity: 1)
+
+    get autocomplete_items_path, params: { q: "化粧" }
+
+    assert_response :success
+    assert_not_includes JSON.parse(response.body), "化粧水X"
+  end
+
+  test "autocomplete limits results to 10" do
+    12.times { |i| @user.items.create!(name: "検索アイテム#{i}", stock_quantity: 1) }
+
+    get autocomplete_items_path, params: { q: "検索アイテム" }
+
+    assert_response :success
+    assert_equal 10, JSON.parse(response.body).size
+  end
+
+  test "autocomplete returns empty array for query shorter than 2 characters" do
+    @user.items.create!(name: "化粧水", stock_quantity: 1)
+
+    get autocomplete_items_path, params: { q: "化" }
+
+    assert_response :success
+    assert_equal [], JSON.parse(response.body)
+  end
+
   test "index shows a message when search has no results" do
     get items_path, params: { q: "存在しないアイテム" }
 


### PR DESCRIPTION
## 概要
アイテム検索欄（一覧・使用中・使い切り・使用中止・レビューの5画面共通パーシャル）にオートコンプリートを追加する。

Closes #73

## 変更内容
- `GET /items/autocomplete`（`ItemsController#autocomplete`）を追加。2文字以上で自分のアイテム名を部分一致検索、最大10件、重複除去
- `shared/_search_form.html.erb` に候補リストのUIを追加（5画面すべてに自動反映）
- `application.js` にデバウンス・fetch・キーボード操作（↑↓/Enter/Esc）・クリック確定・外側クリックで閉じる、を実装
- controller テスト4件を追加

## issue本文からの変更点
「候補が見つかりませんでした」の表示は、検討の結果なくし、**候補がなければ静かにリストを閉じる**方針にした（issue本文を更新済み）。

## 完了条件（issue #73より、更新後）
- [x] 検索フィールドに文字を入力すると候補が表示される
- [x] 候補をクリックすると検索フィールドに反映される
- [x] キーボード操作（↑↓、Enter）で候補を選択できる
- [x] デバウンス処理により無駄なリクエストが発生しない
- [x] 候補がない場合は候補リストが表示されない
- [x] ローディング表示が機能している

## Test plan
- [x] `bin/rails test`（250 runs, 0 failures）
- [x] `bundle exec rubocop`（指摘0件）
- [x] JS構文チェック（`node --check`）
- [x] 開発環境のブラウザで動作確認（候補表示・キーボード操作・候補なし時の挙動）