### PR TITLE
本番デプロイで発生したomniauth自動読み込みエラーを修正する

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ module App
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks])
+    config.autoload_lib(ignore: %w[assets tasks omniauth])
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
## Summary
- 本番デプロイ時に `uninitialized constant Omniauth::Strategies::Line (NameError)` で起動に失敗していた
- 原因: `config.autoload_lib` により `lib/omniauth` がZeitwerkの自動読み込み対象になっており、フォルダ名から推測される `Omniauth` と実際のクラス名 `OmniAuth` が一致していなかった
- `lib/omniauth` を自動読み込みの対象から除外して修正（このファイルはDevise initializerで明示的に`require`しているため、Zeitwerkに任せる必要がない）

## Test plan
- [x] `bin/rails zeitwerk:check`（本番と同じeager load環境で検証）→ 修正前は再現、修正後は "All is good!"
- [x] `bin/rails test`（280件成功）
- [x] `bundle exec rubocop`