### PR TITLE
登録・編集フォームに感想欄を追加する

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
   before_action :set_categories, only: %i[new create edit update]
   before_action :set_filter_params, only: %i[index]
   before_action :set_item, only: %i[show edit update destroy destroy_image toggle_favorite
-                                    toggle_low_stock archive unarchive update_review]
+                                    toggle_low_stock archive unarchive edit_review update_review]
 
   def index
     @selected_status = params[:status].to_s
@@ -105,6 +105,9 @@ class ItemsController < ApplicationController
     @item.update!(low_stock_flagged: !@item.low_stock_flagged?)
 
     redirect_back fallback_location: items_path
+  end
+
+  def edit_review
   end
 
   def update_review

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -29,7 +29,7 @@
             <div class="mt-2 flex flex-wrap items-center gap-1.5">
               <%= render "items/favorite_button", item: item, compact: true %>
               <%= render "items/low_stock_button", item: item %>
-              <%= link_to "感想を書く", edit_usage_log_path(usage_log), class: "ml-auto inline-flex items-center rounded-full border border-emerald-600 px-2.5 py-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-50" %>
+              <%= link_to "感想を書く", edit_review_item_path(item), class: "ml-auto inline-flex items-center rounded-full border border-emerald-600 px-2.5 py-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-50" %>
             </div>
           </article>
         <% end %>

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -113,6 +113,21 @@
       <%= f.text_area :memo, rows: "5", class: "form-input" %>
     </div>
 
+    <!-- 感想（任意） -->
+    <div class="space-y-4 border-t border-slate-100 pt-6">
+      <div>
+        <h2 class="form-label">感想（任意）</h2>
+        <p class="form-help">使ってみてから登録・編集する場合は、ここに書けます。あとからいつでも書き換えられます。</p>
+      </div>
+
+      <%= render "star_rating_input", form: f %>
+
+      <div>
+        <%= f.label :review, "感想", class: "form-label" %>
+        <%= f.text_area :review, rows: "4", class: "form-input", placeholder: "使ってみた感想は任意です" %>
+      </div>
+    </div>
+
     <!-- ボタン群 -->
     <div class="alert-info hidden text-center" data-submit-loading>
       <%= item.persisted? ? "アイテム情報を更新しています..." : "アイテムを登録しています..." %>

--- a/app/views/items/edit_review.html.erb
+++ b/app/views/items/edit_review.html.erb
@@ -1,0 +1,16 @@
+<div class="ui-container">
+  <div class="space-y-5">
+    <h1 class="brand-font text-center text-2xl font-bold text-slate-900">感想を書く</h1>
+
+    <div class="text-center">
+      <% if @item.brand_name.present? %>
+        <p class="text-sm font-medium text-emerald-700"><%= @item.brand_name %></p>
+      <% end %>
+      <p class="brand-font mt-1 text-lg font-bold text-slate-900"><%= @item.name %></p>
+    </div>
+
+    <%= render "review_form", item: @item %>
+
+    <%= link_to "ホームに戻る", home_path, class: "block text-center text-sm text-slate-500 underline-offset-4 hover:underline" %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
       patch :archive
       patch :unarchive
       # updateアクションだとカテゴリが更新されないので、感想の更新専用アクションを作る
+      get :edit_review
       patch :update_review
       delete :image, action: :destroy_image
     end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -22,7 +22,6 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
 
     item = items(:one)
     item.start_using!(user, Time.zone.local(2026, 5, 10))
-    usage_log = item.current_usage_log
 
     get home_path
 
@@ -31,7 +30,7 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{item_path(item)}']", text: item.name
     assert_select "form[action='#{toggle_low_stock_item_path(item)}']"
     assert_select "form[action='#{toggle_favorite_item_path(item)}']"
-    assert_select "a[href='#{edit_usage_log_path(usage_log)}']", text: "感想を書く"
+    assert_select "a[href='#{edit_review_item_path(item)}']", text: "感想を書く"
   end
 
   test "home shows empty state when nothing is in use" do

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -483,6 +483,55 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[name='item[brand_name]'][maxlength='100']"
   end
 
+  test "new page has an optional review section" do
+    get new_item_path
+
+    assert_response :success
+    assert_select "button[data-star-rating-star]", count: 5
+    assert_select "textarea[name='item[review]']"
+  end
+
+  test "edit page has an optional review section with current values" do
+    item = items(:one)
+    item.update!(rating: 3, review: "まあまあ")
+
+    get edit_item_path(item)
+
+    assert_response :success
+    assert_select "input[type='hidden'][name='item[rating]'][value='3']"
+    assert_select "textarea[name='item[review]']", text: "まあまあ"
+  end
+
+  test "create saves rating and review" do
+    assert_difference -> { @user.items.count }, 1 do
+      post items_path, params: {
+        item: {
+          name: "シャンプー",
+          price: 1200,
+          rating: 5,
+          review: "とても良かった"
+        }
+      }
+    end
+
+    item = @user.items.order(:created_at).last
+    assert_equal 5, item.rating
+    assert_equal "とても良かった", item.review
+  end
+
+  test "create fails when review is present without rating" do
+    assert_no_difference -> { @user.items.count } do
+      post items_path, params: {
+        item: {
+          name: "シャンプー",
+          review: "感想だけ書いた"
+        }
+      }
+    end
+
+    assert_response :unprocessable_content
+  end
+
   test "create assigns selected category to item" do
     category = categories(:hair_care)
 
@@ -813,6 +862,19 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "form[action='#{update_review_item_path(item)}'] input[type='hidden'][name='item[rating]'][value='4']"
+    assert_select "form[action='#{update_review_item_path(item)}'] button[data-star-rating-star]", count: 5
+    assert_select "form[action='#{update_review_item_path(item)}'] textarea[name='item[review]']", text: "よかった"
+  end
+
+  test "edit_review shows a minimal page with just the review form" do
+    item = items(:one)
+    item.update!(rating: 4, review: "よかった", brand_name: "ものログ製薬")
+
+    get edit_review_item_path(item)
+
+    assert_response :success
+    assert_includes response.body, item.name
+    assert_select "p.text-emerald-700", text: "ものログ製薬"
     assert_select "form[action='#{update_review_item_path(item)}'] button[data-star-rating-star]", count: 5
     assert_select "form[action='#{update_review_item_path(item)}'] textarea[name='item[review]']", text: "よかった"
   end


### PR DESCRIPTION
## 概要
usage_logs廃止・データモデル簡素化(#297)の一部として、登録・編集フォームに任意の感想（⭐評価+レビュー本文）入力欄を追加する。

Closes #301

## 変更内容
- 登録・編集フォーム(`_form.html.erb`)に感想（任意）セクションを追加。バリデーションは#299で追加済みのため今回は入力欄のみ
- ホーム画面の「感想を書く」リンクの遷移先を、旧usage_logsの編集画面（星評価がドロップダウン式で見た目が異なっていた）から、新しい星タップ式の感想欄だけを表示する専用ページ(`edit_review`)に変更
- `edit_review`画面はブランド名→商品名の順で表示し、「ホームに戻る」リンクを設置

## テスト
- `bin/rails test`: 190件パス
- `bundle exec rubocop`: 問題なし
- ブラウザで新規登録フォーム・ホームからの感想入力遷移を確認済み