### PR TITLE
usage_logsテーブル・items.in_stockカラムを削除するマイグレーションを追加する

### DIFF
--- a/db/migrate/20260820000001_drop_usage_logs_and_remove_in_stock.rb
+++ b/db/migrate/20260820000001_drop_usage_logs_and_remove_in_stock.rb
@@ -1,0 +1,23 @@
+class DropUsageLogsAndRemoveInStock < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :items, :in_stock, :boolean, default: true, null: false
+
+    drop_table :usage_logs do |t|
+      t.datetime "created_at", null: false
+      t.datetime "finished_at"
+      t.uuid "item_id", null: false
+      t.integer "rating"
+      t.text "review"
+      t.datetime "started_at"
+      t.datetime "updated_at", null: false
+      t.uuid "user_id", null: false
+      t.index [ "item_id", "finished_at" ], name: "index_usage_logs_on_item_id_and_finished_at"
+      t.index [ "item_id" ], name: "index_usage_logs_on_item_id"
+      t.index [ "item_id" ], name: "index_usage_logs_on_item_id_where_in_use", unique: true, where: "(finished_at IS NULL)"
+      t.index [ "user_id", "finished_at" ], name: "index_usage_logs_on_user_id_and_finished_at"
+      t.index [ "user_id" ], name: "index_usage_logs_on_user_id"
+      t.foreign_key :items
+      t.foreign_key :users
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_19_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_20_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -60,7 +60,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_19_000001) do
     t.uuid "category_id"
     t.datetime "created_at", null: false
     t.boolean "favorite", default: false
-    t.boolean "in_stock", default: true, null: false
     t.boolean "low_stock_flagged", default: false, null: false
     t.text "memo"
     t.string "name", null: false
@@ -72,22 +71,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_19_000001) do
     t.index ["archived"], name: "index_items_on_archived"
     t.index ["category_id"], name: "index_items_on_category_id"
     t.index ["user_id"], name: "index_items_on_user_id"
-  end
-
-  create_table "usage_logs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "finished_at"
-    t.uuid "item_id", null: false
-    t.integer "rating"
-    t.text "review"
-    t.datetime "started_at"
-    t.datetime "updated_at", null: false
-    t.uuid "user_id", null: false
-    t.index ["item_id", "finished_at"], name: "index_usage_logs_on_item_id_and_finished_at"
-    t.index ["item_id"], name: "index_usage_logs_on_item_id"
-    t.index ["item_id"], name: "index_usage_logs_on_item_id_where_in_use", unique: true, where: "(finished_at IS NULL)"
-    t.index ["user_id", "finished_at"], name: "index_usage_logs_on_user_id_and_finished_at"
-    t.index ["user_id"], name: "index_usage_logs_on_user_id"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -111,6 +94,4 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_19_000001) do
   add_foreign_key "categories", "users"
   add_foreign_key "items", "categories"
   add_foreign_key "items", "users"
-  add_foreign_key "usage_logs", "items"
-  add_foreign_key "usage_logs", "users"
 end

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -7,10 +7,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "index searches current user's items by partial name" do
-    other_user_item = users(:two).items.create!(
-      name: "化粧水 他ユーザー",
-      in_stock: true
-    )
+    other_user_item = users(:two).items.create!(name: "化粧水 他ユーザー")
 
     get items_path, params: { q: "化粧" }
 
@@ -49,9 +46,9 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "autocomplete returns matching item names for current user" do
-    @user.items.create!(name: "化粧水A", in_stock: true)
-    @user.items.create!(name: "化粧水B", in_stock: true)
-    @user.items.create!(name: "歯ブラシ", in_stock: true)
+    @user.items.create!(name: "化粧水A")
+    @user.items.create!(name: "化粧水B")
+    @user.items.create!(name: "歯ブラシ")
 
     get autocomplete_items_path, params: { q: "化粧" }
 
@@ -63,7 +60,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "autocomplete excludes other user's items" do
-    users(:two).items.create!(name: "化粧水X", in_stock: true)
+    users(:two).items.create!(name: "化粧水X")
 
     get autocomplete_items_path, params: { q: "化粧" }
 
@@ -72,7 +69,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "autocomplete limits results to 10" do
-    12.times { |i| @user.items.create!(name: "検索アイテム#{i}", in_stock: true) }
+    12.times { |i| @user.items.create!(name: "検索アイテム#{i}") }
 
     get autocomplete_items_path, params: { q: "検索アイテム" }
 
@@ -81,7 +78,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "autocomplete returns empty array for query shorter than 2 characters" do
-    @user.items.create!(name: "化粧水", in_stock: true)
+    @user.items.create!(name: "化粧水")
 
     get autocomplete_items_path, params: { q: "化" }
 
@@ -321,7 +318,6 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     other_category = other_user.categories.create!(name: "他ユーザーカテゴリ")
     other_item = other_user.items.create!(
       name: "他ユーザーアイテム",
-      in_stock: true,
       category: other_category
     )
 
@@ -383,7 +379,6 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     11.times do |number|
       @user.items.create!(
         name: "検索対象#{number}",
-        in_stock: true,
         category: category
       )
     end
@@ -878,10 +873,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
 
   test "index paginates items with ten items per page" do
     9.times do |number|
-      @user.items.create!(
-        name: "ページネーション確認#{number}",
-        in_stock: true
-      )
+      @user.items.create!(name: "ページネーション確認#{number}")
     end
 
     get items_path
@@ -897,7 +889,7 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "show does not allow accessing another user's item" do
-    other_user_item = users(:two).items.create!(name: "他人のアイテム", in_stock: true)
+    other_user_item = users(:two).items.create!(name: "他人のアイテム")
 
     get item_path(other_user_item)
 

--- a/test/fixtures/items.yml
+++ b/test/fixtures/items.yml
@@ -2,7 +2,6 @@ one:
   user: one
   name: 化粧水
   price: 1200
-  in_stock: true
   favorite: false
   archived: false
 
@@ -10,7 +9,6 @@ two:
   user: one
   name: 乳液
   price: 1800
-  in_stock: false
   favorite: false
   archived: false
 # column: value


### PR DESCRIPTION
## 概要
#303のステップ8。`usage_logs`に依存するコード側の整理（#309で反映済み）が完了し、書き込みパスがすべて閉じたことを確認できたため、テーブル本体と`items.in_stock`カラムを削除するマイグレーションを追加する。

ローカルで実行・確認済み（`bin/rails test` 171件green、`bundle exec rubocop` clean）。

本番DBへの反映（バックフィル・マイグレーション適用）は #311 で別途行う。このPRでは#303はクローズしない（ステップ8のみ）。

## 変更内容
- `db/migrate/20260820000001_drop_usage_logs_and_remove_in_stock.rb` を追加
  - `items.in_stock` カラムを削除
  - `usage_logs` テーブルを削除（down migrationのため、カラム・インデックス・外部キーを明示的に再定義）
- `db/schema.rb` を更新

## 確認内容
- `docker compose exec web bin/rails db:migrate` 実行、成功
- `db/schema.rb`から`usage_logs`・`in_stock`の記述が消えたことを確認
- `docker compose exec web bin/rails test` 171 runs, 0 failures/errors
- `docker compose exec web bundle exec rubocop` clean（88 files）
- ブラウザで `/home` `/items` を目視確認、エラーなし

## テスト計画
- [x] `bin/rails test` が通る
- [x] `bundle exec rubocop` が通る
- [x] ローカルでマイグレーションを実行し、主要画面が正常に表示される

Related: #303