### PR TITLE
アイテムに容量を入力できるようにする

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -238,7 +238,7 @@ class ItemsController < ApplicationController
   end
 
   def item_params
-    params.require(:item).permit(:name, :brand_name, :price, :stock_quantity, :favorite, :memo, :image, :usage_frequency)
+    params.require(:item).permit(:name, :brand_name, :price, :stock_quantity, :favorite, :memo, :image, :usage_frequency, :capacity, :capacity_unit)
   end
 
   # 検索・絞り込み・ページ指定のない初期表示のときだけ「もうすぐ無くなりそう」を出す

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,11 +14,16 @@ class Item < ApplicationRecord
     "たまに" => 1
   }.freeze
 
+  # 容量の単位の選択肢
+  CAPACITY_UNITS = %w[ml g kg 枚 個].freeze
+
   validates :name, presence: true, length: { maximum: 100 }
   validates :brand_name, length: { maximum: 100 }
   validates :price, numericality: { only_integer: true, allow_blank: true, greater_than_or_equal_to: 0 }
   validates :stock_quantity, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :usage_frequency, inclusion: { in: USAGE_FREQUENCIES }, allow_blank: true
+  validates :capacity, numericality: { allow_blank: true, greater_than: 0 }
+  validates :capacity_unit, inclusion: { in: CAPACITY_UNITS }, allow_blank: true
   validate :image_content_type
   validate :image_size
 
@@ -99,6 +104,13 @@ class Item < ApplicationRecord
     return if expected_uses.zero?
 
     (price.to_f / expected_uses).round
+  end
+
+  # 容量あたりのコスト（価格 ÷ 容量）。価格または容量が未入力の場合は nil
+  def cost_per_capacity
+    return if price.blank? || capacity.blank?
+
+    (price.to_f / capacity).round(1)
   end
 
   def average_rating

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -134,6 +134,22 @@
       </div>
     <% end %>
 
+    <!-- 容量 -->
+    <div class="grid gap-4 sm:grid-cols-2">
+      <div>
+        <%= f.label :capacity, "容量", class: "form-label" %>
+        <%= f.text_field :capacity, class: "form-input", placeholder: "例: 500" %>
+      </div>
+
+      <div>
+        <%= f.label :capacity_unit, "単位", class: "form-label" %>
+        <%= f.select :capacity_unit,
+                     Item::CAPACITY_UNITS,
+                     { include_blank: "選択してください" },
+                     { class: "form-input" } %>
+      </div>
+    </div>
+
     <!-- メモ -->
     <div>
       <%= f.label :memo, class: "form-label" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -53,6 +53,20 @@
         </div>
 
         <div class="rounded-lg bg-slate-50 p-3">
+          <dt class="text-xs text-slate-500">容量</dt>
+          <dd class="mt-1 font-semibold text-slate-800">
+            <%= @item.capacity.present? ? "#{number_with_precision(@item.capacity, precision: 2, strip_insignificant_zeros: true)}#{@item.capacity_unit}" : "未設定" %>
+          </dd>
+        </div>
+
+        <div class="rounded-lg bg-slate-50 p-3">
+          <dt class="text-xs text-slate-500">容量あたりコスト</dt>
+          <dd class="mt-1 font-semibold text-slate-800">
+            <%= @item.cost_per_capacity.present? ? "#{number_with_delimiter(@item.cost_per_capacity)}円/#{@item.capacity_unit}" : "データなし" %>
+          </dd>
+        </div>
+
+        <div class="rounded-lg bg-slate-50 p-3">
           <dt class="text-xs text-slate-500">使用頻度</dt>
           <dd class="mt-1 font-semibold text-slate-800"><%= @item.usage_frequency.presence || "未設定" %></dd>
         </div>

--- a/db/migrate/20260725000000_add_capacity_to_items.rb
+++ b/db/migrate/20260725000000_add_capacity_to_items.rb
@@ -1,0 +1,6 @@
+class AddCapacityToItems < ActiveRecord::Migration[7.1]
+  def change
+    add_column :items, :capacity, :decimal, precision: 8, scale: 2
+    add_column :items, :capacity_unit, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_07_24_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_25_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -68,6 +68,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_24_000000) do
     t.datetime "reminder_first_sent_at"
     t.datetime "reminder_second_sent_at"
     t.string "usage_frequency"
+    t.decimal "capacity", precision: 8, scale: 2
+    t.string "capacity_unit"
     t.index ["archived"], name: "index_items_on_archived"
     t.index ["category_id"], name: "index_items_on_category_id"
     t.index ["predicted_finish_on"], name: "index_items_on_predicted_finish_on"

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -1431,6 +1431,48 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "dd", text: "未設定"
   end
 
+  test "update changes capacity and capacity_unit" do
+    item = items(:one)
+
+    patch item_path(item), params: {
+      item: {
+        name: item.name,
+        price: item.price,
+        stock_quantity: item.stock_quantity,
+        capacity: "500",
+        capacity_unit: "ml"
+      }
+    }
+
+    assert_redirected_to items_path
+    item.reload
+    assert_equal 500, item.capacity
+    assert_equal "ml", item.capacity_unit
+  end
+
+  test "show displays capacity and cost per capacity" do
+    item = items(:one)
+    item.update!(price: 1000, capacity: 500, capacity_unit: "ml")
+
+    get item_path(item)
+
+    assert_response :success
+    assert_select "dt", text: "容量"
+    assert_includes response.body, "500ml"
+    assert_select "dt", text: "容量あたりコスト"
+    assert_includes response.body, "2.0円/ml"
+  end
+
+  test "show displays unset message when capacity is blank" do
+    item = items(:one)
+
+    get item_path(item)
+
+    assert_response :success
+    assert_select "dt", text: "容量"
+    assert_select "dd", text: "未設定"
+  end
+
   test "update changes brand name" do
     item = items(:one)
 

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -318,6 +318,27 @@ class ItemTest < ActiveSupport::TestCase
     assert_nil item.cost_per_use
   end
 
+  test "cost_per_capacity divides price by capacity" do
+    item = items(:one)
+    item.update!(price: 1000, capacity: 500, capacity_unit: "ml")
+
+    assert_equal 2.0, item.cost_per_capacity
+  end
+
+  test "cost_per_capacity returns nil when price is blank" do
+    item = items(:one)
+    item.update!(price: nil, capacity: 500, capacity_unit: "ml")
+
+    assert_nil item.cost_per_capacity
+  end
+
+  test "cost_per_capacity returns nil when capacity is blank" do
+    item = items(:one)
+    item.update!(price: 1000, capacity: nil)
+
+    assert_nil item.cost_per_capacity
+  end
+
   test "average_rating uses only usage logs with rating" do
     item = items(:one)
     item.start_using!(users(:one), Time.zone.local(2026, 5, 1))
@@ -541,6 +562,30 @@ class ItemTest < ActiveSupport::TestCase
 
     assert_not item.valid?
     assert_includes item.errors[:brand_name], "は100文字以内で入力してください"
+  end
+
+  test "item can be saved without capacity or capacity_unit" do
+    item = items(:one)
+    item.capacity = nil
+    item.capacity_unit = nil
+
+    assert item.valid?
+  end
+
+  test "item rejects capacity of zero or less" do
+    item = items(:one)
+    item.capacity = 0
+
+    assert_not item.valid?
+    assert_includes item.errors[:capacity], "は0より大きい値にしてください"
+  end
+
+  test "item rejects capacity_unit outside the allowed list" do
+    item = items(:one)
+    item.capacity_unit = "L"
+
+    assert_not item.valid?
+    assert_includes item.errors[:capacity_unit], "は一覧にありません"
   end
 
   test "item accepts png image" do


### PR DESCRIPTION
## Summary
- アイテムに容量（数値）・単位（ml/g/kg/枚/個）を任意入力できるようにした
- 価格と容量から容量あたりコストを計算し、詳細画面に表示するようにした

Closes #254

## Test plan
- [x] `bin/rails test test/models/item_test.rb test/controllers/items_controller_test.rb`
- [x] `bundle exec rubocop`

https://claude.ai/code/session_01DvvBfiCNoKuCAr8C9GUzVN