### PR TITLE
トップページにゲストログイン機能を追加する

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,13 @@
+class Users::SessionsController < Devise::SessionsController
+  def guest_sign_in
+    if current_user&.guest?
+      redirect_to after_sign_in_path_for(current_user)
+      return
+    end
+
+    guest = User.create_guest!
+    guest.seed_guest_sample_data!
+    sign_in guest, event: :authentication
+    redirect_to after_sign_in_path_for(guest), notice: "ゲストとしてログインしました"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   EMAIL_FORMAT = /\A[^@\s]+@[^@\s]+\.[^@\s]+\z/
   LINE_PLACEHOLDER_EMAIL_DOMAIN = "line.invalid"
+  GUEST_EMAIL_DOMAIN = "guest.invalid"
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :trackable
@@ -10,6 +11,9 @@ class User < ApplicationRecord
   has_many :items, dependent: :destroy
   has_many :usage_logs, dependent: :destroy
   has_many :categories, dependent: :destroy
+
+  # スコープ
+  scope :guests, -> { where("email LIKE ?", "%@#{GUEST_EMAIL_DOMAIN}") }
 
   # nameは必須（重複は許可）
   validates :name, presence: true, length: { maximum: 255 }
@@ -23,5 +27,59 @@ class User < ApplicationRecord
   # LINEアカウントと連携済みかどうか
   def line_linked?
     line_user_id.present?
+  end
+
+  # ゲスト用の一時アカウントを新規作成する（呼び出すたびに新しいアカウントを作る）
+  def self.create_guest!
+    create!(
+      email: "guest-#{SecureRandom.uuid}@#{GUEST_EMAIL_DOMAIN}",
+      name: "ゲスト",
+      password: Devise.friendly_token[0, 20]
+    )
+  end
+
+  # ゲスト（一時）アカウントかどうか
+  def guest?
+    email.to_s.end_with?("@#{GUEST_EMAIL_DOMAIN}")
+  end
+
+  # ゲストアカウントに、機能を理解しやすいサンプルデータ（カテゴリ・アイテム・使用履歴）を用意する
+  def seed_guest_sample_data!
+    skin_care = categories.create!(name: "スキンケア")
+    hair_care = categories.create!(name: "ヘアケア")
+    daily_goods = categories.create!(name: "日用品")
+
+    # 使用中
+    moisturizer = items.create!(
+      name: "モイストバランス ローション", brand_name: "kinari", category: skin_care,
+      price: 1200, stock_quantity: 1, capacity: 120, capacity_unit: "ml", usage_frequency: "毎日"
+    )
+    moisturizer.usage_logs.create!(user: self, started_at: 10.days.ago)
+
+    # 使い切り済み（レビューあり）
+    shampoo = items.create!(
+      name: "シルクリペア シャンプー", brand_name: "botanica", category: hair_care,
+      price: 1500, stock_quantity: 0, capacity: 400, capacity_unit: "ml", usage_frequency: "朝晩"
+    )
+    shampoo.usage_logs.create!(
+      user: self, started_at: 60.days.ago, finished_at: 10.days.ago,
+      finish_reason: "used_up", rating: 4, review: "泡立ちが良く、香りも好みでした"
+    )
+
+    # 使用中止
+    serum = items.create!(
+      name: "グロウセラム", brand_name: "clear lab", category: skin_care,
+      price: 3000, stock_quantity: 0, capacity: 30, capacity_unit: "ml"
+    )
+    serum.usage_logs.create!(
+      user: self, started_at: 40.days.ago, finished_at: 20.days.ago,
+      finish_reason: "discontinued", discontinued_reason: "肌に合わなかった"
+    )
+
+    # 未使用・在庫あり
+    items.create!(
+      name: "ランドリーソープ", brand_name: "clean days", category: daily_goods,
+      price: 800, stock_quantity: 3, capacity: 900, capacity_unit: "g"
+    )
   end
 end

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -32,6 +32,9 @@
         <div class="grid gap-3">
           <%= link_to "新規登録", new_user_registration_path, class: "btn-primary w-full" %>
           <%= link_to "ログイン", new_user_session_path, class: "btn-secondary w-full" %>
+          <%= button_to "ゲストとして試す", guest_sign_in_path, method: :post,
+                        class: "block w-full cursor-pointer text-center text-sm font-medium text-emerald-700 hover:underline",
+                        form_class: "w-full" %>
         </div>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,9 @@ Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 
   devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks", registrations: "users/registrations" }
+  devise_scope :user do
+    post "users/guest_sign_in", to: "users/sessions#guest_sign_in", as: :guest_sign_in
+  end
   delete "account/line", to: "users/line_connections#destroy", as: :disconnect_line
   root "static_pages#top"
   get "guide", to: "static_pages#guide", as: :guide

--- a/lib/tasks/guest.rake
+++ b/lib/tasks/guest.rake
@@ -1,0 +1,7 @@
+namespace :guest do
+  desc "作成から24時間以上経過したゲストの一時アカウントを削除する（1日1回の定期実行を想定）"
+  task cleanup: :environment do
+    count = User.guests.where("created_at < ?", 24.hours.ago).destroy_all.size
+    puts "ゲストの一時アカウント: #{count}件を削除しました"
+  end
+end

--- a/test/controllers/users/sessions_controller_test.rb
+++ b/test/controllers/users/sessions_controller_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class Users::SessionsControllerTest < ActionDispatch::IntegrationTest
+  test "guest_sign_in creates a guest account with sample data and signs in" do
+    assert_difference "User.count", 1 do
+      post guest_sign_in_path
+    end
+
+    assert_redirected_to items_path
+    guest = User.guests.order(created_at: :desc).first
+    assert guest.guest?
+    assert_equal 4, guest.items.count
+  end
+
+  test "guest_sign_in reuses the current guest account when already signed in as guest" do
+    post guest_sign_in_path
+
+    assert_no_difference "User.count" do
+      post guest_sign_in_path
+    end
+
+    assert_redirected_to items_path
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -13,4 +13,37 @@ class UserTest < ActiveSupport::TestCase
     assert_not user.valid?
     assert_includes user.errors[:email], "の形式が正しくありません"
   end
+
+  test "create_guest! creates a unique guest account each time" do
+    guest1 = User.create_guest!
+    guest2 = User.create_guest!
+
+    assert_not_equal guest1.id, guest2.id
+    assert_not_equal guest1.email, guest2.email
+    assert guest1.email.end_with?("@#{User::GUEST_EMAIL_DOMAIN}")
+  end
+
+  test "guest? is true for a guest account and false for a regular user" do
+    guest = User.create_guest!
+
+    assert guest.guest?
+    assert_not users(:one).guest?
+  end
+
+  test "guests scope returns only guest accounts" do
+    guest = User.create_guest!
+
+    assert_includes User.guests, guest
+    assert_not_includes User.guests, users(:one)
+  end
+
+  test "seed_guest_sample_data! creates sample categories, items, and usage logs" do
+    guest = User.create_guest!
+
+    guest.seed_guest_sample_data!
+
+    assert_equal 3, guest.categories.count
+    assert_equal 4, guest.items.count
+    assert_equal 3, guest.usage_logs.count
+  end
 end


### PR DESCRIPTION
## Summary
- 訪問者ごとに専用の一時アカウントを作成し、サンプルデータ入りの状態でログインできる「ゲストとして試す」機能を追加
- 固定アカウントを複数人で共有する方式は、他人の操作による競合リスクが構造的に避けられないため見送り、訪問者ごとに独立したアカウントを発行する方式を採用（issue本文参照）
- `User#create_guest!` / `#guest?` / `#seed_guest_sample_data!` を追加（ゲストの識別はLINEログインの仮メールアドレス判定と同じパターンを踏襲）
- `Users::SessionsController#guest_sign_in` でログイン処理を実装
- `lib/tasks/guest.rake`（`guest:cleanup`）で作成から24時間以上経過した一時アカウントを削除
- Renderのcron（毎日8:00 JST）で`guest:cleanup`を自動実行するよう設定済み

closes #146

## Test plan
- [x] `bin/rails test`（282件）全て成功
- [x] `bundle exec rubocop` 指摘なし
- [ ] 本番デプロイ後、トップページの「ゲストとして試す」から実際にログインできることを確認