### PR TITLE
CVE-2026-66066への緩和策としてVips.block_untrusted(true)を追加する

### DIFF
--- a/config/initializers/vips.rb
+++ b/config/initializers/vips.rb
@@ -1,0 +1,3 @@
+# Active Storage 脆弱性対応
+require "vips"
+Vips.block_untrusted(true)


### PR DESCRIPTION
## Summary
- Active Storage + libvipsの組み合わせで、認証なしのRCEにつながりうる脆弱性（CVSS 9.5、CVE-2026-66066）への緊急対応
- `config/initializers/vips.rb`を追加し、libvipsの「信頼できない」ローダーを無効化する
- Rails公式のセキュリティ勧告（Workarounds）に明記されている正式な回避策

Closes #269

## 参考
- https://github.com/rails/rails/security/advisories/GHSA-xr9x-r78c-5hrm
- https://blog.flatt.tech/entry/kindarails2shell_rails

## Test plan
- [x] `bin/rails test`（281件成功）
- [x] `bundle exec rubocop`
- [x] サーバー起動確認
- [x] 実際の画像アップロード・サムネイル生成が正常に動作することを確認（正規の画像処理には影響しない）

## 注意
これは根本対応ではなく応急処置。根本対応（Rails 8アップグレード）は#270で別途対応する。