### PR TITLE
使い方・利用規約・プライバシーポリシー・お問い合わせをスマホ幅ではヘッダーメニューに集約する

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,6 +1,7 @@
 <footer id="footer" class="border-t border-slate-200 bg-white py-6">
   <div class="mx-auto w-full max-w-5xl px-4">
-    <nav class="mb-3 flex flex-wrap justify-center gap-x-5 gap-y-2 text-sm">
+    <%# ログイン時は、スマホ幅でだけ非表示にする（ヘッダーのアカウントメニューに移す）。PCでは常に表示する %>
+    <nav class="mb-3 flex-wrap justify-center gap-x-5 gap-y-2 text-sm <%= user_signed_in? ? "hidden pc:flex" : "flex" %>">
       <%= link_to "使い方", guide_path, class: "text-slate-500 transition hover:text-emerald-700" %>
       <%= link_to "利用規約", terms_path, class: "text-slate-500 transition hover:text-emerald-700" %>
       <%= link_to "プライバシーポリシー", privacy_path, class: "text-slate-500 transition hover:text-emerald-700" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -31,6 +31,13 @@
           <% unless current_user.guest? %>
             <%= link_to "アカウント編集", edit_user_registration_path, class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50" %>
           <% end %>
+          <%# PCではフッターに表示されるため、ヘッダーにはスマホ幅でだけ表示する %>
+          <div class="pc:hidden">
+            <%= link_to "使い方", guide_path, class: "block whitespace-nowrap px-4 py-2 text-xs text-slate-700 transition hover:bg-slate-50" %>
+            <%= link_to "利用規約", terms_path, class: "block whitespace-nowrap px-4 py-2 text-xs text-slate-700 transition hover:bg-slate-50" %>
+            <%= link_to "プライバシーポリシー", privacy_path, class: "block whitespace-nowrap px-4 py-2 text-xs text-slate-700 transition hover:bg-slate-50" %>
+            <%= link_to "お問い合わせ", contact_path, class: "block whitespace-nowrap px-4 py-2 text-xs text-slate-700 transition hover:bg-slate-50" %>
+          </div>
           <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "block px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-50" %>
         </div>
       </details>


### PR DESCRIPTION
## 概要
#308の対応。ログイン後の画面で、フッターに常時表示されている「使い方」「利用規約」「プライバシーポリシー」「お問い合わせ」がノイズになっていた。

## 変更内容
- スマホ幅では、これらのリンクをフッターから隠し、ヘッダーのアカウントメニューに集約する
- PC幅では画面が広く問題になりにくいため、フッターにそのまま残す（挙動は変更なし）
- 未ログイン時は、これまで通りフッターにリンクを残す

## テスト計画
- [x] `bin/rails test` が通る（174件）
- [x] 生成されたCSSルール（`pc:hidden`/`hidden pc:flex`）が意図通りの表示切り替えになることを確認
- [x] Canvasでのテキスト幅計測により、「プライバシーポリシー」がフォントサイズ調整後1行に収まることを確認

Closes #308