### PR TITLE
itemsにrating・reviewカラムを追加する

### DIFF
--- a/db/migrate/20260819000001_add_rating_and_review_to_items.rb
+++ b/db/migrate/20260819000001_add_rating_and_review_to_items.rb
@@ -1,0 +1,6 @@
+class AddRatingAndReviewToItems < ActiveRecord::Migration[8.1]
+  def change
+    add_column :items, :rating, :integer
+    add_column :items, :review, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_17_000005) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_19_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -65,6 +65,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_000005) do
     t.text "memo"
     t.string "name", null: false
     t.integer "price"
+    t.integer "rating"
+    t.text "review"
     t.datetime "updated_at", null: false
     t.uuid "user_id", null: false
     t.index ["archived"], name: "index_items_on_archived"


### PR DESCRIPTION
## 概要
usage_logs廃止・データモデル簡素化(#297)の最初のステップとして、`items`テーブルに`rating`・`review`カラムを追加する。

このPRはスキーマ変更のみで、既存の挙動には一切影響しない(新しいカラムを読み書きするUIはまだ存在しない)。#297の残りの作業(in_stock削除、archived活用UI、各画面の作り直し、usage_logs削除)は別PRで続ける。

## 変更内容
- `db/migrate/20260819000001_add_rating_and_review_to_items.rb`: `items`に`rating`(integer, nullable)・`review`(text, nullable)を追加

## テスト
- ローカルで`bin/rails db:migrate`実行済み
- ローカルDBでusage_logsからのバックフィル(rails runnerでのワンショットスクリプト、マイグレーションファイルには含めない)を試験実行し、正しくコピーされることを確認済み

Closes: 関連 #297(の一部)