### PR TITLE
アイテムの使用頻度を記録し、コスパ計算に反映する

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -238,7 +238,7 @@ class ItemsController < ApplicationController
   end
 
   def item_params
-    params.require(:item).permit(:name, :brand_name, :price, :stock_quantity, :favorite, :memo, :image)
+    params.require(:item).permit(:name, :brand_name, :price, :stock_quantity, :favorite, :memo, :image, :usage_frequency)
   end
 
   # 検索・絞り込み・ページ指定のない初期表示のときだけ「もうすぐ無くなりそう」を出す

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,10 +1,24 @@
 class Item < ApplicationRecord
   attr_accessor :new_category_name, :remove_category
 
+  # 使用頻度の選択肢。ユーザーには選択肢のまま見せ、厳密な回数入力は求めない
+  USAGE_FREQUENCIES = %w[毎日 朝晩 週に数回 たまに その他].freeze
+
+  # コスパ計算用の「週あたり想定使用回数」の目安（ユーザーには非表示）。
+  # 選択式のまま計算に使えるようにするための内部マッピング。
+  # 「その他」は回数を仮定できないため意図的に含めず、1日あたりコストにフォールバックする
+  USAGE_FREQUENCY_WEEKLY_COUNTS = {
+    "毎日" => 7,
+    "朝晩" => 14,
+    "週に数回" => 3,
+    "たまに" => 1
+  }.freeze
+
   validates :name, presence: true, length: { maximum: 100 }
   validates :brand_name, length: { maximum: 100 }
   validates :price, numericality: { only_integer: true, allow_blank: true, greater_than_or_equal_to: 0 }
   validates :stock_quantity, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :usage_frequency, inclusion: { in: USAGE_FREQUENCIES }, allow_blank: true
   validate :image_content_type
   validate :image_size
 
@@ -68,6 +82,23 @@ class Item < ApplicationRecord
     return if average_days.blank?
 
     (price.to_f / average_days).round
+  end
+
+  # 1回あたりのコスト。使用頻度が「その他」・未設定、または平均使用日数が
+  # 不明な場合は nil（呼び出し側は cost_per_day にフォールバックする）
+  def cost_per_use
+    return if price.blank?
+
+    weekly_count = USAGE_FREQUENCY_WEEKLY_COUNTS[usage_frequency]
+    return if weekly_count.blank?
+
+    average_days = average_usage_days
+    return if average_days.blank?
+
+    expected_uses = average_days.to_f / 7 * weekly_count
+    return if expected_uses.zero?
+
+    (price.to_f / expected_uses).round
   end
 
   def average_rating

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -28,6 +28,15 @@
       <p class="form-help">メーカー名やブランド名を残しておくと、あとから見返しやすくなります。</p>
     </div>
 
+    <!-- 使用頻度 -->
+    <div>
+      <%= f.label :usage_frequency, "使用頻度", class: "form-label" %>
+      <%= f.select :usage_frequency,
+                   Item::USAGE_FREQUENCIES,
+                   { include_blank: "選択してください" },
+                   { class: "form-input" } %>
+    </div>
+
     <!-- カテゴリ -->
     <div class="space-y-3">
       <%= render "category_combobox", form: f, item: item, categories: categories %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -41,10 +41,20 @@
         </div>
 
         <div class="rounded-lg bg-slate-50 p-3">
-          <dt class="text-xs text-slate-500">1日あたりコスト</dt>
-          <dd class="mt-1 font-semibold text-slate-800">
-            <%= @item.cost_per_day.present? ? "#{number_with_delimiter(@item.cost_per_day)}円/日" : "データなし" %>
-          </dd>
+          <% if @item.cost_per_use.present? %>
+            <dt class="text-xs text-slate-500">1回あたりコスト</dt>
+            <dd class="mt-1 font-semibold text-slate-800"><%= number_with_delimiter(@item.cost_per_use) %>円/回</dd>
+          <% else %>
+            <dt class="text-xs text-slate-500">1日あたりコスト</dt>
+            <dd class="mt-1 font-semibold text-slate-800">
+              <%= @item.cost_per_day.present? ? "#{number_with_delimiter(@item.cost_per_day)}円/日" : "データなし" %>
+            </dd>
+          <% end %>
+        </div>
+
+        <div class="rounded-lg bg-slate-50 p-3">
+          <dt class="text-xs text-slate-500">使用頻度</dt>
+          <dd class="mt-1 font-semibold text-slate-800"><%= @item.usage_frequency.presence || "未設定" %></dd>
         </div>
 
         <div class="rounded-lg bg-slate-50 p-3">

--- a/db/migrate/20260724000000_add_usage_frequency_to_items.rb
+++ b/db/migrate/20260724000000_add_usage_frequency_to_items.rb
@@ -1,0 +1,5 @@
+class AddUsageFrequencyToItems < ActiveRecord::Migration[7.1]
+  def change
+    add_column :items, :usage_frequency, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_07_19_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_24_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -67,6 +67,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_19_000000) do
     t.date "predicted_finish_on"
     t.datetime "reminder_first_sent_at"
     t.datetime "reminder_second_sent_at"
+    t.string "usage_frequency"
     t.index ["archived"], name: "index_items_on_archived"
     t.index ["category_id"], name: "index_items_on_category_id"
     t.index ["predicted_finish_on"], name: "index_items_on_predicted_finish_on"

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -1394,6 +1394,43 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_equal category, item.reload.category
   end
 
+  test "update changes usage frequency" do
+    item = items(:one)
+
+    patch item_path(item), params: {
+      item: {
+        name: item.name,
+        price: item.price,
+        stock_quantity: item.stock_quantity,
+        usage_frequency: "毎日"
+      }
+    }
+
+    assert_redirected_to items_path
+    assert_equal "毎日", item.reload.usage_frequency
+  end
+
+  test "show displays usage frequency" do
+    item = items(:one)
+    item.update!(usage_frequency: "朝晩")
+
+    get item_path(item)
+
+    assert_response :success
+    assert_select "dt", text: "使用頻度"
+    assert_includes response.body, "朝晩"
+  end
+
+  test "show displays unset message when usage frequency is blank" do
+    item = items(:one)
+
+    get item_path(item)
+
+    assert_response :success
+    assert_select "dt", text: "使用頻度"
+    assert_select "dd", text: "未設定"
+  end
+
   test "update changes brand name" do
     item = items(:one)
 

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -273,6 +273,51 @@ class ItemTest < ActiveSupport::TestCase
     assert_nil item.cost_per_day
   end
 
+  test "cost_per_use divides price by expected weekly uses" do
+    item = items(:one)
+    item.update!(price: 2000, usage_frequency: "毎日")
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 1))
+    item.finish_using!(Time.zone.local(2026, 5, 20))
+
+    # 平均使用日数20日、毎日=週7回 → 想定使用回数20回 → 2000÷20
+    assert_equal 100, item.cost_per_use
+  end
+
+  test "cost_per_use gives the same result regardless of frequency for the same real cost per use" do
+    # 毎日(週7回)で7日使い切り = 実質7回使用。たまに(週1回)で49日使い切り = 同じく実質7回使用。
+    # 使う回数が同じなら、頻度が違っても1回あたりコストは同じになるはず
+    daily_item = items(:one)
+    daily_item.update!(price: 700, usage_frequency: "毎日")
+    daily_item.start_using!(users(:one), Time.zone.local(2026, 5, 1))
+    daily_item.finish_using!(Time.zone.local(2026, 5, 7))
+
+    occasional_item = items(:two)
+    occasional_item.update!(price: 700, usage_frequency: "たまに")
+    occasional_item.start_using!(users(:one), Time.zone.local(2026, 5, 1))
+    occasional_item.finish_using!(Time.zone.local(2026, 6, 18))
+
+    assert_equal 100, daily_item.cost_per_use
+    assert_equal daily_item.cost_per_use, occasional_item.cost_per_use
+  end
+
+  test "cost_per_use returns nil when usage_frequency is その他" do
+    item = items(:one)
+    item.update!(price: 2000, usage_frequency: "その他")
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 1))
+    item.finish_using!(Time.zone.local(2026, 5, 20))
+
+    assert_nil item.cost_per_use
+  end
+
+  test "cost_per_use returns nil when usage_frequency is blank" do
+    item = items(:one)
+    item.update!(price: 2000)
+    item.start_using!(users(:one), Time.zone.local(2026, 5, 1))
+    item.finish_using!(Time.zone.local(2026, 5, 20))
+
+    assert_nil item.cost_per_use
+  end
+
   test "average_rating uses only usage logs with rating" do
     item = items(:one)
     item.start_using!(users(:one), Time.zone.local(2026, 5, 1))


### PR DESCRIPTION
## 概要
アイテムごとに使用頻度を選択式で記録できるようにし、コスパ計算（#132の「1日あたりコスト」）の精度を上げる。

Closes #175

## 背景
「1日あたりコスト」は、毎日使わないアイテムを実態より安く見せてしまう弱点があった（例: 交互に使う2つのアイテムが同じ実質コストでも、暦日数の違いで片方が倍お得に見える）。使用頻度が分かれば「1回あたりコスト」を正確に出せる。

## 変更内容
- `items.usage_frequency`（文字列）を追加
- 選択肢（毎日/朝晩/週に数回/たまに/その他）と、コスパ計算専用の内部マッピング（週あたり目安回数）を`Item`に追加。ユーザーには選択肢のまま見せ、厳密な回数入力は求めない設計
- `Item#cost_per_use`を追加。頻度が「その他」または未設定の場合は`cost_per_day`にフォールバック
- 登録・編集フォームに選択欄を追加、詳細画面はコスパ表示を自動で「1回あたり」⇔「1日あたり」に切り替え
- テストを追加（頻度が違っても実質コストが同じなら同じ結果になることを検証するテストを含む）

## 完了条件（issue #175より）
- [x] アイテム登録・編集画面で使用頻度を選択できる
- [x] アイテム詳細画面で使用頻度を確認できる
- [x] 使用頻度が設定されている場合、コスパ表示が「1回あたりコスト」になる
- [x] 使用頻度が未設定または「その他」の場合、従来どおり「1日あたりコスト」が表示される
- [x] 未入力の場合は「未設定」表示になる
- [x] model / controller test が追加される

## Test plan
- [x] `bin/rails test`（260 runs, 0 failures）
- [x] `bundle exec rubocop`（指摘0件）
- [x] 開発環境のブラウザで実際に使用頻度を設定し、DB・表示を確認