### PR TITLE
アイテムの1日あたりコストを表示する

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -60,6 +60,16 @@ class Item < ApplicationRecord
     (durations.sum.to_f / durations.size).round
   end
 
+  # 1日あたりのコスト（価格 ÷ 平均使用日数）。価格または平均使用日数が無ければ nil
+  def cost_per_day
+    return if price.blank?
+
+    average_days = average_usage_days
+    return if average_days.blank?
+
+    (price.to_f / average_days).round
+  end
+
   def average_rating
     ratings = usage_logs.rated.pluck(:rating)
     return if ratings.blank?

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -41,6 +41,13 @@
         </div>
 
         <div class="rounded-lg bg-slate-50 p-3">
+          <dt class="text-xs text-slate-500">1日あたりコスト</dt>
+          <dd class="mt-1 font-semibold text-slate-800">
+            <%= @item.cost_per_day.present? ? "#{number_with_delimiter(@item.cost_per_day)}円/日" : "データなし" %>
+          </dd>
+        </div>
+
+        <div class="rounded-lg bg-slate-50 p-3">
           <dt class="text-xs text-slate-500">在庫数</dt>
           <dd class="mt-1 font-semibold <%= @item.out_of_stock? ? "text-red-700" : "text-slate-800" %>">
             <%= @item.stock_quantity %>
@@ -62,16 +69,11 @@
           <dd class="mt-1 font-semibold text-slate-800">
             <% if @average_rating.present? %>
               <span class="text-yellow-500"><%= star_rating(@average_rating) %></span>
-              <span class="ml-1"><%= @average_rating %></span>
+              <span class="ml-1"><%= @average_rating %>（<%= @rating_count %>件）</span>
             <% else %>
               未評価
             <% end %>
           </dd>
-        </div>
-
-        <div class="rounded-lg bg-slate-50 p-3">
-          <dt class="text-xs text-slate-500">評価件数</dt>
-          <dd class="mt-1 font-semibold text-slate-800"><%= "#{@rating_count}件" %></dd>
         </div>
       </dl>
     </div>

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -1599,9 +1599,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_includes response.body, "平均評価"
-    assert_includes response.body, "4.0"
-    assert_includes response.body, "評価件数"
-    assert_includes response.body, "2件"
+    assert_includes response.body, "4.0（2件）"
   end
 
   test "show displays unrated message when item has no ratings" do
@@ -1612,7 +1610,6 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, "平均評価"
     assert_includes response.body, "未評価"
-    assert_includes response.body, "0件"
   end
 
   test "show uses consistent finish using button label for in-use item" do

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -248,6 +248,31 @@ class ItemTest < ActiveSupport::TestCase
     assert_nil item.average_usage_days
   end
 
+  test "cost_per_day divides price by average usage days" do
+    item = items(:one)
+    item.update!(price: 1000)
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 1))
+    item.finish_using!(Time.zone.local(2026, 5, 10))
+
+    assert_equal 100, item.cost_per_day
+  end
+
+  test "cost_per_day returns nil when price is blank" do
+    item = items(:one)
+    item.update!(price: nil)
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 1))
+    item.finish_using!(Time.zone.local(2026, 5, 10))
+
+    assert_nil item.cost_per_day
+  end
+
+  test "cost_per_day returns nil when average usage days is unavailable" do
+    item = items(:one)
+    item.update!(price: 1000)
+
+    assert_nil item.cost_per_day
+  end
+
   test "average_rating uses only usage logs with rating" do
     item = items(:one)
     item.start_using!(users(:one), Time.zone.local(2026, 5, 1))


### PR DESCRIPTION
## 概要
価格と使い切り履歴から「1日あたりコスト」を計算し、アイテム詳細に表示する。次の買い物の判断材料にする。

Closes #132

## 変更内容
- `Item#cost_per_day`（`price ÷ average_usage_days`、どちらか無ければnil）を追加
- アイテム詳細画面に「1日あたりコスト」タイルを追加
- ついでに「評価件数」の単独タイルを削除し、「平均評価」タイルに統合（例: `4.0（2件）`）
- テストを追加・調整

## 完了条件（issue #132より）
- [x] アイテムごとに1日あたりコストの目安が確認できる
- [x] データ不足時に不自然な表示にならない（「データなし」）

## Test plan
- [x] `bin/rails test`（253 runs, 0 failures）
- [x] `bundle exec rubocop`（指摘0件）
- [x] 開発環境のブラウザで実データを使って確認