### PR TITLE
持ち物一覧をよく使うもの/なくなりそう/手放したの4タブに作り直す

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,29 +6,26 @@ class ItemsController < ApplicationController
                                     toggle_low_stock archive unarchive update_review]
 
   def index
-    @items = current_user.items.visible.includes(:category).order(created_at: :desc)
     @selected_status = params[:status].to_s
-    @selected_favorite = params[:favorite].to_s
-    @items = @items.by_name(@search_query)
-                   .by_category(@selected_category_id)
-    @items = @items.where(favorite: true) if @selected_favorite == "1"
+    @items =
+      case @selected_status
+      when "favorite"
+        current_user.items.visible.where(favorite: true)
+      when "low_stock"
+        current_user.items.visible.where(low_stock_flagged: true)
+      when "archived"
+        current_user.items.archived
+      else
+        current_user.items.visible
+      end
 
-    in_use_item_ids = current_user.usage_logs.in_use.select(:item_id)
-    case @selected_status
-    when "in_use"
-      @items = @items.where(id: in_use_item_ids)
-    when "out_of_stock"
-      @items = @items.where(in_stock: false).where.not(id: in_use_item_ids)
-    end
+    @items = @items.includes(:category)
+                   .order(created_at: :desc)
+                   .by_name(@search_query)
+                   .by_category(@selected_category_id)
 
     @page_title = "アイテム"
     @items = @items.page(params[:page])
-    @latest_ratings_by_item_id = current_user.usage_logs
-                                              .where(item_id: @items.map(&:id))
-                                              .rated
-                                              .order(created_at: :desc)
-                                              .group_by(&:item_id)
-                                              .transform_values { |usage_logs| usage_logs.first.rating }
   end
 
   # 検索欄のオートコンプリート候補（アイテム名）をJSONで返す

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -4,63 +4,51 @@
              query: @search_query,
              hidden_params: {
                category_id: @selected_category_id.presence,
-               status: @selected_status.presence,
-               favorite: @selected_favorite.presence
+               status: @selected_status.presence
              },
              show_reset: @search_query.present?,
              reset_url: items_path(
                category_id: @selected_category_id.presence,
-               status: @selected_status.presence,
-               favorite: @selected_favorite.presence
+               status: @selected_status.presence
              ) %>
 
   <div class="mb-4 space-y-3">
     <% status_filter_params = {
       q: @search_query.presence,
-      category_id: @selected_category_id.presence,
-      favorite: @selected_favorite.presence
+      category_id: @selected_category_id.presence
     } %>
     <div class="flex flex-wrap items-center justify-between gap-2">
-      <div class="flex items-center gap-2">
-        <nav class="flex gap-1 rounded-full bg-slate-100 p-1 text-sm" aria-label="ステータス">
-          <%= link_to "すべて",
-                      items_path(status_filter_params),
-                      class: class_names(
-                        "shrink-0 rounded-full px-3 py-1.5 font-semibold transition",
-                        @selected_status.blank? ? "bg-white text-emerald-700 shadow-sm" : "text-slate-600 hover:bg-white/70"
-                      ) %>
-          <%= link_to "使用中",
-                      items_path(status_filter_params.merge(status: "in_use")),
-                      class: class_names(
-                        "shrink-0 rounded-full px-3 py-1.5 font-semibold transition",
-                        @selected_status == "in_use" ? "bg-white text-emerald-700 shadow-sm" : "text-slate-600 hover:bg-white/70"
-                      ) %>
-          <%= link_to "在庫なし",
-                      items_path(status_filter_params.merge(status: "out_of_stock")),
-                      class: class_names(
-                        "shrink-0 rounded-full px-3 py-1.5 font-semibold transition",
-                        @selected_status == "out_of_stock" ? "bg-white text-emerald-700 shadow-sm" : "text-slate-600 hover:bg-white/70"
-                      ) %>
-        </nav>
-
-        <%= link_to items_path(status_filter_params.merge(favorite: @selected_favorite == "1" ? nil : "1")),
+      <nav class="flex flex-wrap gap-1 rounded-full bg-slate-100 p-1 text-sm" aria-label="絞り込み">
+        <%= link_to "すべて",
+                    items_path(status_filter_params),
                     class: class_names(
-                      "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border transition",
-                      @selected_favorite == "1" ? "border-yellow-300 bg-yellow-50 text-yellow-600" : "border-slate-200 bg-white text-slate-400 hover:border-yellow-200 hover:bg-yellow-50 hover:text-yellow-600"
-                    ),
-                    aria: { label: @selected_favorite == "1" ? "お気に入りのみの表示をやめる" : "お気に入りのみ表示する" } do %>
-          <svg class="h-4 w-4 <%= @selected_favorite == "1" ? "fill-yellow-500 stroke-yellow-600" : "fill-none stroke-current" %>" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M12 20.5s-7.5-4.4-9.4-9.1C1.2 7.9 3.1 4.8 6.4 4.8c1.9 0 3.3 1 4.1 2.2.8-1.2 2.2-2.2 4.1-2.2 3.3 0 5.2 3.1 3.8 6.6-1.9 4.7-9.4 9.1-9.4 9.1Z"
-                  stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" />
-          </svg>
-        <% end %>
-      </div>
+                      "shrink-0 rounded-full px-3 py-1.5 font-semibold transition",
+                      @selected_status.blank? ? "bg-white text-emerald-700 shadow-sm" : "text-slate-600 hover:bg-white/70"
+                    ) %>
+        <%= link_to "♡ よく使うもの",
+                    items_path(status_filter_params.merge(status: "favorite")),
+                    class: class_names(
+                      "shrink-0 rounded-full px-3 py-1.5 font-semibold transition",
+                      @selected_status == "favorite" ? "bg-white text-emerald-700 shadow-sm" : "text-slate-600 hover:bg-white/70"
+                    ) %>
+        <%= link_to "なくなりそうなもの",
+                    items_path(status_filter_params.merge(status: "low_stock")),
+                    class: class_names(
+                      "shrink-0 rounded-full px-3 py-1.5 font-semibold transition",
+                      @selected_status == "low_stock" ? "bg-white text-emerald-700 shadow-sm" : "text-slate-600 hover:bg-white/70"
+                    ) %>
+        <%= link_to "手放したもの",
+                    items_path(status_filter_params.merge(status: "archived")),
+                    class: class_names(
+                      "shrink-0 rounded-full px-3 py-1.5 font-semibold transition",
+                      @selected_status == "archived" ? "bg-white text-emerald-700 shadow-sm" : "text-slate-600 hover:bg-white/70"
+                    ) %>
+      </nav>
 
       <!-- selectのchangeイベントでフォームを送信すると、選ぶだけで絞り込めるドロップダウンになる -->
       <%= form_with url: items_path, method: :get, local: true, class: "shrink-0" do %>
         <%= hidden_field_tag :q, @search_query.presence %>
         <%= hidden_field_tag :status, @selected_status.presence %>
-        <%= hidden_field_tag :favorite, @selected_favorite.presence %>
         <select name="category_id" onchange="this.form.requestSubmit()" class="form-input h-9 w-auto text-sm">
           <option value="">カテゴリ: すべて</option>
           <% @categories.each do |category| %>
@@ -71,14 +59,11 @@
       <% end %>
     </div>
 
-    <% active_filter_labels = [] %>
-    <% active_filter_labels << "お気に入り" if @selected_favorite == "1" %>
-    <% active_filter_labels << (@selected_category_id == "uncategorized" ? "カテゴリ: 未設定" : "カテゴリ: #{@categories.find { |category| category.id.to_s == @selected_category_id }&.name}") if @selected_category_id.present? %>
-    <% if active_filter_labels.any? %>
+    <% if @selected_category_id.present? %>
       <div class="flex flex-wrap items-center gap-2 text-xs text-slate-500">
-        <% active_filter_labels.compact.each do |label| %>
-          <span class="rounded-full bg-emerald-50 px-2.5 py-1 font-semibold text-emerald-700"><%= label %></span>
-        <% end %>
+        <span class="rounded-full bg-emerald-50 px-2.5 py-1 font-semibold text-emerald-700">
+          <%= @selected_category_id == "uncategorized" ? "カテゴリ: 未設定" : "カテゴリ: #{@categories.find { |category| category.id.to_s == @selected_category_id }&.name}" %>
+        </span>
         <%= link_to "条件をクリア",
                     items_path(q: @search_query.presence, status: @selected_status.presence),
                     class: "font-semibold text-slate-500 underline-offset-4 hover:text-slate-800 hover:underline" %>
@@ -89,41 +74,56 @@
   <% if @items.any? %>
     <div class="grid gap-2">
       <% @items.each do |item| %>
-        <article class="flex items-center gap-3 rounded-lg border border-slate-200 bg-white px-3 py-2.5">
-          <%= link_to item_path(item),
-                      class: "flex min-w-0 flex-1 items-center gap-3 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2",
-                      aria: { label: "#{item.name}の詳細を見る" } do %>
-            <div class="shrink-0">
-              <%= render "image",
-                         item: item,
-                         size_class: "h-12 w-12",
-                         image_class: "h-12 w-12 rounded-lg object-cover",
-                         placeholder_icon_class: "h-5 w-5" %>
-            </div>
+        <article class="rounded-lg border border-slate-200 bg-white p-3">
+          <div class="flex items-center gap-3">
+            <%= link_to item_path(item),
+                        class: "flex min-w-0 flex-1 items-center gap-3 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2",
+                        aria: { label: "#{item.name}の詳細を見る" } do %>
+              <div class="shrink-0">
+                <%= render "image",
+                           item: item,
+                           size_class: "h-12 w-12",
+                           image_class: "h-12 w-12 rounded-lg object-cover",
+                           placeholder_icon_class: "h-5 w-5" %>
+              </div>
 
-            <div class="min-w-0 flex-1">
-              <h2 class="brand-font truncate text-sm font-bold text-slate-900"><%= item.name %></h2>
-              <% if item.brand_name.present? %>
-                <p class="truncate text-xs text-slate-400"><%= item.brand_name %></p>
-              <% end %>
-            </div>
+              <div class="min-w-0 flex-1">
+                <% if item.brand_name.present? %>
+                  <p class="truncate text-xs text-emerald-700"><%= item.brand_name %></p>
+                <% end %>
+                <h2 class="brand-font truncate text-sm font-bold text-slate-900"><%= item.name %></h2>
+              </div>
 
-            <div class="flex shrink-0 flex-col items-end gap-1">
-              <% if item.using? %>
-                <span class="inline-flex whitespace-nowrap rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-semibold text-amber-800">使用中</span>
-              <% elsif item.in_stock? %>
-                <span class="inline-flex whitespace-nowrap rounded-full bg-emerald-50 px-2.5 py-0.5 text-xs font-semibold text-emerald-700">在庫あり</span>
-              <% else %>
-                <span class="inline-flex whitespace-nowrap rounded-full border border-red-200 bg-red-50 px-2.5 py-0.5 text-xs font-semibold text-red-700">在庫なし</span>
-              <% end %>
+              <div class="shrink-0 text-right text-xs font-semibold">
+                <% if item.rating.present? %>
+                  <span class="text-amber-500">⭐️ <%= item.rating %>.0</span>
+                <% else %>
+                  <span class="text-slate-400">評価なし</span>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
 
-              <% if @latest_ratings_by_item_id[item.id] %>
-                <span class="text-xs font-semibold text-yellow-600">⭐️ <%= @latest_ratings_by_item_id[item.id] %></span>
-              <% end %>
-            </div>
-          <% end %>
-
-          <%= render "favorite_button", item: item, compact: true %>
+          <div class="mt-2 flex flex-wrap items-center gap-2 pl-[calc(3rem+0.75rem)]">
+            <% if item.archived? %>
+              <%= link_to "感想を書く", item_path(item, anchor: "review"), class: "inline-flex items-center rounded-full border border-emerald-600 px-2.5 py-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-50" %>
+              <%= link_to "リストに戻す",
+                          unarchive_item_path(item),
+                          data: { turbo_method: :patch },
+                          class: "btn-secondary ml-auto px-3 py-1 text-xs" %>
+            <% else %>
+              <%= render "favorite_button", item: item, compact: true %>
+              <%= render "low_stock_button", item: item %>
+              <%= link_to "感想を書く", item_path(item, anchor: "review"), class: "inline-flex items-center rounded-full border border-emerald-600 px-2.5 py-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-50" %>
+              <%= link_to "手放す",
+                          archive_item_path(item),
+                          data: {
+                            turbo_method: :patch,
+                            turbo_confirm: item.review.present? ? "感想は残したまま、持ち物一覧の「手放した」に移動します。よろしいですか？" : "感想がまだ入力されていません。このまま手放しますか？"
+                          },
+                          class: "ml-auto text-xs text-slate-400 underline-offset-4 transition hover:text-red-600 hover:underline" %>
+            <% end %>
+          </div>
         </article>
       <% end %>
     </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -66,7 +66,7 @@
       <% end %>
     </div>
 
-    <div class="border-t border-slate-100 pt-5">
+    <div id="review" class="border-t border-slate-100 pt-5">
       <%= render "review_form", item: @item %>
     </div>
 

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -97,33 +97,58 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{items_path}']", text: "検索条件をリセット"
   end
 
-  test "index highlights out of stock item" do
-    get items_path
-
-    assert_response :success
-    assert_select "span.bg-red-50", text: "在庫なし"
-  end
-
   test "index shows status filters" do
     get items_path
 
     assert_response :success
     assert_select "a[href='#{items_path}']", text: "すべて"
-    assert_select "a[href='#{items_path(status: "in_use")}']", text: "使用中"
-    assert_select "a[href='#{items_path(status: "out_of_stock")}']", text: "在庫なし"
+    assert_select "a[href='#{items_path(status: "favorite")}']", text: "♡ よく使うもの"
+    assert_select "a[href='#{items_path(status: "low_stock")}']", text: "なくなりそうなもの"
+    assert_select "a[href='#{items_path(status: "archived")}']", text: "手放したもの"
   end
 
   test "index filters favorite items" do
     favorite_item = items(:one)
     favorite_item.update!(favorite: true)
 
-    get items_path, params: { favorite: "1" }
+    get items_path, params: { status: "favorite" }
 
     assert_response :success
     assert_includes response.body, favorite_item.name
     assert_no_match items(:two).name, response.body
-    assert_select "a[href='#{items_path}'][aria-label='お気に入りのみの表示をやめる']"
-    assert_select "form[action='#{toggle_favorite_item_path(favorite_item)}']"
+  end
+
+  test "index filters low stock items by status" do
+    low_stock_item = items(:one)
+    low_stock_item.update!(low_stock_flagged: true)
+
+    get items_path, params: { status: "low_stock" }
+
+    assert_response :success
+    assert_includes response.body, low_stock_item.name
+    assert_no_match items(:two).name, response.body
+  end
+
+  test "index shows archived items only on the archived tab, with a restore link" do
+    archived_item = items(:two)
+    archived_item.update!(archived: true)
+
+    get items_path, params: { status: "archived" }
+
+    assert_response :success
+    assert_includes response.body, archived_item.name
+    assert_no_match items(:one).name, response.body
+    assert_select "a[href='#{unarchive_item_path(archived_item)}']", text: "リストに戻す"
+    assert_select "a[href='#{item_path(archived_item, anchor: "review")}']", text: "感想を書く"
+  end
+
+  test "index does not show archived items on the all tab" do
+    items(:two).update!(archived: true)
+
+    get items_path
+
+    assert_response :success
+    assert_no_match items(:two).name, response.body
   end
 
   test "toggle_favorite switches item favorite state" do
@@ -134,25 +159,6 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to item_path(item)
-  end
-
-  test "index filters in-use items by status" do
-    item = items(:one)
-    item.start_using!(@user, Time.current)
-
-    get items_path, params: { status: "in_use" }
-
-    assert_response :success
-    assert_includes response.body, item.name
-    assert_no_match items(:two).name, response.body
-  end
-
-  test "index filters out-of-stock items by status" do
-    get items_path, params: { status: "out_of_stock" }
-
-    assert_response :success
-    assert_includes response.body, items(:two).name
-    assert_no_match items(:one).name, response.body
   end
 
   test "index links item information to detail page" do
@@ -173,10 +179,9 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "form[action='#{toggle_favorite_item_path(item)}']"
   end
 
-  test "index shows the latest rating for an item with a finished usage cycle" do
+  test "index shows the item's rating" do
     item = items(:one)
-    item.start_using!(@user, Time.zone.local(2026, 5, 1))
-    item.finish_using!(Time.zone.local(2026, 5, 10), rating: 4)
+    item.update!(rating: 4)
 
     get items_path
 
@@ -191,6 +196,28 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "article", text: /⭐️/, count: 0
+  end
+
+  test "index shows brand name above the item name for each row" do
+    item = items(:one)
+    item.update!(brand_name: "ものログ製薬")
+
+    get items_path
+
+    assert_response :success
+    assert_select "article p.text-emerald-700", text: "ものログ製薬"
+    assert response.body.index("ものログ製薬") < response.body.index(">#{item.name}<")
+  end
+
+  test "index shows low stock toggle, review link, and archive link for a visible item" do
+    item = items(:one)
+
+    get items_path
+
+    assert_response :success
+    assert_select "article form[action='#{toggle_low_stock_item_path(item)}']"
+    assert_select "article a[href='#{item_path(item, anchor: "review")}']", text: "感想を書く"
+    assert_select "article a[href='#{archive_item_path(item)}']", text: "手放す"
   end
 
   test "index filters items by category" do
@@ -270,7 +297,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     get items_path, params: { category_id: category.id }
 
     assert_response :success
-    assert_select "a[href='#{items_path(category_id: category.id, status: "in_use")}']", text: "使用中"
+    assert_select "a[href='#{items_path(category_id: category.id, status: "favorite")}']", text: "♡ よく使うもの"
   end
 
   test "index does not show reset link when only category is selected" do


### PR DESCRIPTION
## 概要
usage_logs廃止・データモデル簡素化(#297)の一部として、持ち物一覧の絞り込みを「使用中/在庫なし」から「よく使うもの/なくなりそう/手放した」の4タブに作り直す。

Closes #300

## 変更内容
- `items_controller#index`: 絞り込みロジックをfavorite/low_stock/archivedベースに変更(usage_logsへの依存を撤去)
- 一覧画面: 4タブ化、各行にブランド名を商品名より先に表示、`Item#rating`を直接表示、なくなりそうトグル・感想を書くリンク・手放す/リストに戻すリンクを追加

## 既知の未対応点
- ホーム画面の「今使っているもの」セクションが`items_path(status: "in_use")`にリンクしているが、該当する絞り込みがなくなったため「すべて」表示になる(エラーにはならない)。このセクション自体を#302で削除するため、今回は対応しない。

## テスト
- `bin/rails test`: 185件パス
- `bundle exec rubocop`: 問題なし
- ブラウザでタブ切り替えの動作を確認済み