### PR TITLE
ホーム画面・感想を振り返る画面をItem基準に作り直す

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -9,10 +9,9 @@ class HomeController < ApplicationController
     @low_stock_items_count = low_stock_items.count
     @low_stock_items = low_stock_items.limit(LOW_STOCK_DISPLAY_LIMIT)
 
-    @unreviewed_items = current_user.items.visible
-                                     .where(rating: nil)
-                                     .order(created_at: :desc)
-                                     .limit(UNREVIEWED_DISPLAY_LIMIT)
+    unreviewed_items = current_user.items.visible.where(rating: nil).order(created_at: :desc)
+    @unreviewed_items_count = unreviewed_items.count
+    @unreviewed_items = unreviewed_items.limit(UNREVIEWED_DISPLAY_LIMIT)
 
     @good_items = current_user.items.visible
                                .where(rating: 4..5)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,28 +1,27 @@
 class HomeController < ApplicationController
   before_action :authenticate_user!
 
-  IN_USE_DISPLAY_LIMIT = 4
+  LOW_STOCK_DISPLAY_LIMIT = 4
+  UNREVIEWED_DISPLAY_LIMIT = 6
 
   def show
-    in_use_usage_logs = current_user.usage_logs
-                                     .in_use
-                                     .includes(:item)
-                                     .order(started_at: :desc)
-    @in_use_usage_logs_count = in_use_usage_logs.count
-    @in_use_usage_logs = in_use_usage_logs.limit(IN_USE_DISPLAY_LIMIT)
+    low_stock_items = current_user.items.visible.where(low_stock_flagged: true).order(updated_at: :desc)
+    @low_stock_items_count = low_stock_items.count
+    @low_stock_items = low_stock_items.limit(LOW_STOCK_DISPLAY_LIMIT)
 
-    @good_usage_logs = current_user.usage_logs
-                                    .rated
-                                    .where(rating: 4..5)
-                                    .includes(:item)
-                                    .order(rating: :desc, created_at: :desc)
-                                    .limit(3)
+    @unreviewed_items = current_user.items.visible
+                                     .where(rating: nil)
+                                     .order(created_at: :desc)
+                                     .limit(UNREVIEWED_DISPLAY_LIMIT)
 
-    @bad_usage_logs = current_user.usage_logs
-                                   .rated
-                                   .where(rating: 1..2)
-                                   .includes(:item)
-                                   .order(rating: :asc, created_at: :desc)
-                                   .limit(3)
+    @good_items = current_user.items.visible
+                               .where(rating: 4..5)
+                               .order(rating: :desc, updated_at: :desc)
+                               .limit(3)
+
+    @bad_items = current_user.items.visible
+                              .where(rating: 1..2)
+                              .order(rating: :asc, updated_at: :desc)
+                              .limit(3)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,21 +3,18 @@ class ItemsController < ApplicationController
   before_action :set_categories, only: %i[new create edit update]
   before_action :set_filter_params, only: %i[index]
   before_action :set_item, only: %i[show edit update destroy destroy_image toggle_favorite
-                                    toggle_low_stock archive unarchive edit_review update_review]
+                                    toggle_low_stock confirm_archive archive unarchive edit_review update_review]
 
   def index
-    @selected_status = params[:status].to_s
-    @items =
-      case @selected_status
-      when "favorite"
-        current_user.items.visible.where(favorite: true)
-      when "low_stock"
-        current_user.items.visible.where(low_stock_flagged: true)
-      when "archived"
-        current_user.items.archived
-      else
-        current_user.items.visible
-      end
+    @scope = params[:scope].to_s
+    @favorite_filter = params[:favorite] == "1"
+    @low_stock_filter = params[:low_stock] == "1"
+    @unreviewed_filter = params[:unreviewed] == "1"
+
+    @items = @scope == "archived" ? current_user.items.archived : current_user.items.visible
+    @items = @items.where(favorite: true) if @favorite_filter
+    @items = @items.where(low_stock_flagged: true) if @low_stock_filter
+    @items = @items.where(rating: nil) if @unreviewed_filter
 
     @items = @items.includes(:category)
                    .order(created_at: :desc)
@@ -91,6 +88,9 @@ class ItemsController < ApplicationController
     redirect_back fallback_location: item_path(@item), notice: notice
   end
 
+  def confirm_archive
+  end
+
   def archive
     @item.archive!
     redirect_to items_path, notice: "手放したアイテムに移動しました"
@@ -112,7 +112,10 @@ class ItemsController < ApplicationController
 
   def update_review
     if @item.update(review_params)
-      redirect_to @item, notice: "感想を更新しました"
+      redirect_to(
+        params[:return_to] == "confirm_archive" ? confirm_archive_item_path(@item) : item_path(@item),
+        notice: "感想を更新しました"
+      )
     else
       redirect_to @item, alert: @item.errors.full_messages.to_sentence
     end

--- a/app/controllers/usage_logs_controller.rb
+++ b/app/controllers/usage_logs_controller.rb
@@ -12,15 +12,13 @@ class UsageLogsController < ApplicationController
   def reviews
     @page_title = "レビュー"
     @selected_rating = params[:rating].to_s
-    @usage_logs = current_user.usage_logs
-                              .finished
-                              .rated
-                              .by_rating(@selected_rating)
-                              .by_item_name(@search_query)
-                              .by_item_category(@selected_category_id)
-                              .includes(:item)
-                              .order(finished_at: :desc)
-                              .page(params[:page])
+    @items = current_user.items
+                         .where.not(rating: nil)
+                         .by_rating(@selected_rating)
+                         .by_name(@search_query)
+                         .by_category(@selected_category_id)
+                         .order(updated_at: :desc)
+                         .page(params[:page])
   end
 
   def update

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -36,6 +36,11 @@ class Item < ApplicationRecord
 
     where(category_id: category_id)
   }
+  scope :by_rating, ->(rating) {
+    return all if rating.blank?
+
+    where(rating: rating)
+  }
 
   def current_usage_log
     usage_logs.in_use.order(started_at: :desc).first

--- a/app/views/home/_review_summary.html.erb
+++ b/app/views/home/_review_summary.html.erb
@@ -1,5 +1,3 @@
-<% item = usage_log.item %>
-
 <article class="flex items-center gap-2.5 rounded-2xl border border-slate-200 bg-white p-3">
   <div class="shrink-0">
     <%= render "items/image",
@@ -10,12 +8,15 @@
   </div>
 
   <div class="min-w-0 flex-1">
+    <% if item.brand_name.present? %>
+      <p class="truncate text-xs text-emerald-700"><%= item.brand_name %></p>
+    <% end %>
     <h4 class="brand-font truncate text-sm font-bold text-slate-900">
       <%= link_to item.name, item_path(item), class: "transition hover:text-emerald-700" %>
     </h4>
-    <p class="mt-0.5 text-sm font-semibold text-yellow-500"><%= star_rating(usage_log.rating) %></p>
-    <% if usage_log.review.present? %>
-      <p class="mt-0.5 truncate text-xs text-slate-500"><%= usage_log.review %></p>
+    <p class="mt-0.5 text-sm font-semibold text-yellow-500"><%= star_rating(item.rating) %></p>
+    <% if item.review.present? %>
+      <p class="mt-0.5 truncate text-xs text-slate-500"><%= item.review %></p>
     <% end %>
   </div>
 </article>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -4,13 +4,12 @@
   </div>
 
   <section>
-    <h2 class="brand-font text-lg font-bold text-slate-900">今使っているもの</h2>
+    <h2 class="brand-font text-lg font-bold text-slate-900">なくなりそう</h2>
+    <p class="mt-1 text-xs text-slate-500">次にリピートするか、別のものを試すか決めるタイミングです。</p>
 
-    <% if @in_use_usage_logs.any? %>
+    <% if @low_stock_items.any? %>
       <div class="mt-3 grid grid-cols-[repeat(auto-fill,minmax(148px,1fr))] gap-2.5 pc:grid-cols-[repeat(auto-fill,minmax(170px,1fr))]">
-        <% @in_use_usage_logs.each do |usage_log| %>
-          <% item = usage_log.item %>
-
+        <% @low_stock_items.each do |item| %>
           <article class="rounded-2xl border border-slate-200 bg-white p-2.5">
             <%= link_to item_path(item), class: "block" do %>
               <%= render "items/image",
@@ -18,45 +17,80 @@
                          size_class: "h-14 w-full",
                          image_class: "h-14 w-full rounded-lg object-cover",
                          placeholder_icon_class: "h-6 w-6" %>
-              <h3 class="brand-font mt-1.5 truncate text-sm font-bold text-slate-900">
-                <%= item.name %>
-              </h3>
               <% if item.brand_name.present? %>
-                <p class="truncate text-xs text-slate-400"><%= item.brand_name %></p>
+                <p class="mt-1.5 truncate text-xs text-emerald-700"><%= item.brand_name %></p>
               <% end %>
+              <h3 class="brand-font truncate text-sm font-bold text-slate-900"><%= item.name %></h3>
             <% end %>
 
-            <div class="mt-2 flex flex-wrap items-center gap-1.5">
-              <%= render "items/favorite_button", item: item, compact: true %>
-              <%= render "items/low_stock_button", item: item %>
-              <%= link_to "感想を書く", edit_review_item_path(item), class: "ml-auto inline-flex items-center rounded-full border border-emerald-600 px-2.5 py-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-50" %>
+            <div class="mt-2 flex items-center justify-between gap-1.5">
+              <% if item.rating.present? %>
+                <span class="text-xs font-semibold text-amber-500">⭐️ <%= item.rating %>.0</span>
+              <% else %>
+                <span class="text-xs text-slate-400">評価なし</span>
+              <% end %>
+              <%= link_to item.rating.present? ? "感想を編集" : "感想を書く", edit_review_item_path(item), class: "inline-flex items-center rounded-full border border-emerald-600 px-2.5 py-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-50" %>
             </div>
           </article>
         <% end %>
       </div>
 
-      <% if @in_use_usage_logs_count > @in_use_usage_logs.size %>
+      <% if @low_stock_items_count > @low_stock_items.size %>
         <div class="mt-3 text-right">
-          <%= link_to "もっと見る >>", items_path(status: "in_use"), class: "text-sm font-medium text-emerald-700 hover:underline" %>
+          <%= link_to "もっと見る >>", items_path(status: "low_stock"), class: "text-sm font-medium text-emerald-700 hover:underline" %>
         </div>
       <% end %>
     <% else %>
       <div class="ui-empty-state mt-3">
-        <p class="text-sm">使用中のアイテムがありません</p>
+        <p class="text-sm">なくなりそうなアイテムはありません</p>
       </div>
     <% end %>
   </section>
 
   <section class="mt-8">
-    <h2 class="brand-font text-lg font-bold text-slate-900">よかったもの・イマイチだったもの</h2>
+    <h2 class="brand-font text-lg font-bold text-slate-900">レビュー未記入</h2>
+    <p class="mt-1 text-xs text-slate-500">感想を書けば、この一覧から自然に消えていきます。</p>
+
+    <% if @unreviewed_items.any? %>
+      <div class="mt-3 grid grid-cols-[repeat(auto-fill,minmax(148px,1fr))] gap-2.5 pc:grid-cols-[repeat(auto-fill,minmax(170px,1fr))]">
+        <% @unreviewed_items.each do |item| %>
+          <article class="rounded-2xl border border-slate-200 bg-white p-2.5">
+            <%= link_to item_path(item), class: "block" do %>
+              <%= render "items/image",
+                         item: item,
+                         size_class: "h-14 w-full",
+                         image_class: "h-14 w-full rounded-lg object-cover",
+                         placeholder_icon_class: "h-6 w-6" %>
+              <% if item.brand_name.present? %>
+                <p class="mt-1.5 truncate text-xs text-emerald-700"><%= item.brand_name %></p>
+              <% end %>
+              <h3 class="brand-font truncate text-sm font-bold text-slate-900"><%= item.name %></h3>
+            <% end %>
+
+            <%= link_to "感想を書く", edit_review_item_path(item), class: "mt-2 block rounded-full border border-emerald-600 px-2.5 py-1 text-center text-xs font-semibold text-emerald-700 transition hover:bg-emerald-50" %>
+          </article>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="ui-empty-state mt-3">
+        <p class="text-sm">未記入のレビューはありません</p>
+      </div>
+    <% end %>
+  </section>
+
+  <section class="mt-8">
+    <div class="flex items-baseline justify-between">
+      <h2 class="brand-font text-lg font-bold text-slate-900">よかったもの・イマイチだったもの</h2>
+      <%= link_to "すべて見る", reviews_usage_logs_path, class: "text-sm font-medium text-emerald-700 hover:underline" %>
+    </div>
 
     <div class="mt-3">
       <h3 class="text-sm font-bold text-emerald-700">よかったもの</h3>
 
-      <% if @good_usage_logs.any? %>
+      <% if @good_items.any? %>
         <div class="mt-2 grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-2.5">
-          <% @good_usage_logs.each do |usage_log| %>
-            <%= render "review_summary", usage_log: usage_log %>
+          <% @good_items.each do |item| %>
+            <%= render "review_summary", item: item %>
           <% end %>
         </div>
       <% else %>
@@ -67,10 +101,10 @@
     <div class="mt-4">
       <h3 class="text-sm font-bold text-red-700">イマイチだったもの</h3>
 
-      <% if @bad_usage_logs.any? %>
+      <% if @bad_items.any? %>
         <div class="mt-2 grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-2.5">
-          <% @bad_usage_logs.each do |usage_log| %>
-            <%= render "review_summary", usage_log: usage_log %>
+          <% @bad_items.each do |item| %>
+            <%= render "review_summary", item: item %>
           <% end %>
         </div>
       <% else %>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -1,11 +1,7 @@
 <div class="ui-container-wide">
-  <div class="mb-6 flex items-center justify-between">
-    <h1 class="brand-font text-2xl font-bold text-slate-900">ホーム</h1>
-  </div>
-
   <section>
-    <h2 class="brand-font text-lg font-bold text-slate-900">なくなりそう</h2>
-    <p class="mt-1 text-xs text-slate-500">次にリピートするか、別のものを試すか決めるタイミングです。</p>
+    <h2 class="brand-font text-lg font-bold text-slate-900">なくなりそうなもの</h2>
+    <p class="mt-1 text-xs text-slate-500">リピートするか、別のものを試すか決めるタイミングです。</p>
 
     <% if @low_stock_items.any? %>
       <div class="mt-3 grid grid-cols-[repeat(auto-fill,minmax(148px,1fr))] gap-2.5 pc:grid-cols-[repeat(auto-fill,minmax(170px,1fr))]">
@@ -29,7 +25,7 @@
               <% else %>
                 <span class="text-xs text-slate-400">評価なし</span>
               <% end %>
-              <%= link_to item.rating.present? ? "感想を編集" : "感想を書く", edit_review_item_path(item), class: "inline-flex items-center rounded-full border border-emerald-600 px-2.5 py-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-50" %>
+              <%= render "items/review_link", item: item, url: edit_review_item_path(item) %>
             </div>
           </article>
         <% end %>
@@ -37,7 +33,7 @@
 
       <% if @low_stock_items_count > @low_stock_items.size %>
         <div class="mt-3 text-right">
-          <%= link_to "もっと見る >>", items_path(status: "low_stock"), class: "text-sm font-medium text-emerald-700 hover:underline" %>
+          <%= link_to "もっと見る >>", items_path(low_stock: "1"), class: "text-sm font-medium text-emerald-700 hover:underline" %>
         </div>
       <% end %>
     <% else %>
@@ -48,8 +44,8 @@
   </section>
 
   <section class="mt-8">
-    <h2 class="brand-font text-lg font-bold text-slate-900">レビュー未記入</h2>
-    <p class="mt-1 text-xs text-slate-500">感想を書けば、この一覧から自然に消えていきます。</p>
+    <h2 class="brand-font text-lg font-bold text-slate-900">レビューをかいていないもの</h2>
+    <p class="mt-1 text-xs text-slate-500">まだ感想を書いていないアイテムです。</p>
 
     <% if @unreviewed_items.any? %>
       <div class="mt-3 grid grid-cols-[repeat(auto-fill,minmax(148px,1fr))] gap-2.5 pc:grid-cols-[repeat(auto-fill,minmax(170px,1fr))]">
@@ -67,10 +63,18 @@
               <h3 class="brand-font truncate text-sm font-bold text-slate-900"><%= item.name %></h3>
             <% end %>
 
-            <%= link_to "感想を書く", edit_review_item_path(item), class: "mt-2 block rounded-full border border-emerald-600 px-2.5 py-1 text-center text-xs font-semibold text-emerald-700 transition hover:bg-emerald-50" %>
+            <div class="mt-2 flex justify-end">
+              <%= render "items/review_link", item: item, url: edit_review_item_path(item) %>
+            </div>
           </article>
         <% end %>
       </div>
+
+      <% if @unreviewed_items_count > @unreviewed_items.size %>
+        <div class="mt-3 text-right">
+          <%= link_to "もっと見る >>", items_path(unreviewed: "1"), class: "text-sm font-medium text-emerald-700 hover:underline" %>
+        </div>
+      <% end %>
     <% else %>
       <div class="ui-empty-state mt-3">
         <p class="text-sm">未記入のレビューはありません</p>

--- a/app/views/items/_review_form.html.erb
+++ b/app/views/items/_review_form.html.erb
@@ -2,6 +2,10 @@
   <p class="text-xs font-semibold text-emerald-700">今の感想（いつでも書き換えできます）</p>
 
   <%= form_with model: item, url: update_review_item_path(item), method: :patch, local: true, class: "mt-3 space-y-4" do |form| %>
+    <% if local_assigns[:return_to].present? %>
+      <%= hidden_field_tag :return_to, return_to %>
+    <% end %>
+
     <%= render "star_rating_input", form: form %>
 
     <div>

--- a/app/views/items/_review_link.html.erb
+++ b/app/views/items/_review_link.html.erb
@@ -1,0 +1,5 @@
+<% if item.rating.present? %>
+  <%= link_to "感想を編集", url, class: "inline-flex items-center rounded-full border border-slate-300 px-2.5 py-1 text-xs font-semibold text-slate-600 transition hover:bg-slate-50" %>
+<% else %>
+  <%= link_to "感想を書く", url, class: "inline-flex items-center rounded-full bg-emerald-100 px-2.5 py-1 text-xs font-semibold text-emerald-800 transition hover:bg-emerald-200" %>
+<% end %>

--- a/app/views/items/confirm_archive.html.erb
+++ b/app/views/items/confirm_archive.html.erb
@@ -1,0 +1,25 @@
+<div class="ui-container">
+  <div class="space-y-5">
+    <h1 class="brand-font text-center text-2xl font-bold text-slate-900">このアイテムを手放す</h1>
+
+    <div class="text-center">
+      <% if @item.brand_name.present? %>
+        <p class="text-sm font-medium text-emerald-700"><%= @item.brand_name %></p>
+      <% end %>
+      <p class="brand-font mt-1 text-lg font-bold text-slate-900"><%= @item.name %></p>
+    </div>
+
+    <p class="text-center text-sm text-slate-500">
+      感想は手放した後も「手放したもの」タブに残ります。次に選ぶときの参考になるよう、今の気持ちを書き残しておきましょう。
+    </p>
+
+    <%= render "review_form", item: @item, return_to: "confirm_archive" %>
+
+    <%= link_to "このアイテムを手放す",
+                archive_item_path(@item),
+                data: { turbo_method: :patch, turbo_confirm: "手放しますか？（よく使うもの・なくなりそうのフラグは自動でオフになります。）" },
+                class: "block rounded-full border border-red-200 px-4 py-2 text-center text-sm font-semibold text-red-600 transition hover:bg-red-50" %>
+
+    <%= link_to "やめる（一覧に戻る）", items_path, class: "block text-center text-sm text-slate-500 underline-offset-4 hover:underline" %>
+  </div>
+</div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -94,19 +94,26 @@
                 <h2 class="brand-font truncate text-sm font-bold text-slate-900"><%= item.name %></h2>
               </div>
 
-              <div class="shrink-0 text-right text-xs font-semibold">
+              <div class="shrink-0 text-right text-sm font-semibold">
                 <% if item.rating.present? %>
-                  <span class="text-amber-500">⭐️ <%= item.rating %>.0</span>
+                  <span class="text-yellow-500"><%= star_rating(item.rating) %></span>
                 <% else %>
-                  <span class="text-slate-400">評価なし</span>
+                  <span class="text-xs font-normal text-slate-400">評価なし</span>
                 <% end %>
               </div>
             <% end %>
           </div>
 
+          <% if item.review.present? %>
+            <div class="mt-1.5 pl-[calc(3rem+0.75rem)]">
+              <p class="truncate border-l-2 border-emerald-200 pl-2 text-xs italic text-slate-700">“<%= item.review %>”</p>
+            </div>
+          <% end %>
+
+          <% review_link_label = item.rating.present? ? "感想を編集" : "感想を書く" %>
           <div class="mt-2 flex flex-wrap items-center gap-2 pl-[calc(3rem+0.75rem)]">
             <% if item.archived? %>
-              <%= link_to "感想を書く", item_path(item, anchor: "review"), class: "inline-flex items-center rounded-full border border-emerald-600 px-2.5 py-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-50" %>
+              <%= link_to review_link_label, item_path(item, anchor: "review"), class: "inline-flex items-center rounded-full border border-emerald-600 px-2.5 py-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-50" %>
               <%= link_to "リストに戻す",
                           unarchive_item_path(item),
                           data: { turbo_method: :patch },
@@ -114,7 +121,7 @@
             <% else %>
               <%= render "favorite_button", item: item, compact: true %>
               <%= render "low_stock_button", item: item %>
-              <%= link_to "感想を書く", item_path(item, anchor: "review"), class: "inline-flex items-center rounded-full border border-emerald-600 px-2.5 py-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-50" %>
+              <%= link_to review_link_label, item_path(item, anchor: "review"), class: "inline-flex items-center rounded-full border border-emerald-600 px-2.5 py-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-50" %>
               <%= link_to "手放す",
                           archive_item_path(item),
                           data: {

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,63 +1,76 @@
 <div class="ui-container-wide">
+  <% carry_params = {
+    q: @search_query.presence,
+    category_id: @selected_category_id.presence,
+    scope: @scope.presence,
+    favorite: @favorite_filter ? "1" : nil,
+    low_stock: @low_stock_filter ? "1" : nil,
+    unreviewed: @unreviewed_filter ? "1" : nil
+  } %>
+
   <%= render "shared/search_form",
              url: items_path,
              query: @search_query,
-             hidden_params: {
-               category_id: @selected_category_id.presence,
-               status: @selected_status.presence
-             },
+             hidden_params: carry_params.except(:q),
              show_reset: @search_query.present?,
-             reset_url: items_path(
-               category_id: @selected_category_id.presence,
-               status: @selected_status.presence
-             ) %>
+             reset_url: items_path(carry_params.except(:q)) %>
 
   <div class="mb-4 space-y-3">
-    <% status_filter_params = {
-      q: @search_query.presence,
-      category_id: @selected_category_id.presence
-    } %>
-    <div class="flex flex-wrap items-center justify-between gap-2">
-      <nav class="flex flex-wrap gap-1 rounded-full bg-slate-100 p-1 text-sm" aria-label="絞り込み">
-        <%= link_to "すべて",
-                    items_path(status_filter_params),
-                    class: class_names(
-                      "shrink-0 rounded-full px-3 py-1.5 font-semibold transition",
-                      @selected_status.blank? ? "bg-white text-emerald-700 shadow-sm" : "text-slate-600 hover:bg-white/70"
-                    ) %>
-        <%= link_to "♡ よく使うもの",
-                    items_path(status_filter_params.merge(status: "favorite")),
-                    class: class_names(
-                      "shrink-0 rounded-full px-3 py-1.5 font-semibold transition",
-                      @selected_status == "favorite" ? "bg-white text-emerald-700 shadow-sm" : "text-slate-600 hover:bg-white/70"
-                    ) %>
-        <%= link_to "なくなりそうなもの",
-                    items_path(status_filter_params.merge(status: "low_stock")),
-                    class: class_names(
-                      "shrink-0 rounded-full px-3 py-1.5 font-semibold transition",
-                      @selected_status == "low_stock" ? "bg-white text-emerald-700 shadow-sm" : "text-slate-600 hover:bg-white/70"
-                    ) %>
-        <%= link_to "手放したもの",
-                    items_path(status_filter_params.merge(status: "archived")),
-                    class: class_names(
-                      "shrink-0 rounded-full px-3 py-1.5 font-semibold transition",
-                      @selected_status == "archived" ? "bg-white text-emerald-700 shadow-sm" : "text-slate-600 hover:bg-white/70"
-                    ) %>
-      </nav>
+    <!-- 範囲: 見ている母集団そのものを切り替える -->
+    <nav class="flex w-fit gap-1 rounded-full bg-slate-100 p-1 text-sm" aria-label="範囲">
+      <%= link_to "すべて",
+                  items_path(carry_params.merge(scope: nil, favorite: nil, low_stock: nil, unreviewed: nil)),
+                  class: class_names(
+                    "shrink-0 rounded-full px-3 py-1.5 font-medium transition",
+                    @scope.blank? ? "bg-white text-emerald-700 shadow-sm" : "text-slate-600 hover:bg-white/70"
+                  ) %>
+      <%= link_to "手放したもの",
+                  items_path(carry_params.merge(scope: "archived", favorite: nil, low_stock: nil, unreviewed: nil)),
+                  class: class_names(
+                    "shrink-0 rounded-full px-3 py-1.5 font-medium transition",
+                    @scope == "archived" ? "bg-white text-emerald-700 shadow-sm" : "text-slate-600 hover:bg-white/70"
+                  ) %>
+    </nav>
 
-      <!-- selectのchangeイベントでフォームを送信すると、選ぶだけで絞り込めるドロップダウンになる -->
-      <%= form_with url: items_path, method: :get, local: true, class: "shrink-0" do %>
-        <%= hidden_field_tag :q, @search_query.presence %>
-        <%= hidden_field_tag :status, @selected_status.presence %>
-        <select name="category_id" onchange="this.form.requestSubmit()" class="form-input h-9 w-auto text-sm">
-          <option value="">カテゴリ: すべて</option>
-          <% @categories.each do |category| %>
-            <option value="<%= category.id %>" <%= "selected" if @selected_category_id == category.id.to_s %>><%= category.name %></option>
-          <% end %>
-          <option value="uncategorized" <%= "selected" if @selected_category_id == "uncategorized" %>>未設定</option>
-        </select>
-      <% end %>
-    </div>
+    <% unless @scope == "archived" %>
+      <!-- 属性タグ: 複数同時に当てはまり得るので、独立してON/OFFできるチップにする -->
+      <div class="flex flex-wrap items-center gap-2 text-sm">
+        <%= link_to "♡ よく使うもの",
+                    items_path(carry_params.merge(favorite: @favorite_filter ? nil : "1")),
+                    class: class_names(
+                      "shrink-0 rounded-full border px-3 py-1.5 font-medium transition",
+                      @favorite_filter ? "border-emerald-600 bg-emerald-50 text-emerald-700" : "border-slate-200 text-slate-600 hover:bg-slate-50"
+                    ) %>
+        <%= link_to "なくなりそう",
+                    items_path(carry_params.merge(low_stock: @low_stock_filter ? nil : "1")),
+                    class: class_names(
+                      "shrink-0 rounded-full border px-3 py-1.5 font-medium transition",
+                      @low_stock_filter ? "border-emerald-600 bg-emerald-50 text-emerald-700" : "border-slate-200 text-slate-600 hover:bg-slate-50"
+                    ) %>
+        <%= link_to "レビュー未記入",
+                    items_path(carry_params.merge(unreviewed: @unreviewed_filter ? nil : "1")),
+                    class: class_names(
+                      "shrink-0 rounded-full border px-3 py-1.5 font-medium transition",
+                      @unreviewed_filter ? "border-emerald-600 bg-emerald-50 text-emerald-700" : "border-slate-200 text-slate-600 hover:bg-slate-50"
+                    ) %>
+      </div>
+    <% end %>
+
+    <!-- カテゴリ: 状態とは別軸の分類。selectのchangeイベントでフォームを送信すると、選ぶだけで絞り込める -->
+    <%= form_with url: items_path, method: :get, local: true, class: "flex" do %>
+      <%= hidden_field_tag :q, @search_query.presence %>
+      <%= hidden_field_tag :scope, @scope.presence %>
+      <%= hidden_field_tag :favorite, @favorite_filter ? "1" : nil %>
+      <%= hidden_field_tag :low_stock, @low_stock_filter ? "1" : nil %>
+      <%= hidden_field_tag :unreviewed, @unreviewed_filter ? "1" : nil %>
+      <select name="category_id" onchange="this.form.requestSubmit()" class="form-input h-9 w-auto text-sm">
+        <option value="">カテゴリ: すべて</option>
+        <% @categories.each do |category| %>
+          <option value="<%= category.id %>" <%= "selected" if @selected_category_id == category.id.to_s %>><%= category.name %></option>
+        <% end %>
+        <option value="uncategorized" <%= "selected" if @selected_category_id == "uncategorized" %>>未設定</option>
+      </select>
+    <% end %>
 
     <% if @selected_category_id.present? %>
       <div class="flex flex-wrap items-center gap-2 text-xs text-slate-500">
@@ -65,7 +78,7 @@
           <%= @selected_category_id == "uncategorized" ? "カテゴリ: 未設定" : "カテゴリ: #{@categories.find { |category| category.id.to_s == @selected_category_id }&.name}" %>
         </span>
         <%= link_to "条件をクリア",
-                    items_path(q: @search_query.presence, status: @selected_status.presence),
+                    items_path(carry_params.except(:category_id)),
                     class: "font-semibold text-slate-500 underline-offset-4 hover:text-slate-800 hover:underline" %>
       </div>
     <% end %>
@@ -110,10 +123,9 @@
             </div>
           <% end %>
 
-          <% review_link_label = item.rating.present? ? "感想を編集" : "感想を書く" %>
           <div class="mt-2 flex flex-wrap items-center gap-2 pl-[calc(3rem+0.75rem)]">
             <% if item.archived? %>
-              <%= link_to review_link_label, item_path(item, anchor: "review"), class: "inline-flex items-center rounded-full border border-emerald-600 px-2.5 py-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-50" %>
+              <%= render "review_link", item: item, url: item_path(item, anchor: "review") %>
               <%= link_to "リストに戻す",
                           unarchive_item_path(item),
                           data: { turbo_method: :patch },
@@ -121,13 +133,9 @@
             <% else %>
               <%= render "favorite_button", item: item, compact: true %>
               <%= render "low_stock_button", item: item %>
-              <%= link_to review_link_label, item_path(item, anchor: "review"), class: "inline-flex items-center rounded-full border border-emerald-600 px-2.5 py-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-50" %>
+              <%= render "review_link", item: item, url: item_path(item, anchor: "review") %>
               <%= link_to "手放す",
-                          archive_item_path(item),
-                          data: {
-                            turbo_method: :patch,
-                            turbo_confirm: item.review.present? ? "感想は残したまま、持ち物一覧の「手放した」に移動します。よろしいですか？" : "感想がまだ入力されていません。このまま手放しますか？"
-                          },
+                          confirm_archive_item_path(item),
                           class: "ml-auto text-xs text-slate-400 underline-offset-4 transition hover:text-red-600 hover:underline" %>
             <% end %>
           </div>
@@ -147,7 +155,7 @@
         <p class="mt-4 text-lg">条件に合うアイテムがありません</p>
         <p class="mt-2 text-sm">検索条件を変更して、もう一度お試しください。</p>
         <%= link_to "検索条件をリセット",
-                    items_path(status: @selected_status.presence),
+                    items_path(carry_params.except(:q)),
                     class: "btn-secondary mt-5" %>
       <% else %>
         <p class="mt-4 text-lg">アイテムがありません</p>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -72,11 +72,7 @@
 
     <div class="border-t border-slate-100 pt-5 space-y-3 text-center">
       <%= link_to "このアイテムを手放す",
-                  archive_item_path(@item),
-                  data: {
-                    turbo_method: :patch,
-                    turbo_confirm: @item.review.present? ? "感想は残したまま、持ち物一覧の「手放した」に移動します。よろしいですか？" : "感想がまだ入力されていません。このまま手放しますか？"
-                  },
+                  confirm_archive_item_path(@item),
                   class: "block text-sm text-slate-500 underline-offset-4 transition hover:text-amber-700 hover:underline" %>
 
       <%= link_to "削除する",

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,7 +34,7 @@
   <body class="min-h-screen bg-slate-50 text-slate-900">
     <%= render 'shared/header' %>
 
-    <main class="min-h-[calc(100vh-9rem)] <%= "pb-20 pc:pb-0" if user_signed_in? %>">
+    <main class="min-h-[calc(100vh-9rem)] <%= "pb-24 pc:pb-0" if user_signed_in? %>">
       <% if flash.any? %>
         <div class="mx-auto w-full max-w-5xl px-4 pt-4">
           <% flash.each do |message_type, message| %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,14 +6,14 @@
     <% end %>
 
     <% if user_signed_in? %>
-      <% active_nav_class = "rounded-md bg-emerald-50 px-3 py-1.5 font-medium text-emerald-700 transition hover:bg-emerald-100" %>
-      <% inactive_nav_class = "rounded-md px-3 py-1.5 font-medium text-slate-700 transition hover:bg-slate-100" %>
+      <% active_nav_class = "border-b-2 border-emerald-600 px-5 py-2 font-semibold text-emerald-700" %>
+      <% inactive_nav_class = "border-b-2 border-transparent px-5 py-2 font-medium text-slate-600 transition hover:border-slate-200 hover:text-emerald-700" %>
       <% home_active = controller_name == "home" %>
       <% items_active = controller_name == "items" && !%w[new create].include?(action_name) %>
       <% reviews_active = controller_name == "usage_logs" %>
       <% register_active = controller_name == "items" && %w[new create].include?(action_name) %>
 
-      <nav class="hidden items-center gap-2 text-sm pc:flex" aria-label="メインメニュー">
+      <nav class="hidden items-center gap-1 self-stretch text-sm pc:flex" aria-label="メインメニュー">
         <%= link_to "ホーム", home_path, class: home_active ? active_nav_class : inactive_nav_class %>
         <%= link_to "持ち物", items_path, class: items_active ? active_nav_class : inactive_nav_class %>
         <%= link_to "感想", reviews_usage_logs_path, class: reviews_active ? active_nav_class : inactive_nav_class %>
@@ -36,10 +36,10 @@
 </header>
 
 <% if user_signed_in? %>
-  <% active_tab_class = "flex min-w-0 flex-1 flex-col items-center gap-0.5 whitespace-nowrap rounded-md py-1.5 font-medium text-emerald-700" %>
-  <% inactive_tab_class = "flex min-w-0 flex-1 flex-col items-center gap-0.5 whitespace-nowrap rounded-md py-1.5 font-medium text-slate-500" %>
+  <% active_tab_class = "flex min-w-0 flex-1 flex-col items-center gap-0.5 whitespace-nowrap rounded-md py-2.5 font-medium text-emerald-700" %>
+  <% inactive_tab_class = "flex min-w-0 flex-1 flex-col items-center gap-0.5 whitespace-nowrap rounded-md py-2.5 font-medium text-slate-500" %>
 
-  <nav class="fixed inset-x-0 bottom-0 z-20 flex gap-1 border-t border-emerald-100 bg-white/95 px-2 py-1 text-center text-xs shadow-[0_-1px_4px_rgba(0,0,0,0.06)] pc:hidden" aria-label="スマートフォンメニュー">
+  <nav class="fixed inset-x-0 bottom-0 z-20 flex gap-1 border-t border-emerald-100 bg-white/95 px-2 py-2 text-center text-sm shadow-[0_-1px_4px_rgba(0,0,0,0.06)] pc:hidden" aria-label="スマートフォンメニュー">
     <%= link_to "ホーム", home_path, class: home_active ? active_tab_class : inactive_tab_class %>
     <%= link_to "持ち物", items_path, class: items_active ? active_tab_class : inactive_tab_class %>
     <%= link_to "感想", reviews_usage_logs_path, class: reviews_active ? active_tab_class : inactive_tab_class %>

--- a/app/views/usage_logs/reviews.html.erb
+++ b/app/views/usage_logs/reviews.html.erb
@@ -32,11 +32,9 @@
     </select>
   <% end %>
 
-  <% if @usage_logs.any? %>
+  <% if @items.any? %>
     <div class="grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-2.5">
-      <% @usage_logs.each do |usage_log| %>
-        <% item = usage_log.item %>
-
+      <% @items.each do |item| %>
         <article class="flex items-center gap-3 rounded-2xl border border-slate-200 bg-white p-3">
           <div class="shrink-0">
             <%= render "items/image",
@@ -47,32 +45,32 @@
           </div>
 
           <div class="min-w-0 flex-1">
-            <div class="flex items-baseline justify-between gap-2">
-              <h2 class="brand-font truncate text-sm font-bold text-slate-900">
-                <%= link_to item.name, item_path(item), class: "transition hover:text-emerald-700" %>
-              </h2>
-              <span class="shrink-0 text-xs text-slate-400"><%= format_date(usage_log.finished_at) %></span>
-            </div>
-            <p class="mt-0.5 text-sm font-semibold text-yellow-500"><%= star_rating(usage_log.rating) %></p>
-            <p class="mt-0.5 line-clamp-2 text-xs text-slate-600"><%= usage_log.review.presence || "レビューなし" %></p>
+            <% if item.brand_name.present? %>
+              <p class="truncate text-xs text-emerald-700"><%= item.brand_name %></p>
+            <% end %>
+            <h2 class="brand-font truncate text-sm font-bold text-slate-900">
+              <%= link_to item.name, item_path(item), class: "transition hover:text-emerald-700" %>
+            </h2>
+            <p class="mt-0.5 text-sm font-semibold text-yellow-500"><%= star_rating(item.rating) %></p>
+            <p class="mt-0.5 line-clamp-2 text-xs text-slate-600"><%= item.review.presence || "レビューなし" %></p>
           </div>
 
-          <%= link_to "編集", edit_usage_log_path(usage_log), class: "shrink-0 text-xs font-medium text-emerald-700 transition hover:text-emerald-800" %>
+          <%= link_to "編集", edit_review_item_path(item), class: "shrink-0 text-xs font-medium text-emerald-700 transition hover:text-emerald-800" %>
         </article>
       <% end %>
     </div>
 
     <div class="mt-8">
-      <%= paginate @usage_logs %>
+      <%= paginate @items %>
     </div>
   <% else %>
     <div class="ui-empty-state">
       <% if @search_query.present? %>
-        <p class="text-lg">条件に合う評価・レビュー履歴がありません</p>
+        <p class="text-lg">条件に合う評価・レビューがありません</p>
         <p class="mt-2 text-sm">検索条件を変更して、もう一度お試しください。</p>
         <%= link_to "検索条件をリセット", reviews_usage_logs_path, class: "btn-secondary mt-5" %>
       <% else %>
-        <p class="text-lg">評価・レビュー履歴がありません</p>
+        <p class="text-lg">評価・レビューがありません</p>
         <p class="mt-2 text-sm">評価を残したアイテムがここに表示されます。</p>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     member do
       patch :toggle_low_stock
       patch :toggle_favorite
+      get :confirm_archive
       patch :archive
       patch :unarchive
       # updateアクションだとカテゴリが更新されないので、感想の更新専用アクションを作る

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -7,7 +7,7 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     get home_path
 
     assert_response :success
-    assert_select "h1", "ホーム"
+    assert_select "h2", text: "なくなりそうなもの"
   end
 
   test "signed out visitor is redirected to sign in" do
@@ -26,7 +26,7 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     get home_path
 
     assert_response :success
-    assert_select "h2", text: "なくなりそう"
+    assert_select "h2", text: "なくなりそうなもの"
     assert_select "a[href='#{item_path(item)}']", text: item.name
     assert_select "a[href='#{edit_review_item_path(item)}']", text: "感想を書く"
   end
@@ -85,7 +85,7 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     get home_path
 
     assert_response :success
-    assert_select "h2", text: "レビュー未記入"
+    assert_select "h2", text: "レビューをかいていないもの"
     assert_select "a[href='#{item_path(item)}']", text: item.name
     assert_select "a[href='#{edit_review_item_path(item)}']", text: "感想を書く"
   end
@@ -101,6 +101,30 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select ".ui-empty-state", text: /未記入のレビューはありません/
+  end
+
+  test "home shows at most 6 unreviewed items with a link to see more" do
+    user = users(:one)
+    sign_in user
+
+    items(:one).destroy
+    items(:two).destroy
+    7.times { |number| user.items.create!(name: "未記入アイテム#{number}") }
+
+    get home_path
+
+    assert_response :success
+    assert_select "a[href='#{items_path(unreviewed: "1")}']", text: "もっと見る >>"
+  end
+
+  test "home does not show the more link when 6 or fewer items are unreviewed" do
+    user = users(:one)
+    sign_in user
+
+    get home_path
+
+    assert_response :success
+    assert_select "a[href='#{items_path(unreviewed: "1")}']", text: "もっと見る >>", count: 0
   end
 
   test "home shows highly rated and poorly rated items separately" do
@@ -133,7 +157,7 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     get home_path
 
     assert_response :success
-    assert_select "a[href='#{items_path(status: "low_stock")}']", text: "もっと見る >>"
+    assert_select "a[href='#{items_path(low_stock: "1")}']", text: "もっと見る >>"
   end
 
   test "home does not show the more link when 4 or fewer items are low on stock" do
@@ -146,7 +170,7 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     get home_path
 
     assert_response :success
-    assert_select "a[href='#{items_path(status: "low_stock")}']", text: "もっと見る >>", count: 0
+    assert_select "a[href='#{items_path(low_stock: "1")}']", text: "もっと見る >>", count: 0
   end
 
   test "home does not show middling ratings in good or bad sections" do

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -16,37 +16,47 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_user_session_path
   end
 
-  test "home shows in-use items with low stock toggle and review link" do
+  test "home shows low stock items with a review link" do
     user = users(:one)
     sign_in user
 
     item = items(:one)
-    item.start_using!(user, Time.zone.local(2026, 5, 10))
+    item.update!(low_stock_flagged: true)
 
     get home_path
 
     assert_response :success
-    assert_select "h2", text: "今使っているもの"
+    assert_select "h2", text: "なくなりそう"
     assert_select "a[href='#{item_path(item)}']", text: item.name
-    assert_select "form[action='#{toggle_low_stock_item_path(item)}']"
-    assert_select "form[action='#{toggle_favorite_item_path(item)}']"
     assert_select "a[href='#{edit_review_item_path(item)}']", text: "感想を書く"
   end
 
-  test "home shows empty state when nothing is in use" do
+  test "home shows an edit label for the review link when the low stock item already has a rating" do
+    user = users(:one)
+    sign_in user
+
+    item = items(:one)
+    item.update!(low_stock_flagged: true, rating: 4)
+
+    get home_path
+
+    assert_response :success
+    assert_select "a[href='#{edit_review_item_path(item)}']", text: "感想を編集"
+  end
+
+  test "home shows empty state when nothing is low on stock" do
     sign_in users(:one)
 
     get home_path
 
     assert_response :success
-    assert_select ".ui-empty-state", text: /使用中のアイテムがありません/
+    assert_select ".ui-empty-state", text: /なくなりそうなアイテムはありません/
   end
 
-  test "home does not show other user's in-use items" do
+  test "home does not show other user's low stock items" do
     sign_in users(:one)
 
-    other_item = users(:two).items.create!(name: "他ユーザーのアイテム", in_stock: true)
-    other_item.start_using!(users(:two), Time.zone.local(2026, 5, 10))
+    other_item = users(:two).items.create!(name: "他ユーザーのアイテム", low_stock_flagged: true)
 
     get home_path
 
@@ -54,18 +64,54 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_no_match "他ユーザーのアイテム", response.body
   end
 
+  test "home does not show archived items even if low stock" do
+    sign_in users(:one)
+
+    item = items(:one)
+    item.update!(low_stock_flagged: true, archived: true)
+
+    get home_path
+
+    assert_response :success
+    assert_select ".ui-empty-state", text: /なくなりそうなアイテムはありません/
+  end
+
+  test "home shows unreviewed items with a review link" do
+    user = users(:one)
+    sign_in user
+
+    item = items(:one)
+
+    get home_path
+
+    assert_response :success
+    assert_select "h2", text: "レビュー未記入"
+    assert_select "a[href='#{item_path(item)}']", text: item.name
+    assert_select "a[href='#{edit_review_item_path(item)}']", text: "感想を書く"
+  end
+
+  test "home does not show reviewed items in the unreviewed section" do
+    user = users(:one)
+    sign_in user
+
+    items(:one).update!(rating: 4, review: "よかった")
+    items(:two).update!(rating: 5, review: "とても良かった")
+
+    get home_path
+
+    assert_response :success
+    assert_select ".ui-empty-state", text: /未記入のレビューはありません/
+  end
+
   test "home shows highly rated and poorly rated items separately" do
     user = users(:one)
     sign_in user
 
     good_item = items(:one)
-    good_item.start_using!(user, Time.zone.local(2026, 5, 1))
-    good_item.finish_using!(Time.zone.local(2026, 5, 10), rating: 5, review: "また使いたい")
+    good_item.update!(rating: 5, review: "また使いたい")
 
     bad_item = items(:two)
-    bad_item.update!(in_stock: true)
-    bad_item.start_using!(user, Time.zone.local(2026, 5, 1))
-    bad_item.finish_using!(Time.zone.local(2026, 5, 5), rating: 1, review: "合わなかった")
+    bad_item.update!(rating: 1, review: "合わなかった")
 
     get home_path
 
@@ -76,33 +122,31 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{item_path(bad_item)}']", text: bad_item.name
   end
 
-  test "home shows at most 4 in-use items with a link to see more" do
+  test "home shows at most 4 low stock items with a link to see more" do
     user = users(:one)
     sign_in user
 
     5.times do |number|
-      item = user.items.create!(name: "使用中アイテム#{number}", in_stock: true)
-      item.start_using!(user, Time.zone.local(2026, 5, 10))
+      user.items.create!(name: "なくなりそうアイテム#{number}", low_stock_flagged: true)
     end
 
     get home_path
 
     assert_response :success
-    assert_select "article", count: 4
-    assert_select "a[href='#{items_path(status: "in_use")}']", text: "もっと見る >>"
+    assert_select "a[href='#{items_path(status: "low_stock")}']", text: "もっと見る >>"
   end
 
-  test "home does not show the more link when 4 or fewer items are in use" do
+  test "home does not show the more link when 4 or fewer items are low on stock" do
     user = users(:one)
     sign_in user
 
     item = items(:one)
-    item.start_using!(user, Time.zone.local(2026, 5, 10))
+    item.update!(low_stock_flagged: true)
 
     get home_path
 
     assert_response :success
-    assert_select "a[href='#{items_path(status: "in_use")}']", text: "もっと見る >>", count: 0
+    assert_select "a[href='#{items_path(status: "low_stock")}']", text: "もっと見る >>", count: 0
   end
 
   test "home does not show middling ratings in good or bad sections" do
@@ -110,13 +154,25 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     sign_in user
 
     item = items(:one)
-    item.start_using!(user, Time.zone.local(2026, 5, 1))
-    item.finish_using!(Time.zone.local(2026, 5, 10), rating: 3)
+    item.update!(rating: 3)
 
     get home_path
 
     assert_response :success
     assert_includes response.body, "まだ高評価のレビューがありません"
     assert_includes response.body, "まだ低評価のレビューがありません"
+  end
+
+  test "home does not show archived items in good or bad sections" do
+    user = users(:one)
+    sign_in user
+
+    item = items(:one)
+    item.update!(rating: 5, archived: true)
+
+    get home_path
+
+    assert_response :success
+    assert_includes response.body, "まだ高評価のレビューがありません"
   end
 end

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -41,7 +41,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
       assert_select "a[href='#{new_item_path}']", text: "登録"
     end
     assert_select "nav[aria-label='メインメニュー'].pc\\:flex" do
-      assert_select "a.bg-emerald-50[href='#{items_path}']", text: "持ち物"
+      assert_select "a.border-emerald-600[href='#{items_path}']", text: "持ち物"
       assert_select "a[href='#{home_path}']", text: "ホーム"
       assert_select "a[href='#{reviews_usage_logs_path}']", text: "感想"
       assert_select "a[href='#{new_item_path}']", text: "登録"
@@ -97,21 +97,40 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{items_path}']", text: "検索条件をリセット"
   end
 
-  test "index shows status filters" do
+  test "index shows scope tabs and attribute tag chips" do
     get items_path
 
     assert_response :success
     assert_select "a[href='#{items_path}']", text: "すべて"
-    assert_select "a[href='#{items_path(status: "favorite")}']", text: "♡ よく使うもの"
-    assert_select "a[href='#{items_path(status: "low_stock")}']", text: "なくなりそうなもの"
-    assert_select "a[href='#{items_path(status: "archived")}']", text: "手放したもの"
+    assert_select "a[href='#{items_path(scope: "archived")}']", text: "手放したもの"
+    assert_select "a[href='#{items_path(favorite: "1")}']", text: "♡ よく使うもの"
+    assert_select "a[href='#{items_path(low_stock: "1")}']", text: "なくなりそう"
+    assert_select "a[href='#{items_path(unreviewed: "1")}']", text: "レビュー未記入"
+  end
+
+  test "index does not show attribute tag chips on the archived scope" do
+    get items_path, params: { scope: "archived" }
+
+    assert_response :success
+    assert_select "a[href='#{items_path(scope: "archived", favorite: "1")}']", count: 0
+  end
+
+  test "index filters unreviewed items" do
+    unreviewed_item = items(:one)
+    items(:two).update!(rating: 4)
+
+    get items_path, params: { unreviewed: "1" }
+
+    assert_response :success
+    assert_includes response.body, unreviewed_item.name
+    assert_no_match items(:two).name, response.body
   end
 
   test "index filters favorite items" do
     favorite_item = items(:one)
     favorite_item.update!(favorite: true)
 
-    get items_path, params: { status: "favorite" }
+    get items_path, params: { favorite: "1" }
 
     assert_response :success
     assert_includes response.body, favorite_item.name
@@ -122,18 +141,31 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     low_stock_item = items(:one)
     low_stock_item.update!(low_stock_flagged: true)
 
-    get items_path, params: { status: "low_stock" }
+    get items_path, params: { low_stock: "1" }
 
     assert_response :success
     assert_includes response.body, low_stock_item.name
     assert_no_match items(:two).name, response.body
   end
 
+  test "index combines multiple attribute tag filters" do
+    both = items(:one)
+    both.update!(favorite: true, low_stock_flagged: true)
+    only_favorite = items(:two)
+    only_favorite.update!(favorite: true, low_stock_flagged: false)
+
+    get items_path, params: { favorite: "1", low_stock: "1" }
+
+    assert_response :success
+    assert_includes response.body, both.name
+    assert_no_match only_favorite.name, response.body
+  end
+
   test "index shows archived items only on the archived tab, with a restore link" do
     archived_item = items(:two)
     archived_item.update!(archived: true)
 
-    get items_path, params: { status: "archived" }
+    get items_path, params: { scope: "archived" }
 
     assert_response :success
     assert_includes response.body, archived_item.name
@@ -236,7 +268,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "article form[action='#{toggle_low_stock_item_path(item)}']"
     assert_select "article a[href='#{item_path(item, anchor: "review")}']", text: "感想を書く"
-    assert_select "article a[href='#{archive_item_path(item)}']", text: "手放す"
+    assert_select "article a[href='#{confirm_archive_item_path(item)}']", text: "手放す"
   end
 
   test "index shows an edit label for the review link when the item already has a rating" do
@@ -326,7 +358,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     get items_path, params: { category_id: category.id }
 
     assert_response :success
-    assert_select "a[href='#{items_path(category_id: category.id, status: "favorite")}']", text: "♡ よく使うもの"
+    assert_select "a[href='#{items_path(category_id: category.id, favorite: "1")}']", text: "♡ よく使うもの"
   end
 
   test "index does not show reset link when only category is selected" do
@@ -367,6 +399,26 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
       q: "検索対象",
       category_id: category.id
     )}']"
+  end
+
+  test "confirm_archive shows the review form and a real archive button" do
+    item = items(:one)
+    item.update!(rating: 4, review: "よかった")
+
+    get confirm_archive_item_path(item)
+
+    assert_response :success
+    assert_includes response.body, item.name
+    assert_select "form[action='#{update_review_item_path(item)}'] input[type='hidden'][name='return_to'][value='confirm_archive']"
+    assert_select "a[href='#{archive_item_path(item)}']", text: "このアイテムを手放す"
+  end
+
+  test "update_review redirects back to confirm_archive when return_to is set" do
+    item = items(:one)
+
+    patch update_review_item_path(item), params: { item: { rating: 4, review: "よかった" }, return_to: "confirm_archive" }
+
+    assert_redirected_to confirm_archive_item_path(item)
   end
 
   test "archive archives item and clears low_stock_flagged and favorite" do
@@ -914,7 +966,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     get item_path(item)
 
     assert_response :success
-    assert_select "a[href='#{archive_item_path(item)}']", text: "このアイテムを手放す"
+    assert_select "a[href='#{confirm_archive_item_path(item)}']", text: "このアイテムを手放す"
   end
 
   test "update with invalid image rerenders edit page" do

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -186,7 +186,26 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     get items_path
 
     assert_response :success
-    assert_includes response.body, "⭐️ 4"
+    assert_select "article span.text-yellow-500", text: /★★★★\s*☆/
+  end
+
+  test "index shows the review snippet when the item has a review" do
+    item = items(:one)
+    item.update!(rating: 4, review: "泡立ちが良くて香りも好み")
+
+    get items_path
+
+    assert_response :success
+    assert_includes response.body, "泡立ちが良くて香りも好み"
+  end
+
+  test "index does not show a review snippet when the item has no review" do
+    item = items(:one)
+
+    get items_path
+
+    assert_response :success
+    assert_select "article p.italic", count: 0
   end
 
   test "index does not show a rating for an item without any reviews" do
@@ -195,7 +214,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     get items_path
 
     assert_response :success
-    assert_select "article", text: /⭐️/, count: 0
+    assert_select "article span.text-yellow-500", count: 0
   end
 
   test "index shows brand name above the item name for each row" do
@@ -218,6 +237,16 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "article form[action='#{toggle_low_stock_item_path(item)}']"
     assert_select "article a[href='#{item_path(item, anchor: "review")}']", text: "感想を書く"
     assert_select "article a[href='#{archive_item_path(item)}']", text: "手放す"
+  end
+
+  test "index shows an edit label for the review link when the item already has a rating" do
+    item = items(:one)
+    item.update!(rating: 4)
+
+    get items_path
+
+    assert_response :success
+    assert_select "article a[href='#{item_path(item, anchor: "review")}']", text: "感想を編集"
   end
 
   test "index filters items by category" do

--- a/test/controllers/usage_logs_controller_test.rb
+++ b/test/controllers/usage_logs_controller_test.rb
@@ -63,8 +63,8 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{item_path(@item)}']", text: "アイテム本体を見る"
   end
 
-  test "reviews shows finished usage logs with rating and review" do
-    @usage_log.update!(rating: 4, review: "また使いたい")
+  test "reviews shows items with rating and review" do
+    @item.update!(rating: 4, review: "また使いたい")
 
     get reviews_usage_logs_path
 
@@ -72,11 +72,11 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, @item.name
     assert_select "p", text: /★★★★\s*☆/
     assert_includes response.body, "また使いたい"
-    assert_select "a[href='#{edit_usage_log_path(@usage_log)}']", text: "編集"
+    assert_select "a[href='#{edit_review_item_path(@item)}']", text: "編集"
   end
 
-  test "reviews shows rated usage log without review as no review" do
-    @usage_log.update!(rating: 4, review: "")
+  test "reviews shows rated item without review as no review" do
+    @item.update!(rating: 4, review: "")
 
     get reviews_usage_logs_path
 
@@ -86,18 +86,16 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "レビューなし"
   end
 
-  test "reviews does not show unrated usage logs" do
+  test "reviews does not show unrated items" do
     get reviews_usage_logs_path
 
     assert_response :success
     assert_no_match @item.name, response.body
   end
 
-  test "reviews does not show other user's usage logs" do
+  test "reviews does not show other user's items" do
     other_user = users(:two)
-    other_item = other_user.items.create!(name: "他のアイテム", in_stock: true)
-    other_item.start_using!(other_user, Time.zone.local(2026, 5, 10))
-    other_item.finish_using!(Time.zone.local(2026, 5, 12), rating: 5, review: "他ユーザー")
+    other_user.items.create!(name: "他のアイテム", rating: 5, review: "他ユーザー")
 
     get reviews_usage_logs_path
 
@@ -106,16 +104,10 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
     assert_no_match "他ユーザー", response.body
   end
 
-  test "reviews searches rated usage logs by item name" do
-    @usage_log.update!(rating: 4, review: "また使いたい")
+  test "reviews searches rated items by name" do
+    @item.update!(rating: 4, review: "また使いたい")
     other_item = items(:two)
-    other_item.update!(in_stock: true)
-    other_item.start_using!(@user, Time.zone.local(2026, 5, 11))
-    other_item.finish_using!(
-      Time.zone.local(2026, 5, 13),
-      rating: 5,
-      review: "しっとりした"
-    )
+    other_item.update!(rating: 5, review: "しっとりした")
 
     get reviews_usage_logs_path, params: { q: "化粧" }
 
@@ -130,17 +122,14 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
     get reviews_usage_logs_path, params: { q: "存在しないアイテム" }
 
     assert_response :success
-    assert_includes response.body, "条件に合う評価・レビュー履歴がありません"
+    assert_includes response.body, "条件に合う評価・レビューがありません"
     assert_select "a[href='#{reviews_usage_logs_path}']", text: "検索条件をリセット"
   end
 
-  test "reviews filters usage logs by item category" do
-    @item.update!(category: categories(:hair_care))
-    @usage_log.update!(rating: 4)
+  test "reviews filters items by category" do
+    @item.update!(category: categories(:hair_care), rating: 4)
     other_item = items(:two)
-    other_item.update!(in_stock: true, category: categories(:skin_care))
-    other_item.start_using!(@user, Time.zone.local(2026, 5, 11))
-    other_item.finish_using!(Time.zone.local(2026, 5, 13), rating: 5)
+    other_item.update!(category: categories(:skin_care), rating: 5)
 
     get reviews_usage_logs_path, params: { category_id: categories(:hair_care).id }
 
@@ -151,12 +140,9 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "reviews combines item name and category filters" do
-    @item.update!(category: categories(:hair_care))
-    @usage_log.update!(rating: 4)
+    @item.update!(category: categories(:hair_care), rating: 4)
     other_item = items(:two)
-    other_item.update!(in_stock: true, category: categories(:hair_care))
-    other_item.start_using!(@user, Time.zone.local(2026, 5, 11))
-    other_item.finish_using!(Time.zone.local(2026, 5, 13), rating: 5)
+    other_item.update!(category: categories(:hair_care), rating: 5)
 
     get reviews_usage_logs_path, params: {
       q: "化粧",
@@ -169,12 +155,10 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[type='hidden'][name='category_id'][value='#{categories(:hair_care).id}']"
   end
 
-  test "reviews filters usage logs by rating" do
-    @usage_log.update!(rating: 4, review: "また使いたい")
+  test "reviews filters items by rating" do
+    @item.update!(rating: 4, review: "また使いたい")
     other_item = items(:two)
-    other_item.update!(in_stock: true)
-    other_item.start_using!(@user, Time.zone.local(2026, 5, 11))
-    other_item.finish_using!(Time.zone.local(2026, 5, 13), rating: 5)
+    other_item.update!(rating: 5)
 
     get reviews_usage_logs_path, params: { rating: "4" }
 
@@ -185,7 +169,7 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "reviews search form keeps selected rating" do
-    @usage_log.update!(rating: 4)
+    @item.update!(rating: 4)
 
     get reviews_usage_logs_path, params: { rating: "4" }
 
@@ -195,8 +179,7 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
 
   test "reviews rating filters keep selected category" do
     category = categories(:hair_care)
-    @item.update!(category: category)
-    @usage_log.update!(rating: 4)
+    @item.update!(category: category, rating: 4)
 
     get reviews_usage_logs_path, params: { category_id: category.id, rating: "4" }
 
@@ -205,13 +188,10 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
     assert_select "select[name='rating'] option[selected]", text: /⭐️\s*4/
   end
 
-  test "reviews filters usage logs for uncategorized items" do
-    @item.update!(category: categories(:hair_care))
-    @usage_log.update!(rating: 4)
+  test "reviews filters items for uncategorized items" do
+    @item.update!(category: categories(:hair_care), rating: 4)
     other_item = items(:two)
-    other_item.update!(in_stock: true)
-    other_item.start_using!(@user, Time.zone.local(2026, 5, 11))
-    other_item.finish_using!(Time.zone.local(2026, 5, 13), rating: 5)
+    other_item.update!(rating: 5)
 
     get reviews_usage_logs_path, params: { category_id: "uncategorized" }
 
@@ -223,13 +203,11 @@ class UsageLogsControllerTest < ActionDispatch::IntegrationTest
   test "reviews keeps search category and rating filters in pagination links" do
     category = categories(:hair_care)
     11.times do |number|
-      item = @user.items.create!(
+      @user.items.create!(
         name: "検索対象#{number}",
-        in_stock: true,
-        category: category
+        category: category,
+        rating: 4
       )
-      item.start_using!(@user, Time.zone.local(2026, 5, 10))
-      item.finish_using!(Time.zone.local(2026, 5, 12), rating: 4)
     end
 
     get reviews_usage_logs_path, params: {


### PR DESCRIPTION
## 概要
usage_logs廃止・データモデル簡素化(#297)の一部として、ホーム画面と感想を振り返る画面をItem基準に作り直す。あわせて持ち物一覧の絞り込みUXも整理する。

Closes #302

## 変更内容
- ホームの「今使っているもの」を廃止し、「なくなりそう」「レビュー未記入」セクションを新設
- 「よかったもの・イマイチだったもの」を`Item#rating`ベースに書き換え
- 感想を振り返る画面(`usage_logs#reviews`)を`Item`基準に作り直し（ルーティングは維持、#303で正式にItemsController側へ移行予定）
- 持ち物一覧: 感想スニペットの引用表示、感想有無で見た目が変わる`_review_link`パーツ、「レビュー未記入」タブ新設
- 絞り込みの構造を「範囲(すべて/手放したもの)」と「属性タグ(よく使うもの/なくなりそう/レビュー未記入、複数同時選択可)」に整理
- 「手放す」を、感想を登録・編集してから手放せる専用確認画面(`confirm_archive`)に変更
- スマホ下タブ・PC上部タブのUI調整（余白・フォント・下線インジケーター）

## テスト
- `bin/rails test`: 205件パス
- `bundle exec rubocop`: 問題なし
- ブラウザで一通りの操作フロー（絞り込み複数選択、手放す前の感想登録、感想を振り返る画面からの編集）を確認済み