### PR TITLE
LINE連携済みユーザーのパスワード設定対応とline_linked?への整理

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -4,7 +4,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # LINE連携済みユーザーは、本人の知らない自動生成パスワードを持っているため、
   # 現在のパスワード確認をスキップして名前・メールアドレスを更新できるようにする
   def update_resource(resource, params)
-    return super unless resource.line_user_id.present?
+    return super unless resource.line_linked?
 
     params = params.dup
     params.delete(:current_password)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,4 +19,9 @@ class User < ApplicationRecord
   def placeholder_email?
     email.to_s.end_with?("@#{LINE_PLACEHOLDER_EMAIL_DOMAIN}")
   end
+
+  # LINEアカウントと連携済みかどうか
+  def line_linked?
+    line_user_id.present?
+  end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -54,7 +54,11 @@
         <div>
           <%= f.label :current_password, "現在のパスワード", class: "form-label" %>
           <%= f.password_field :current_password, autocomplete: "current-password", class: "form-input" %>
-          <p class="form-help">変更を保存するには、確認のため現在のパスワードを入力してください</p>
+          <% if current_user.line_linked? %>
+            <p class="form-help">LINE連携済みのため、入力は不要です（空欄のままで保存できます）</p>
+          <% else %>
+            <p class="form-help">変更を保存するには、確認のため現在のパスワードを入力してください</p>
+          <% end %>
         </div>
       </div>
 
@@ -66,7 +70,7 @@
     <!-- LINE連携 -->
     <div class="border-t border-slate-100 pt-5">
       <h3 class="form-label">LINE連携</h3>
-      <% if current_user.line_user_id.present? %>
+      <% if current_user.line_linked? %>
         <p class="mb-3 text-sm text-slate-500">LINEアカウントと連携済みです。</p>
         <%= button_to "LINE連携を解除する",
                        disconnect_line_path,

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -59,6 +59,23 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "line-updated@example.com", user.email
   end
 
+  test "update sets a new password without current_password for a LINE-linked user" do
+    user = users(:one)
+    user.update!(line_user_id: "line-uid-123")
+    sign_in user
+
+    patch user_registration_path, params: {
+      user: {
+        password: "mynewpassword123",
+        password_confirmation: "mynewpassword123"
+      }
+    }
+
+    assert_redirected_to root_path
+    user.reload
+    assert user.valid_password?("mynewpassword123")
+  end
+
   test "destroy removes the user along with their items, categories, and usage logs" do
     user = users(:one)
     item = items(:one)


### PR DESCRIPTION
## Summary
- LINE連携済みユーザーが、現在のパスワード無しで新しいパスワードを設定できることをテストで確認
- アカウント編集画面の「現在のパスワード」欄に、LINE連携済みユーザー向けの案内文を追加
- `line_user_id.present?`の直書きを`User#line_linked?`に統一（コントローラー1箇所・ビュー2箇所）

Closes #262（再オープン分の追加対応）

## Test plan
- [x] `bin/rails test`（281件成功）
- [x] `bundle exec rubocop`