### PR TITLE
アカウント編集画面を使えるようにする

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name, :email ])
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
   end
 
   private

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,79 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="ui-container">
+  <div class="space-y-6">
+    <!-- ヘッダー部分 -->
+    <div class="text-center">
+      <h2 class="brand-font text-2xl font-bold text-slate-900">
+        アカウント編集
+      </h2>
+      <p class="mt-2 text-sm text-slate-500">
+        ユーザー名・メールアドレス・パスワードを変更できます
+      </p>
+    </div>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <!-- フォーム部分 -->
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: "ui-card space-y-6" }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+      <div class="space-y-5">
+        <!-- 名前フィールド -->
+        <div>
+          <%= f.label :name, "ユーザー名", class: "form-label" %>
+          <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-input" %>
+        </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
+        <!-- メールアドレスフィールド -->
+        <div>
+          <%= f.label :email, "メールアドレス", class: "form-label" %>
+          <%= f.email_field :email, autocomplete: "email", class: "form-input" %>
+        </div>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+        <!-- パスワードフィールド -->
+        <div>
+          <div class="flex items-baseline justify-between mb-2">
+            <%= f.label :password, "新しいパスワード", class: "block text-sm font-semibold text-slate-700" %>
+            <% if @minimum_password_length %>
+              <span class="text-xs text-slate-500">
+                (<%= @minimum_password_length %>文字以上)
+              </span>
+            <% end %>
+          </div>
+          <%= f.password_field :password, autocomplete: "new-password", class: "form-input" %>
+          <p class="form-help">変更しない場合は空欄のままにしてください</p>
+        </div>
+
+        <!-- パスワード確認フィールド -->
+        <div>
+          <%= f.label :password_confirmation, "新しいパスワード（確認）", class: "form-label" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-input" %>
+        </div>
+
+        <!-- 現在のパスワードフィールド -->
+        <div>
+          <%= f.label :current_password, "現在のパスワード", class: "form-label" %>
+          <%= f.password_field :current_password, autocomplete: "current-password", class: "form-input" %>
+          <p class="form-help">変更を保存するには、確認のため現在のパスワードを入力してください</p>
+        </div>
+      </div>
+
+      <div class="actions">
+        <%= f.submit "更新する", class: "btn-primary w-full cursor-pointer" %>
+      </div>
     <% end %>
+
+    <!-- アカウント削除 -->
+    <div class="border-t border-slate-100 pt-5 text-center">
+      <p class="mb-3 text-sm text-slate-500">
+        アカウントを削除すると、登録したアイテムや使用履歴もすべて削除されます。
+      </p>
+      <%= button_to "アカウントを削除する",
+                     registration_path(resource_name),
+                     method: :delete,
+                     data: { turbo_confirm: "本当にアカウントを削除しますか？この操作は取り消せません。" },
+                     class: "btn-danger w-full" %>
+    </div>
+
+    <div class="text-center text-sm">
+      <%= link_to "アイテム一覧へ", items_path %>
+    </div>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,7 +8,17 @@
         <% end %>
 
         <% if user_signed_in? %>
-          <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "btn-secondary px-3 py-1.5" %>
+          <!-- detailsタグは、ブラウザ標準の「クリックで開閉する箱」の機能。JS不要でドロップダウンを作れる -->
+          <details class="relative">
+            <summary class="btn-secondary inline-flex cursor-pointer list-none px-3 py-1.5 [&::-webkit-details-marker]:hidden">
+              <%= current_user.name %>
+            </summary>
+
+            <div class="absolute right-0 z-10 mt-2 w-40 rounded-lg border border-slate-200 bg-white py-1 shadow-lg">
+              <%= link_to "アカウント編集", edit_user_registration_path, class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50" %>
+              <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50" %>
+            </div>
+          </details>
         <% end %>
       </div>
 

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class RegistrationsControllerTest < ActionDispatch::IntegrationTest
+  test "edit renders the account edit page for a signed-in user" do
+    sign_in users(:one)
+
+    get edit_user_registration_path
+
+    assert_response :success
+    assert_select "h2", text: "アカウント編集"
+  end
+
+  test "update changes the user's name and email" do
+    sign_in users(:one)
+
+    patch user_registration_path, params: {
+      user: {
+        name: "更新後の名前",
+        email: "updated@example.com",
+        current_password: "password"
+      }
+    }
+
+    assert_redirected_to root_path
+    users(:one).reload
+    assert_equal "更新後の名前", users(:one).name
+    assert_equal "updated@example.com", users(:one).email
+  end
+
+  test "destroy removes the user along with their items, categories, and usage logs" do
+    user = users(:one)
+    item = items(:one)
+    item.start_using!(user, Time.zone.local(2026, 5, 1))
+    usage_log_id = item.reload.current_usage_log.id
+    item_ids = user.items.ids
+    category_ids = user.categories.ids
+
+    sign_in user
+
+    delete user_registration_path
+
+    assert_redirected_to root_path
+    assert_nil User.find_by(id: user.id)
+    assert_empty Item.where(id: item_ids)
+    assert_empty Category.where(id: category_ids)
+    assert_nil UsageLog.find_by(id: usage_log_id)
+  end
+end


### PR DESCRIPTION
## Summary
- Devise標準のままだった `/users/edit` を日本語化し、他画面と統一感のあるデザインに変更
- ヘッダーにユーザー名クリックで開くドロップダウン（`<details>`/`<summary>`、JS不要）を追加し、「アカウント編集」への導線を用意
- `account_update` 時に `name` がStrong Parametersで許可されておらず保存されないバグを修正
- アカウント削除時に items / categories / usage_logs が連鎖削除されることを確認するテストを追加

Closes #257

## Test plan
- [x] `bin/rails test`（278件成功）
- [x] `bundle exec rubocop`
- [x] ブラウザで表示・ドロップダウン開閉・編集画面遷移を確認