### PR TITLE
CIにlibvipsのインストール手順を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
           ruby-version: 3.2.2
           bundler-cache: true
 
+      - name: Install libvips
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libvips
+
       - name: Prepare database
         run: bin/rails db:prepare
 


### PR DESCRIPTION
## Summary
- #269 (CVE-2026-66066対応) 以降、CIの `test` ジョブが `bin/rails db:prepare` の段階で `LoadError: Could not open library 'vips.so.42'` により失敗し続けていた
- 原因: `config/initializers/vips.rb` が `require "vips"` するようになったが、GitHub ActionsのUbuntuランナーには `libvips` 本体（ネイティブライブラリ）がインストールされていなかった
- ローカルのDocker環境ではDockerfileで `libvips` をインストール済みのため、この問題に気づきにくかった
- CIワークフローにも `apt-get install libvips` の手順を追加して解消

## Test plan
- [x] このPR自体のCI（Run Rubocop / test）が通ることを確認